### PR TITLE
Personalize checkout address and phone labels with recipient name

### DIFF
--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -23,7 +23,7 @@ defmodule Edenflowers.Store.Order do
     Validations
   }
 
-  alias __MODULE__.Changes.{ResetCheckout, GenerateOrderReference}
+  alias __MODULE__.Changes.{ResetCheckout, GenerateOrderReference, ConfirmDeliveryAddress}
 
   postgres do
     repo Edenflowers.Repo
@@ -41,7 +41,7 @@ defmodule Edenflowers.Store.Order do
     define :add_promotion_with_id, action: :add_promotion_with_id, args: [:promotion_id]
     define :add_promotion_with_code, action: :add_promotion_with_code, args: [:code]
     define :clear_promotion, action: :clear_promotion
-    define :preview_delivery, action: :preview_delivery
+    define :confirm_delivery_address, action: :confirm_delivery_address, args: [:address]
     define :reset_delivery_address, action: :reset_delivery_address
     define :update_fulfillment_option, action: :update_fulfillment_option, args: [:fulfillment_option_id]
     define :update_gift, action: :update_gift, args: [:gift]
@@ -145,12 +145,7 @@ defmodule Edenflowers.Store.Order do
         :recipient_phone_number,
         :delivery_address,
         :delivery_instructions,
-        :fulfillment_date,
-        :fulfillment_amount,
-        :calculated_address,
-        :here_id,
-        :distance,
-        :position
+        :fulfillment_date
       ]
 
       change {ValidateFulfillmentDate, []}
@@ -174,8 +169,9 @@ defmodule Edenflowers.Store.Order do
       require_atomic? false
     end
 
-    update :preview_delivery do
-      accept [:delivery_address, :calculated_address, :position, :here_id, :distance, :fulfillment_amount]
+    update :confirm_delivery_address do
+      argument :address, :string, allow_nil?: false
+      change {ConfirmDeliveryAddress, []}
       require_atomic? false
     end
 

--- a/lib/edenflowers/store/order/changes/confirm_delivery_address.ex
+++ b/lib/edenflowers/store/order/changes/confirm_delivery_address.ex
@@ -1,0 +1,39 @@
+defmodule Edenflowers.Store.Order.Changes.ConfirmDeliveryAddress do
+  use Ash.Resource.Change
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  alias Edenflowers.Fulfillments
+  alias Edenflowers.Store.FulfillmentOption
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.before_action(changeset, fn changeset ->
+      address = Ash.Changeset.get_argument(changeset, :address)
+      fulfillment_option_id = Ash.Changeset.get_attribute(changeset, :fulfillment_option_id)
+
+      with {:ok, fulfillment_option} <- FulfillmentOption.get_by_id(fulfillment_option_id, authorize?: false),
+           {:ok, result} <- Fulfillments.calculate_delivery(address, fulfillment_option) do
+        Ash.Changeset.force_change_attributes(changeset,
+          delivery_address: address,
+          calculated_address: result.calculated_address,
+          position: result.position,
+          here_id: result.here_id,
+          distance: result.distance,
+          fulfillment_amount: result.fulfillment_amount
+        )
+      else
+        {:error, :address_not_found} ->
+          Ash.Changeset.add_error(changeset, field: :delivery_address, message: ~t"Address not found")
+
+        {:error, :out_of_delivery_range} ->
+          Ash.Changeset.add_error(changeset, field: :delivery_address, message: ~t"Outside delivery range")
+
+        {:error, _} ->
+          Ash.Changeset.add_error(changeset,
+            field: :delivery_address,
+            message: ~t"There was a problem calculating delivery cost, please try again later"
+          )
+      end
+    end)
+  end
+end

--- a/lib/edenflowers/store/order/changes/validate_and_calculate_fulfillment.ex
+++ b/lib/edenflowers/store/order/changes/validate_and_calculate_fulfillment.ex
@@ -47,10 +47,26 @@ defmodule Edenflowers.Store.Order.ValidateAndCalculateFulfillment do
   end
 
   defp handle_delivery(changeset) do
+    delivery_address = Ash.Changeset.get_attribute(changeset, :delivery_address)
     calculated_address = Ash.Changeset.get_attribute(changeset, :calculated_address)
     fulfillment_amount = Ash.Changeset.get_attribute(changeset, :fulfillment_amount)
 
