### PR TITLE
Rate limit newsletter signups to once per 5 minutes per email

### DIFF
--- a/lib/edenflowers/workers/send_newsletter_promo_email.ex
+++ b/lib/edenflowers/workers/send_newsletter_promo_email.ex
@@ -1,7 +1,7 @@
 defmodule Edenflowers.Workers.SendNewsletterPromoEmail do
   use Oban.Worker,
     queue: :default,
-    unique: [fields: [:args], keys: [:email], period: 300, states: [:available, :scheduled, :executing]]
+    unique: [fields: [:args], keys: [:email], period: 300, states: [:available, :scheduled, :executing, :completed]]
 
   import Edenflowers.Actors
 
@@ -11,9 +11,7 @@ defmodule Edenflowers.Workers.SendNewsletterPromoEmail do
   alias Edenflowers.Store.Promotion
 
   def enqueue(%{"email" => _email} = args) do
-    args
-    |> __MODULE__.new()
-    |> Oban.insert()
+    args |> __MODULE__.new() |> Oban.insert()
   end
 
   def perform(%Oban.Job{args: %{"email" => email, "locale" => locale}}) do

--- a/lib/edenflowers_web/components/newsletter_signup_form.ex
+++ b/lib/edenflowers_web/components/newsletter_signup_form.ex
@@ -48,6 +48,7 @@ defmodule EdenflowersWeb.NewsletterSignupForm do
     case Edenflowers.Accounts.User.subscribe_to_newsletter(email_address) do
       {:ok, _} ->
         locale = Gettext.get_locale(EdenflowersWeb.Gettext)
+
         Edenflowers.Workers.SendNewsletterPromoEmail.enqueue(%{"email" => email_address, "locale" => locale})
         {:noreply, assign(socket, submitted: true)}
 


### PR DESCRIPTION
## Summary

- Adds `:completed` to the Oban unique job states on `SendNewsletterPromoEmail`, so that a repeat signup attempt within 5 minutes for the same email is silently deduplicated — even if the promo email job has already finished running.
- No user-facing error is shown; the form just appears to succeed normally.

## What changed

Previously the unique states were `[:available, :scheduled, :executing]`, meaning once a job completed the dedup window was effectively over. Adding `:completed` closes that gap so the 5-minute window holds regardless of job state.

Closes #11.