### PR TITLE
Move delivery address geocoding into Ash action

### DIFF
--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -23,7 +23,7 @@ defmodule Edenflowers.Store.Order do
     Validations
   }
 
-  alias __MODULE__.Changes.{ResetCheckout, GenerateOrderReference}
+  alias __MODULE__.Changes.{ResetCheckout, GenerateOrderReference, ConfirmDeliveryAddress}
 
   postgres do
     repo Edenflowers.Repo
@@ -41,7 +41,7 @@ defmodule Edenflowers.Store.Order do
     define :add_promotion_with_id, action: :add_promotion_with_id, args: [:promotion_id]
     define :add_promotion_with_code, action: :add_promotion_with_code, args: [:code]
     define :clear_promotion, action: :clear_promotion
-    define :preview_delivery, action: :preview_delivery
+    define :confirm_delivery_address, action: :confirm_delivery_address, args: [:address]
     define :reset_delivery_address, action: :reset_delivery_address
     define :update_fulfillment_option, action: :update_fulfillment_option, args: [:fulfillment_option_id]
     define :update_gift, action: :update_gift, args: [:gift]
@@ -145,12 +145,7 @@ defmodule Edenflowers.Store.Order do
         :recipient_phone_number,
         :delivery_address,
         :delivery_instructions,
-        :fulfillment_date,
-        :fulfillment_amount,
-        :calculated_address,
-        :here_id,
-        :distance,
-        :position
+        :fulfillment_date
       ]
 
       change {ValidateFulfillmentDate, []}
@@ -174,8 +169,9 @@ defmodule Edenflowers.Store.Order do
       require_atomic? false
     end
 
-    update :preview_delivery do
-      accept [:delivery_address, :calculated_address, :position, :here_id, :distance, :fulfillment_amount]
+    update :confirm_delivery_address do
+      argument :address, :string, allow_nil?: false
+      change {ConfirmDeliveryAddress, []}
       require_atomic? false
     end
 

--- a/lib/edenflowers/store/order/changes/confirm_delivery_address.ex
+++ b/lib/edenflowers/store/order/changes/confirm_delivery_address.ex
@@ -1,0 +1,39 @@
+defmodule Edenflowers.Store.Order.Changes.ConfirmDeliveryAddress do
+  use Ash.Resource.Change
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  alias Edenflowers.Fulfillments
+  alias Edenflowers.Store.FulfillmentOption
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.before_action(changeset, fn changeset ->
+      address = Ash.Changeset.get_argument(changeset, :address)
+      fulfillment_option_id = Ash.Changeset.get_attribute(changeset, :fulfillment_option_id)
+
+      with {:ok, fulfillment_option} <- FulfillmentOption.get_by_id(fulfillment_option_id, authorize?: false),
+           {:ok, result} <- Fulfillments.calculate_delivery(address, fulfillment_option) do
+        Ash.Changeset.force_change_attributes(changeset,
+          delivery_address: address,
+          calculated_address: result.calculated_address,
+          position: result.position,
+          here_id: result.here_id,
+          distance: result.distance,
+          fulfillment_amount: result.fulfillment_amount
+        )
+      else
+        {:error, :address_not_found} ->
+          Ash.Changeset.add_error(changeset, field: :delivery_address, message: ~t"Address not found")
+
+        {:error, :out_of_delivery_range} ->
+          Ash.Changeset.add_error(changeset, field: :delivery_address, message: ~t"Outside delivery range")
+
+        {:error, _} ->
+          Ash.Changeset.add_error(changeset,
+            field: :delivery_address,
+            message: ~t"There was a problem calculating delivery cost, please try again later"
+          )
+      end
+    end)
+  end
+end

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -4,7 +4,6 @@ defmodule EdenflowersWeb.CheckoutLive do
   require Logger
 
   alias Edenflowers.Store.{Order, FulfillmentOption, LineItem, ProductVariant}
-  alias Edenflowers.{Fulfillments}
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
 
@@ -511,7 +510,12 @@ defmodule EdenflowersWeb.CheckoutLive do
 
     case String.trim(params["delivery_address"] || "") do
       "" -> maybe_reset_delivery_address(socket)
-      _ -> {:noreply, socket}
+      address ->
+        if address != (socket.assigns.order.delivery_address || "") do
+          maybe_reset_delivery_address(socket)
+        else
+          {:noreply, socket}
+        end
     end
   end
 
@@ -594,7 +598,7 @@ defmodule EdenflowersWeb.CheckoutLive do
         {:noreply, socket}
 
       true ->
-        send(self(), {:calculate_delivery, address})
+        send(self(), {:confirm_delivery_address, address})
         {:noreply, assign(socket, address_state: :loading)}
     end
   end
@@ -672,26 +676,21 @@ defmodule EdenflowersWeb.CheckoutLive do
     {:noreply, assign(socket, form: form)}
   end
 
-  def handle_info({:calculate_delivery, address}, socket) do
-    fulfillment_option = socket.assigns.order.fulfillment_option
+  def handle_info({:confirm_delivery_address, address}, socket) do
     actor = socket.assigns[:current_user]
 
-    case Fulfillments.calculate_delivery(address, fulfillment_option) do
-      {:ok, result} ->
-        order =
-          Order.preview_delivery!(
-            socket.assigns.order,
-            Map.put(result, :delivery_address, address),
-            actor: actor
-          )
-
+    case Order.confirm_delivery_address(socket.assigns.order, address, actor: actor) do
+      {:ok, order} ->
         {:noreply, assign(socket, order: order, address_state: :confirmed, address_error: nil)}
 
-      {:error, :address_not_found} ->
-        {:noreply, assign(socket, address_state: :error, address_error: ~t"Address not found")}
+      {:error, %Ash.Error.Invalid{errors: errors}} ->
+        message =
+          case Enum.find(errors, &match?(%{field: :delivery_address}, &1)) do
+            %{message: msg} -> msg
+            _ -> ~t"There was a problem calculating delivery cost, please try again later"
+          end
 
-      {:error, :out_of_delivery_range} ->
-        {:noreply, assign(socket, address_state: :error, address_error: ~t"Outside delivery range")}
+        {:noreply, assign(socket, address_state: :error, address_error: message)}
 
       {:error, _} ->
         {:noreply,


### PR DESCRIPTION
Delivery address confirmation involved a subtle bug: after a user confirmed an address, changing the input field and submitting without re-confirming would pass `ValidateAndCalculateFulfillment` validation (which only checked that `calculated_address` was non-nil) while saving a mismatched `delivery_address`. Out-of-range and address-not-found errors also only existed as LiveView assign logic with no enforcement at the data layer.

The fix moves geocoding into a dedicated `ConfirmDeliveryAddress` Ash change used by a new `confirm_delivery_address` action. This makes the business rules (range limits, geocoding errors) enforceable in Ash rather than UI-only, and atomically writes all delivery fields together so `delivery_address` and `calculated_address` can never diverge. The `validate_form_3` handler is also updated to reset confirmed delivery data whenever the address field is edited, ensuring stale confirmation data cannot slip through on submit.