-    if is_nil(calculated_address) or is_nil(fulfillment_amount) do
+    address_blank? = is_nil(delivery_address) or String.trim(delivery_address) == ""
+
+    changeset =
+      if address_blank? do
+        Ash.Changeset.force_change_attributes(changeset,
+          calculated_address: nil,
+          position: nil,
+          here_id: nil,
+          distance: nil,
+          fulfillment_amount: nil
+        )
+      else
+        changeset
+      end
+
+    if address_blank? or is_nil(calculated_address) or is_nil(fulfillment_amount) do
       Ash.Changeset.add_error(changeset, %Ash.Error.Changes.InvalidAttribute{
         field: :delivery_address,
         message: ~t"Please enter and confirm a delivery address"

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -4,7 +4,6 @@ defmodule EdenflowersWeb.CheckoutLive do
   require Logger
 
   alias Edenflowers.Store.{Order, FulfillmentOption, LineItem, ProductVariant}
-  alias Edenflowers.{Fulfillments}
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
 
@@ -511,7 +510,12 @@ defmodule EdenflowersWeb.CheckoutLive do
 
     case String.trim(params["delivery_address"] || "") do
       "" -> maybe_reset_delivery_address(socket)
-      _ -> {:noreply, socket}
+      address ->
+        if address != (socket.assigns.order.delivery_address || "") do
+          maybe_reset_delivery_address(socket)
+        else
+          {:noreply, socket}
+        end
     end
   end
 
@@ -594,7 +598,7 @@ defmodule EdenflowersWeb.CheckoutLive do
         {:noreply, socket}
 
       true ->
-        send(self(), {:calculate_delivery, address})
+        send(self(), {:confirm_delivery_address, address})
         {:noreply, assign(socket, address_state: :loading)}
     end
   end
@@ -672,26 +676,21 @@ defmodule EdenflowersWeb.CheckoutLive do
     {:noreply, assign(socket, form: form)}
   end
 
-  def handle_info({:calculate_delivery, address}, socket) do
-    fulfillment_option = socket.assigns.order.fulfillment_option
+  def handle_info({:confirm_delivery_address, address}, socket) do
     actor = socket.assigns[:current_user]
 
-    case Fulfillments.calculate_delivery(address, fulfillment_option) do
-      {:ok, result} ->
-        order =
-          Order.preview_delivery!(
-            socket.assigns.order,
-            Map.put(result, :delivery_address, address),
-            actor: actor
-          )
-
+    case Order.confirm_delivery_address(socket.assigns.order, address, actor: actor) do
+      {:ok, order} ->
         {:noreply, assign(socket, order: order, address_state: :confirmed, address_error: nil)}
 
-      {:error, :address_not_found} ->
-        {:noreply, assign(socket, address_state: :error, address_error: ~t"Address not found")}
+      {:error, %Ash.Error.Invalid{errors: errors}} ->
+        message =
+          case Enum.find(errors, &match?(%{field: :delivery_address}, &1)) do
+            %{message: msg} -> msg
+            _ -> ~t"There was a problem calculating delivery cost, please try again later"
+          end
 
-      {:error, :out_of_delivery_range} ->
-        {:noreply, assign(socket, address_state: :error, address_error: ~t"Outside delivery range")}
+        {:noreply, assign(socket, address_state: :error, address_error: message)}
 
       {:error, _} ->
         {:noreply,

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -813,15 +813,6 @@ defmodule EdenflowersWeb.CheckoutLive do
     end
   end
 
-  defp recipient_label(%{customer_name: name}, field) when is_binary(name) and name != "" do
-    first_name = name |> String.split() |> List.first()
-
-    case field do
-      "address" -> gettext("%{name}'s Address *", name: first_name)
-      "phone" -> gettext("%{name}'s Phone Number", name: first_name)
-    end
-  end
-
   defp recipient_label(_order, field) do
     case field do
       "address" -> gettext("Address *")

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -229,7 +229,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                       <%= if @order.fulfillment_option.fulfillment_method == :delivery do %>
                         <fieldset>
                           <label class="flex flex-col">
-                            <span class="mb-1">{~t"Address *"}</span>
+                            <span class="mb-1">{recipient_label(@order, "address")}</span>
                             <div class="relative">
                               <input
                                 type="text"
@@ -283,7 +283,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                       <% end %>
 
                       <.input
-                        label={~t"Phone Number"}
+                        label={recipient_label(@order, "phone")}
                         placeholder={~t"045 1505141"}
                         field={@form[:recipient_phone_number]}
                         type="text"
@@ -802,6 +802,29 @@ defmodule EdenflowersWeb.CheckoutLive do
      socket
      |> put_flash(:error, flash_message)
      |> push_navigate(to: ~p"/")}
+  end
+
+  defp recipient_label(%{gift: true, recipient_name: name}, field) when is_binary(name) and name != "" do
+    first_name = name |> String.split() |> List.first()
+    case field do
+      "address" -> gettext("%{name}'s Address *", name: first_name)
+      "phone" -> gettext("%{name}'s Phone Number", name: first_name)
+    end
+  end
+
+  defp recipient_label(%{customer_name: name}, field) when is_binary(name) and name != "" do
+    first_name = name |> String.split() |> List.first()
+    case field do
+      "address" -> gettext("%{name}'s Address *", name: first_name)
+      "phone" -> gettext("%{name}'s Phone Number", name: first_name)
+    end
+  end
+
+  defp recipient_label(_order, field) do
+    case field do
+      "address" -> gettext("Address *")
+      "phone" -> gettext("Phone Number")
+    end
   end
 
   defp action_name(action, step) when is_atom(action) and is_integer(step) do

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -806,6 +806,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp recipient_label(%{gift: true, recipient_name: name}, field) when is_binary(name) and name != "" do
     first_name = name |> String.split() |> List.first()
+
     case field do
       "address" -> gettext("%{name}'s Address *", name: first_name)
       "phone" -> gettext("%{name}'s Phone Number", name: first_name)
@@ -814,6 +815,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp recipient_label(%{customer_name: name}, field) when is_binary(name) and name != "" do
     first_name = name |> String.split() |> List.first()
+
     case field do
       "address" -> gettext("%{name}'s Address *", name: first_name)
       "phone" -> gettext("%{name}'s Phone Number", name: first_name)

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -4,6 +4,7 @@ defmodule EdenflowersWeb.CheckoutLive do
   require Logger
 
   alias Edenflowers.Store.{Order, FulfillmentOption, LineItem, ProductVariant}
+  alias Edenflowers.Fulfillments
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
 
@@ -27,11 +28,7 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:order, order)
        |> assign(:form, make_form(order, action_name(:save, order.step)))
        |> assign(:promotional_form, make_form(order, :add_promotion_with_code))
-       |> assign(
-         :address_state,
-         if(order.step == 3 and not is_nil(order.calculated_address), do: :confirmed, else: :idle)
-       )
-       |> assign(:address_error, nil)
+       |> assign(:address_lookup, nil)
        |> setup_stripe(order)}
     else
       {:error, :empty_cart} ->
