### PR TITLE
Fix atomic warning on LineItem remove_item action

### DIFF
--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -37,7 +37,9 @@ defmodule Edenflowers.Store.LineItem do
       ]
     end
 
-    destroy :remove_item
+    destroy :remove_item do
+      require_atomic? false
+    end
 
     update :increment_quantity do
       change atomic_update(:quantity, expr(quantity + 1))


### PR DESCRIPTION
`Ash.Notifier.PubSub` fires a Phoenix PubSub broadcast after deletion, that's Elixir-side work and cannot be included in an atomic database operation. Setting `require_atomic? false` acknowledges the non-atomic behaviour: Ash will load the record first, delete it, then run the notifier.