### PR TITLE
Tighten typography and color systems

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -13,7 +13,17 @@
   --font-sans: "Open Sans", sans-serif;
   --font-serif: "Crimson Text", serif;
   --header-height: 8rem;
-  --color-image: white;
+}
+
+/* Pastel palette — soft surfaces for banners, callouts, section backgrounds.
+   Use these for decorative backgrounds; use semantic tokens (primary, accent)
+   for brand-meaningful colors. `inline` lets us reference Tailwind's default
+   palette vars without CSS-variable scoping issues. */
+@theme inline {
+  --color-pastel-1: var(--color-sky-100);    /* cool blue   — announcements, info */
+  --color-pastel-2: var(--color-pink-100);   /* soft pink   — footer, romance */
+  --color-pastel-3: var(--color-amber-100);  /* warm cream  — highlights, quotes */
+  --color-pastel-4: var(--color-green-100);  /* fresh green — nature, success-adjacent */
 }
 
 /* A Tailwind plugin that makes "hero-#{ICON}" classes available.
@@ -34,10 +44,9 @@
   color-scheme: "light";
   --color-primary: oklch(0.3684 0.0478 156.76); /* brand primary */
   --color-primary-content: oklch(0.97 0 0); /* neutral-100 */
-  --color-accent: var(--color-pink-100);
-  --color-accent-alt: oklch(0.81 0.15 93); /* a mustardy yellow */
+  --color-accent: var(--color-pink-100); /* same as --color-pastel-2 */
+  --color-accent-alt: oklch(0.81 0.15 93); /* mustardy yellow — link underline on serif headings */
   --color-accent-content: var(--color-base-content);
-  --color-secondary: oklch(0.83 0.0222 158.49); /* brand secondary */
   --color-base-100: white;
   --color-base-200: oklch(98.5% 0.001 106.423); /* stone-50 */
   --color-base-300: oklch(97% 0.001 106.424); /* stone-100 */