@@ -234,22 +231,21 @@ defmodule EdenflowersWeb.CheckoutLive do
                                 id={@form[:delivery_address].id}
                                 name={@form[:delivery_address].name}
                                 value={Phoenix.HTML.Form.normalize_value("text", @form[:delivery_address].value)}
-                                placeholder={~t"Stadsgatan 3, 65300 Vasa"}
                                 class={["input input-lg w-full pr-10", @form[:delivery_address].errors != [] && Phoenix.Component.used_input?(@form[:delivery_address]) && "input-error"]}
                                 phx-blur="check_delivery_address"
                               />
                               <div class="pointer-events-none absolute inset-y-0 right-3 z-10 flex items-center">
                                 <span
-                                  :if={@address_state == :loading}
+                                  :if={@address_lookup == :loading}
                                   class="loading loading-spinner loading-sm text-base-content/40"
                                 />
                                 <.icon
-                                  :if={@address_state == :confirmed}
+                                  :if={@address_lookup == nil and not is_nil(@order.calculated_address)}
                                   name="hero-check-circle-mini"
                                   class="text-success size-5"
                                 />
                                 <.icon
-                                  :if={@address_state == :error}
+                                  :if={match?({:error, _}, @address_lookup)}
                                   name="hero-exclamation-circle-mini"
                                   class="text-error size-5"
                                 />
