### PR TITLE
Add maternity route with dedicated layout

### DIFF
--- a/lib/edenflowers_web/components/layouts/maternity_root.html.heex
+++ b/lib/edenflowers_web/components/layouts/maternity_root.html.heex
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light" class="w-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="csrf-token" content={get_csrf_token()} />
+    <.live_title default="Store" prefix="Eden Flowers — ">
+      {assigns[:page_title]}
+    </.live_title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"
+      rel="stylesheet"
+    />
+
+    <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
+    </script>
+  </head>
+  <body class="bg-base-200 flex min-h-screen flex-col antialiased ready">
+    {@inner_content}
+  </body>
+</html>

--- a/lib/edenflowers_web/router.ex
+++ b/lib/edenflowers_web/router.ex
@@ -25,10 +25,27 @@ defmodule EdenflowersWeb.Router do
     plug :load_from_session
   end
 
+  pipeline :maternity_browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {EdenflowersWeb.Layouts, :maternity_root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
   pipeline :api do
     plug :accepts, ["json"]
     plug :load_from_bearer
     plug :set_actor, :user
+  end
+
+  scope "/", EdenflowersWeb do
+    pipe_through :maternity_browser
+
+    live_session :maternity, root_layout: {EdenflowersWeb.Layouts, :maternity_root} do
+      live "/maternity", MaternityLive
+    end
   end
 
   scope "/", EdenflowersWeb do
@@ -40,7 +57,6 @@ defmodule EdenflowersWeb.Router do
         EdenflowersWeb.Hooks.PutOrder,
         EdenflowersWeb.Hooks.HandleLineItemChanged
       ] do
-      live "/maternity", MaternityLive
       live "/", HomeLive
       live "/store", StoreLive
       live "/store/:category", StoreLive


### PR DESCRIPTION
## Summary

Introduces a dedicated maternity page with its own browser pipeline and root layout, separated from the main application layout and hooks.

## Key changes

- **New maternity layout** (`maternity_root.html.heex`): standalone HTML structure, custom fonts (Crimson Text and Open Sans), DaisyUI theming.
- **New `:maternity_browser` pipeline**: bypasses the standard browser hooks (`PutOrder`, `HandleLineItemChanged`) used by the store.
- **Route reorganization**: `/maternity` moves from the main browser scope to a dedicated scope with its own live session and pipeline.

The maternity route now functions independently from the store's order management hooks, with its own styling, behavior, and lifecycle.