@@ -87,6 +96,22 @@ sl-dropdown::part(panel) {
 
 @utility hero-heading {
   @apply text-5xl sm:text-6xl md:text-7xl;
+}
+
+@utility page-title {
+  @apply font-serif text-4xl;
+}
+
+@utility section-title {
+  @apply font-serif text-2xl sm:text-3xl;
+}
+
+@utility card-title {
+  @apply font-serif text-xl;
+}
+
+@utility logo-wordmark {
+  @apply font-sans font-bold uppercase tracking-widest;
 }
 
 #hotfx-shy-header {

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -88,7 +88,7 @@ defmodule EdenflowersWeb.CalendarComponent do
         </button>
       </div>
 
-      <div class="border-base-content/10 mt-2 grid grid-cols-7 border-b text-center text-sm leading-6">
+      <div class="border-base-content/20 mt-2 grid grid-cols-7 border-b text-center text-sm leading-6">
         <%= for week_day <- List.first(@week_rows) do %>
           <span>
             {Cldr.DateTime.to_string!(week_day, format: "EEEEEE")}
@@ -192,7 +192,7 @@ defmodule EdenflowersWeb.CalendarComponent do
     base_class = "flex flex-none items-center justify-center p-1.5"
 
     if is_disabled do
-      "#{base_class} text-gray-300 opacity-50"
+      "#{base_class} text-base-content/20"
     else
       "#{base_class} cursor-pointer text-base-content hover:text-base-content/60"
     end

--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -103,11 +103,15 @@ defmodule EdenflowersWeb.CoreComponents do
   """
   attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
   attr :class, :any
-  attr :variant, :string, values: ~w(primary)
+  attr :variant, :string, values: ~w(primary secondary)
   slot :inner_block, required: true
 
   def button(%{rest: rest} = assigns) do
-    variants = %{"primary" => "btn-primary", nil => "btn-primary btn-soft"}
+    variants = %{
+      "primary" => "btn-primary",
+      "secondary" => "btn-primary btn-soft",
+      nil => "btn-primary btn-soft"
+    }
 
     assigns =
       assign_new(assigns, :class, fn ->
@@ -387,7 +391,7 @@ defmodule EdenflowersWeb.CoreComponents do
         <h1 class="text-lg font-semibold leading-8">
           {render_slot(@inner_block)}
         </h1>
-        <p :if={@subtitle != []} class="text-base-content/70 text-sm">
+        <p :if={@subtitle != []} class="text-base-content/80 text-sm">
           {render_slot(@subtitle)}
         </p>
       </div>
@@ -606,7 +610,7 @@ defmodule EdenflowersWeb.CoreComponents do
 
   attr :id, :string, required: true
   attr :placement, :string, default: "left", values: ["left", "right", "top", "bottom"]
-  attr :class, :string, default: "bg-white min-w-96"
+  attr :class, :string, default: "bg-base-100 min-w-96"
   slot :inner_block, required: true
 
   def drawer(%{placement: placement} = assigns) do

--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -21,7 +21,7 @@ defmodule EdenflowersWeb.Layouts do
     ~H"""
     <div class="auth-background-pattern flex min-h-screen flex-col">
       <header class="py-8 text-center">
-        <.link navigate={~p"/"} class="text-primary font-sans text-xl font-bold uppercase tracking-widest sm:text-2xl">
+        <.link navigate={~p"/"} class="text-primary logo-wordmark text-xl sm:text-2xl">
           Eden Flowers
         </.link>
       </header>
@@ -73,7 +73,7 @@ defmodule EdenflowersWeb.Layouts do
       <header class="bg-accent-2 flex flex-row items-center justify-between pt-8 pr-4 pl-8">
         <.link
           navigate={~p"/"}
-          class="text-primary font-sans whitespace-nowrap font-bold uppercase tracking-widest sm:text-2xl"
+          class="text-primary logo-wordmark whitespace-nowrap sm:text-2xl"
         >
           Eden Flowers
         </.link>
@@ -88,7 +88,7 @@ defmodule EdenflowersWeb.Layouts do
           <ul class="space-y-4">
             <li :for={{url, name} <- @nav}>
               <.link
-                class="font-serif text-base-content text-2xl hover:decoration-(--color-accent-alt) hover:underline hover:underline-offset-4 sm:text-3xl"
+                class="text-base-content text-lg hover:decoration-(--color-accent-alt) hover:underline hover:underline-offset-4"
                 phx-click={JS.exec("phx-hide", to: "#nav-drawer")}
                 navigate={url}
               >
@@ -138,7 +138,7 @@ defmodule EdenflowersWeb.Layouts do
     >
       <header class="w-full">
         <%!-- Banner --%>
-        <section class="border-b bg-sky-100 py-2 text-center">
+        <section class="bg-pastel-1 border-b py-2 text-center">
           <span class="text-accent-content text-sm">{~t"Let us know what you think of the new website! 🚀"}</span>
         </section>
 
@@ -179,7 +179,7 @@ defmodule EdenflowersWeb.Layouts do
               <%!-- Logo --%>
               <.link
                 navigate={~p"/"}
-                class="text-primary font-sans whitespace-nowrap text-xl font-bold uppercase tracking-widest sm:text-2xl"
+                class="text-primary logo-wordmark whitespace-nowrap text-xl sm:text-2xl"
               >
                 Eden Flowers
               </.link>
@@ -248,7 +248,7 @@ defmodule EdenflowersWeb.Layouts do
     </main>
 
     <footer>
-      <div class="border-t border-b bg-pink-100">
+      <div class="bg-accent border-t border-b">
         <div class="container py-12 md:py-24">
           <div class="flex flex-col gap-8 md:flex-row">
             <div class="m-auto max-w-lg flex-1 space-y-4">

--- a/lib/edenflowers_web/components/newsletter_signup_form.ex
+++ b/lib/edenflowers_web/components/newsletter_signup_form.ex
@@ -9,7 +9,7 @@ defmodule EdenflowersWeb.NewsletterSignupForm do
   def render(assigns) do
     ~H"""
     <section class="space-y-2">
-      <h1 class="font-serif text-2xl sm:text-3xl">
+      <h1 class="section-title">
         {~t"Register and enjoy 15% off your next order."}
       </h1>
 
@@ -34,7 +34,7 @@ defmodule EdenflowersWeb.NewsletterSignupForm do
           </div>
         </.form>
 
-        <p class="font-sans text-xs">
+        <p class="text-xs">
           {~t"We send out only ocassional emails. Unsubscribe at any time."}
         </p>
       <% end %>

--- a/lib/edenflowers_web/live/about_live.ex
+++ b/lib/edenflowers_web/live/about_live.ex
@@ -11,7 +11,7 @@ defmodule EdenflowersWeb.AboutLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash}>
       <div class="container my-36">
-        <h1 class="font-serif text-4xl">{~t"About"}</h1>
+        <h1 class="page-title">{~t"About"}</h1>
       </div>
     </Layouts.app>
     """

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -317,7 +317,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                             <.icon
                               :if={day == ~D[2025-05-07]}
                               name="hero-heart-solid"
-                              class="absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5 text-red-400"
+                              class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
                             />
                           </:day_decoration>
                         </.live_component>
@@ -363,7 +363,7 @@ defmodule EdenflowersWeb.CheckoutLive do
               </.steps>
             </div>
 
-            <div class="md:border-neutral/10 md:border-r" />
+            <div class="md:border-neutral/20 md:border-r" />
 
             <div class="md:w-[35%] md:sticky md:top-6 md:h-fit md:overflow-y-auto">
               <section class="flex flex-col gap-4 p-1" data-testid="cart-section">

--- a/lib/edenflowers_web/live/condolences_live.ex
+++ b/lib/edenflowers_web/live/condolences_live.ex
@@ -11,7 +11,7 @@ defmodule EdenflowersWeb.CondolencesLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash}>
       <div class="container my-36">
