### PR TITLE
Remove NEWSLETTER- prefix from newsletter promo codes

### DIFF
--- a/lib/edenflowers/store/promotion.ex
+++ b/lib/edenflowers/store/promotion.ex
@@ -48,7 +48,7 @@ defmodule Edenflowers.Store.Promotion do
         today = DateTime.now!("Europe/Helsinki") |> DateTime.to_date()
 
         changeset
-        |> Ash.Changeset.force_change_attribute(:code, "NEWSLETTER-#{code}")
+        |> Ash.Changeset.force_change_attribute(:code, code)
         |> Ash.Changeset.force_change_attribute(:name, "Newsletter Welcome")
         |> Ash.Changeset.force_change_attribute(:discount_percentage, Decimal.new("0.15"))
         |> Ash.Changeset.force_change_attribute(:minimum_cart_total, Decimal.new("0"))

--- a/test/edenflowers/workers/send_newsletter_promo_email_test.exs
+++ b/test/edenflowers/workers/send_newsletter_promo_email_test.exs
@@ -20,7 +20,7 @@ defmodule Edenflowers.Workers.SendNewsletterPromoEmailTest do
 
       {:ok, user} = User.get_by_email(user.email, authorize?: false, load: [:newsletter_promo])
       assert user.newsletter_promo_id != nil
-      assert to_string(user.newsletter_promo.code) =~ "NEWSLETTER-"
+      assert to_string(user.newsletter_promo.code) =~ ~r/^[0-9A-F]{6}$/
     end
   end
 


### PR DESCRIPTION
## What changed

Newsletter promo codes no longer include the `NEWSLETTER-` prefix. They are now just the 6-character uppercase hex string (e.g. `A3F2C1`) generated from 3 random bytes.

## Why

Simpler codes are cleaner for customers to type at checkout.

## Test

Updated the assertion in `send_newsletter_promo_email_test.exs` to verify the code matches `~r/^[0-9A-F]{6}$/` instead of checking for the old prefix.