@@ -265,11 +261,11 @@ defmodule EdenflowersWeb.CheckoutLive do
                           }>
                             {msg}
                           </.error>
-                          <p :if={@address_state == :confirmed} class="mt-1.5 text-sm">
+                          <p :if={@address_lookup == nil and not is_nil(@order.calculated_address)} class="mt-1.5 text-sm">
                             {format_distance(@order.distance)} • {format_delivery_amount(@order)}
                           </p>
-                          <p :if={@address_state == :error} class="text-error mt-1.5 text-sm">
-                            {@address_error}
+                          <p :if={match?({:error, _}, @address_lookup)} class="text-error mt-1.5 text-sm">
+                            {elem(@address_lookup, 1)}
                           </p>
                         </fieldset>
 
@@ -508,14 +504,10 @@ defmodule EdenflowersWeb.CheckoutLive do
     form = AshPhoenix.Form.validate(socket.assigns.form, params)
     socket = assign(socket, form: form)
 
-    case String.trim(params["delivery_address"] || "") do
-      "" -> maybe_reset_delivery_address(socket)
-      address ->
-        if address != (socket.assigns.order.delivery_address || "") do
-          maybe_reset_delivery_address(socket)
-        else
-          {:noreply, socket}
-        end
+    if String.trim(params["delivery_address"] || "") == "" do
+      {:noreply, assign(socket, address_lookup: :cleared)}
+    else
+      {:noreply, socket}
     end
   end
 
@@ -560,13 +552,7 @@ defmodule EdenflowersWeb.CheckoutLive do
     |> Ash.update!()
 
     order = Order.get_for_checkout!(order.id, actor: actor)
-
-    address_state =
-      if not is_nil(order.calculated_address),
-        do: :confirmed,
-        else: :idle
-
-    {:noreply, assign(socket, order: order, address_state: address_state, address_error: nil)}
+    {:noreply, assign(socket, order: order, address_lookup: nil)}
   end
 
   def handle_event("edit_step_" <> step, _params, %{assigns: %{order: order}} = socket) do
@@ -584,22 +570,20 @@ defmodule EdenflowersWeb.CheckoutLive do
   def handle_event("update_fulfillment_option", %{"form" => %{"fulfillment_option_id" => id}}, socket) do
     actor = socket.assigns[:current_user]
     order = Order.update_fulfillment_option!(socket.assigns.order, id, actor: actor)
-    {:noreply, assign(socket, order: order, address_state: :idle, address_error: nil)}
+    {:noreply, assign(socket, order: order, address_lookup: nil)}
   end
 
   def handle_event("check_delivery_address", %{"value" => address}, socket) do
     cond do
       String.trim(address) == "" ->
-        actor = socket.assigns[:current_user]
-        order = Order.reset_delivery_address!(socket.assigns.order, actor: actor)
-        {:noreply, assign(socket, order: order, address_state: :idle)}
+        {:noreply, assign(socket, address_lookup: :cleared)}
 
-      address == socket.assigns.order.delivery_address ->
+      address == socket.assigns.order.delivery_address and socket.assigns.address_lookup != :cleared ->
         {:noreply, socket}
 
       true ->
         send(self(), {:confirm_delivery_address, address})
-        {:noreply, assign(socket, address_state: :loading)}
+        {:noreply, assign(socket, address_lookup: :loading)}
     end
   end
 
@@ -681,7 +665,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
     case Order.confirm_delivery_address(socket.assigns.order, address, actor: actor) do
       {:ok, order} ->
-        {:noreply, assign(socket, order: order, address_state: :confirmed, address_error: nil)}
+        {:noreply, assign(socket, order: order, address_lookup: nil)}
 
       {:error, %Ash.Error.Invalid{errors: errors}} ->
         message =
@@ -690,13 +674,12 @@ defmodule EdenflowersWeb.CheckoutLive do
             _ -> ~t"There was a problem calculating delivery cost, please try again later"
           end
 
-        {:noreply, assign(socket, address_state: :error, address_error: message)}
+        {:noreply, assign(socket, address_lookup: {:error, message})}
 
       {:error, _} ->
         {:noreply,
          assign(socket,
-           address_state: :error,
-           address_error: ~t"There was a problem calculating delivery cost, please try again later"
+           address_lookup: {:error, ~t"There was a problem calculating delivery cost, please try again later"}
          )}
     end
   end