-        <h1 class="font-serif text-4xl">{~t"Condolences"}</h1>
+        <h1 class="page-title">{~t"Condolences"}</h1>
       </div>
     </Layouts.app>
     """

--- a/lib/edenflowers_web/live/contact_live.ex
+++ b/lib/edenflowers_web/live/contact_live.ex
@@ -11,7 +11,7 @@ defmodule EdenflowersWeb.ContactLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash}>
       <.container>
-        <h1 class="font-serif text-4xl">{~t"Contact"}</h1>
+        <h1 class="page-title">{~t"Contact"}</h1>
       </.container>
     </Layouts.app>
     """

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -22,7 +22,7 @@ defmodule EdenflowersWeb.HomeLive do
         />
 
         <div class="container absolute inset-0 flex flex-col items-center justify-center gap-8 text-center">
-          <h1 class="hero-heading text-image font-serif max-w-[20ch] tracking-wide">
+          <h1 class="hero-heading font-serif max-w-[20ch] tracking-wide text-white">
             {~t"Fresh flowers for everyday moments."}
           </h1>
           <a href="#store" class="btn-primary btn btn-lg mx-auto">
@@ -33,7 +33,7 @@ defmodule EdenflowersWeb.HomeLive do
 
       <section id="store" class="not-last:border-b">
         <div class="m-auto py-24 xl:max-w-[70vw]">
-          <h2 class="font-serif mb-4 px-2 text-3xl">{~t"Featured Blooms"}</h2>
+          <h2 class="section-title mb-4 px-2">{~t"Featured Blooms"}</h2>
 
           <div
             id="product-slider"
@@ -55,7 +55,7 @@ defmodule EdenflowersWeb.HomeLive do
                     />
                   </div>
                   <div class="text-base-content flex flex-col items-center">
-                    <h3 id={product.name} class="font-serif text-xl">{product.name}</h3>
+                    <h3 id={product.name} class="card-title">{product.name}</h3>
                     <p class="text-sm">{Edenflowers.Utils.format_money(product.cheapest_price)}</p>
                   </div>
                 </.link>

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -67,7 +67,7 @@ defmodule EdenflowersWeb.ProductLive do
           <section aria-labelledby="product-details-heading" class="flex flex-col gap-8">
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3">
-                <h1 id="product-details-heading" data-testid="product-name" class="font-serif text-4xl tracking-wide">
+                <h1 id="product-details-heading" data-testid="product-name" class="page-title tracking-wide">
                   {@product.name}
                 </h1>
               </div>
@@ -138,7 +138,7 @@ defmodule EdenflowersWeb.ProductLive do
 
         <%!-- FAQs Section --%>
         <section aria-labelledby="faq-heading" class="m-auto max-w-4xl">
-          <h2 id="faq-heading" class="font-serif mb-12 text-center text-3xl">{~t"Frequently Asked Questions"}</h2>
+          <h2 id="faq-heading" class="section-title mb-12 text-center">{~t"Frequently Asked Questions"}</h2>
 
           <div class="space-y-4">
             <div class="collapse collapse-arrow bg-base-100 border-base-300 rounded-lg border">

--- a/lib/edenflowers_web/live/store_live.ex
+++ b/lib/edenflowers_web/live/store_live.ex
@@ -51,7 +51,7 @@ defmodule EdenflowersWeb.StoreLive do
         </.breadcrumb>
 
         <div class="mb-12">
-          <h1 class="font-serif text-base-content mb-2 text-4xl">
+          <h1 class="page-title text-base-content mb-2">
             {@selected_category.name}
           </h1>
           <p class="text-base-content/60 text-sm sm:text-base">
