### PR TITLE
Fix promotion uniqueness tests leaking data outside SQL sandbox

### DIFF
--- a/test/promotion_test.exs
+++ b/test/promotion_test.exs
@@ -434,38 +434,26 @@ defmodule Edenflowers.Store.PromotionTest do
   end
 
   describe "Promotion unique code constraint" do
-    import Generator
+    defp create_promotion(attrs) do
+      Promotion
+      |> Ash.Changeset.for_create(:create, Map.merge(%{
+        name: "Promo",
+        discount_percentage: "0.15",
+        minimum_cart_total: "0"
+      }, attrs))
+      |> Ash.create(authorize?: false)
+    end
 
     test "prevents duplicate promotion codes" do
-      generate(promotion(code: "DUPLICATE"))
+      {:ok, _} = create_promotion(%{code: "DUPLICATE"})
 
-      assert {:error, error} =
-               Promotion
-               |> Ash.Changeset.for_create(:create, %{
-                 name: "Second Promo",
-                 code: "DUPLICATE",
-                 discount_percentage: "0.15",
-                 minimum_cart_total: "0"
-               })
-               |> Ash.create(authorize?: false)
-
-      assert %Ash.Error.Invalid{} = error
+      assert {:error, %Ash.Error.Invalid{}} = create_promotion(%{code: "DUPLICATE"})
     end
 
     test "enforces case-insensitive uniqueness for codes" do
-      generate(promotion(code: "CaseTest"))
+      {:ok, _} = create_promotion(%{code: "CaseTest"})
 
-      assert {:error, error} =
-               Promotion
-               |> Ash.Changeset.for_create(:create, %{
-                 name: "Second Promo",
-                 code: "CASETEST",
-                 discount_percentage: "0.15",
-                 minimum_cart_total: "0"
-               })
-               |> Ash.create(authorize?: false)
-
-      assert %Ash.Error.Invalid{} = error
+      assert {:error, %Ash.Error.Invalid{}} = create_promotion(%{code: "CASETEST"})
     end
   end
 end


### PR DESCRIPTION
## What changed

Replaced `Ash.Generator.generate/1` calls in the promotion uniqueness tests with direct `Ash.create` calls.

## Why

`Ash.Generator`'s `generate/1` opens its own DB connection, bypassing the Ecto SQL sandbox. This means inserted rows aren't rolled back after each test, so the second test fails with a duplicate key error on its *first* insert — the row left behind by the previous test.

Using `Ash.create` directly runs through the sandboxed connection and rolls back cleanly after each test.

## Reviewer notes

This is a pre-existing CI failure unrelated to the newsletter promo code changes in PR #14.