@@ -711,7 +694,8 @@ defmodule EdenflowersWeb.CheckoutLive do
      socket
      |> assign(order: order)
      |> assign(form: make_form(order, action_name(:save, order.step)))
-     |> assign(promotional_form: make_form(order, :add_promotion_with_code))}
+     |> assign(promotional_form: make_form(order, :add_promotion_with_code))
+     |> assign(address_lookup: nil)}
   end
 
   # Reloads order on line item changes. Redirects to homepage when the cart becomes empty.
@@ -823,18 +807,6 @@ defmodule EdenflowersWeb.CheckoutLive do
   defp get_next_section_id(id, 2), do: "#{id}-form-3a"
   defp get_next_section_id(id, 3), do: "#{id}-form-4"
   defp get_next_section_id(_, _), do: nil
-
-  # Clears calculated delivery fields when the address input is emptied.
-  # No-op if nothing has been calculated yet (calculated_address is nil).
-  defp maybe_reset_delivery_address(%{assigns: %{order: %{calculated_address: nil}}} = socket) do
-    {:noreply, socket}
-  end
-
-  defp maybe_reset_delivery_address(socket) do
-    actor = socket.assigns[:current_user]
-    order = Order.reset_delivery_address!(socket.assigns.order, actor: actor)
-    {:noreply, assign(socket, order: order, address_state: :idle)}
-  end
 
   defp format_distance(nil), do: ""
 

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -28,6 +28,11 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:order, order)
        |> assign(:form, make_form(order, action_name(:save, order.step)))
        |> assign(:promotional_form, make_form(order, :add_promotion_with_code))
+       # address_lookup tracks transient geocoding state not representable by order data:
+       # nil = idle or confirmed (check order.calculated_address to distinguish)
+       # :loading = geocode request in flight
+       # :cleared = user emptied the field; stale geocode data still on order but should be hidden
+       # {:error, msg} = geocode failed
        |> assign(:address_lookup, nil)
        |> setup_stripe(order)}
     else
@@ -500,6 +505,9 @@ defmodule EdenflowersWeb.CheckoutLive do
   # ==============
 
   # Form validation & submission
+
+  # Clears address confirmation indicators immediately as the user empties the field,
+  # rather than waiting for blur. check_delivery_address handles the blur case.
   def handle_event("validate_form_3", %{"form" => params}, socket) do
     form = AshPhoenix.Form.validate(socket.assigns.form, params)
     socket = assign(socket, form: form)
@@ -578,10 +586,14 @@ defmodule EdenflowersWeb.CheckoutLive do
       String.trim(address) == "" ->
         {:noreply, assign(socket, address_lookup: :cleared)}
 
+      # Skip re-geocoding if the address hasn't changed since the last confirmed lookup.
+      # The :cleared guard ensures re-entering the same address after clearing still triggers
+      # a fresh lookup, since the stale geocode data is still on the order at that point.
       address == socket.assigns.order.delivery_address and socket.assigns.address_lookup != :cleared ->
         {:noreply, socket}
 
       true ->
+        # Deferred via send/2 so the :loading state renders before the blocking geocode call.
         send(self(), {:confirm_delivery_address, address})
         {:noreply, assign(socket, address_lookup: :loading)}
     end
@@ -686,6 +698,8 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   # Reloads order and rebuilds forms when order is updated via PubSub.
   # Centralizes form synchronization to prevent stale data across all order modifications.
+  # Reloads order and rebuilds forms when order is updated via PubSub.
+  # Resets address_lookup to nil so confirmed state is re-derived from order.calculated_address.
   def handle_info(%Phoenix.Socket.Broadcast{topic: "order:updated:" <> order_id}, socket) do
     actor = socket.assigns[:current_user]
     order = Order.get_for_checkout!(order_id, actor: actor)


### PR DESCRIPTION
## Summary

- Address and phone number labels in checkout step 3 now show the recipient's first name (e.g. "David's Address *", "Sarah's Phone Number")
- For gift orders, uses the recipient name; for self orders, uses the generic "Address *" / "Phone Number"