@@ -74,8 +74,8 @@ defmodule EdenflowersWeb.StoreLive do
         <%= if Enum.empty?(@products) do %>
           <div class="border-primary/40 bg-base-100 flex flex-col items-center gap-4 border border-dashed px-8 py-16 text-center">
             <.icon name="hero-sparkles" class="text-primary h-12 w-12" />
-            <h3 class="font-serif text-2xl">{~t"Fresh stems loading soon"}</h3>
-            <p class="text-base-content/70 max-w-md text-sm sm:text-base">
+            <h3 class="section-title">{~t"Fresh stems loading soon"}</h3>
+            <p class="text-base-content/80 max-w-md text-sm sm:text-base">
               {~t"We're refreshing our collection. Check back shortly for newly arranged bouquets ready to ship."}
             </p>
           </div>
@@ -104,13 +104,13 @@ defmodule EdenflowersWeb.StoreLive do
                 <div class="flex flex-1 flex-col justify-between gap-2 px-5 pt-5 pb-5 sm:px-6 sm:pb-6">
                   <h3
                     id={"product-#{product.id}"}
-                    class="font-serif text-base-content text-xl tracking-wide sm:text-2xl"
+                    class="card-title text-base-content tracking-wide"
                   >
                     {product.name}
                   </h3>
 
                   <div class="text-base-content flex items-center justify-between">
-                    <span class="text-base-content/70 text-sm sm:text-base">
+                    <span class="text-base-content/80 text-sm sm:text-base">
                       {Edenflowers.Utils.format_money(product.cheapest_price)}
                     </span>
                     <span class="text-base-content/60 flex items-center gap-1 text-xs uppercase tracking-wider transition duration-200 group-hover:text-primary sm:text-sm">

--- a/lib/edenflowers_web/live/weddings_live.ex
+++ b/lib/edenflowers_web/live/weddings_live.ex
@@ -11,7 +11,7 @@ defmodule EdenflowersWeb.WeddingsLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash}>
       <div class="container my-36">
-        <h1 class="font-serif text-4xl">{~t"Weddings"}</h1>
+        <h1 class="page-title">{~t"Weddings"}</h1>
       </div>
     </Layouts.app>
     """


### PR DESCRIPTION
## Summary

Two passes over the design system that surfaced from an audit of fonts and colors:

**Typography**
- Introduces four `@utility` classes for patterns that were duplicated across the app: `page-title`, `section-title`, `card-title`, `logo-wordmark`
- Migrates existing usages (all page headings, section headings, product cards, logos, newsletter)
- Switches the mobile nav drawer from serif to sans so it matches the desktop nav treatment. This is a trial — easy to revert if the drawer felt better as an editorial moment

**Color system**
- Adds a 4-step pastel scale (`pastel-1`..`pastel-4`) via `@theme inline`, so soft decorative surfaces (banners, callouts, future sections) use semantic tokens instead of raw Tailwind palette classes like `bg-sky-100`
- Removes unused tokens: `--color-secondary` (defined, never referenced) and `--color-image` (was only aliased on one hero heading, swapped for plain `text-white`)
- Replaces raw colors with tokens in 5 spots: announcement banner → `bg-pastel-1`, footer → `bg-accent`, validation icon → `text-error`, calendar disabled text → `text-base-content/20`, drawer default → `bg-base-100`
- Normalizes opacity modifiers onto a 4-stop scale (`/20`, `/40`, `/60`, `/80`) — previously six stops were in use
- Adds a `"secondary"` variant to the `<.button>` component (maps to `btn-primary btn-soft`); the `nil` default is unchanged for back-compat

## Why

The audits found the codebase was ~70% system-compliant but had drift: scattered opacity values, raw Tailwind color classes bypassing the theme (`bg-pink-100` sat next to an unused `--color-accent: var(--color-pink-100)` definition), and duplicated heading class strings. Consolidating this now makes future theme work (dark mode, brand refresh) much easier, and gives a single place to edit when we want a heading size to change.

## Note on pastel-3 and pastel-4

Defined but not yet used anywhere — reserved for callouts / highlight sections. Prune if still unused after a few iterations.

## Test plan

- [ ] Homepage hero text still reads white on the image
- [ ] Announcement banner color unchanged (sky blue)
- [ ] Footer pink looks identical (now sourced via `bg-accent`)
- [ ] Product cards on home + store still use the serif heading
- [ ] Mobile nav drawer now uses sans — judge whether to keep or revert to serif
- [ ] Calendar disabled previous-month arrow reads as faded text rather than gray
- [ ] Checkout form validation icon matches other daisyUI error colors
- [ ] `<.button variant="secondary">` renders as soft brand-green