### PR TITLE
Fix from address in emails to use info@edenflowers.fi

### DIFF
--- a/lib/edenflowers/email.ex
+++ b/lib/edenflowers/email.ex
@@ -8,6 +8,8 @@ defmodule Edenflowers.Email do
 
   require EEx
 
+  @from_address {"Eden Flowers", "info@edenflowers.fi"}
+
   # Compile the template at compile-time so gettext extraction works
   EEx.function_from_file(
     :defp,
@@ -23,7 +25,7 @@ defmodule Edenflowers.Email do
     Gettext.put_locale(EdenflowersWeb.Gettext, order.locale)
 
     new()
-    |> from({"Eden Flowers", "orders@edenflowers.com"})
+    |> from(@from_address)
     |> to(order.customer_email)
     |> subject("#{gettext("Order Confirmation")} - #{order.order_reference}")
     |> text_body(render_order_confirmation(order, order.locale))


### PR DESCRIPTION
## Summary
- Defines `@from_address` module attribute in `Edenflowers.Email` so the sender address is written once
- Corrects the address from `orders@edenflowers.com` to `info@edenflowers.fi`