### PR TITLE
Replace bulk_destroy with single-item destroy in ClearGiftFields

### DIFF
--- a/lib/edenflowers/store/order/changes/clear_gift_fields.ex
+++ b/lib/edenflowers/store/order/changes/clear_gift_fields.ex
@@ -1,9 +1,9 @@
 defmodule Edenflowers.Store.Order.Changes.ClearGiftFields do
   @moduledoc """
-  Clears gift-related fields and removes card line items when the order is not a gift.
+  Clears gift-related fields and removes the card line item when the order is not a gift.
 
   When the gift flag is set to false, this change clears the recipient_name and
-  card_message fields and destroys any card line items attached to the order.
+  card_message fields and destroys the card line item attached to the order, if any.
   """
   use Ash.Resource.Change
 
@@ -20,10 +20,19 @@ defmodule Edenflowers.Store.Order.Changes.ClearGiftFields do
         Ash.Changeset.after_action(changeset, fn _changeset, result ->
           Edenflowers.Store.LineItem
           |> Ash.Query.filter(order_id == ^result.id and is_card == true)
-          |> Ash.bulk_destroy(:remove_item, %{}, authorize?: false, return_errors?: true, strategy: [:stream])
+          |> Ash.read_one(authorize?: false)
           |> case do
-            %Ash.BulkResult{status: :success} -> {:ok, result}
-            %Ash.BulkResult{errors: errors} -> {:error, errors}
+            {:ok, nil} ->
+              {:ok, result}
+
+            {:ok, line_item} ->
+              case Ash.destroy(line_item, action: :remove_item, authorize?: false) do
+                :ok -> {:ok, result}
+                {:error, error} -> {:error, error}
+              end
+
+            {:error, error} ->
+              {:error, error}
           end
         end)
       else


### PR DESCRIPTION
## Summary
- A gift order has at most one card line item (the UI uses `Enum.find` and `ValidateCardMessageLength` does too), so `Ash.bulk_destroy` was the wrong tool. Its `BulkResult` shape is what produced the original bug: the after_action was returning `{:error, errors}` (a list), which is not a valid after_action return.
- Replace with `Ash.read_one` + `Ash.destroy`. Errors propagate as proper Ash error structs, no list unwrap needed, and the code matches the actual data model.
- Drops the `:strategy` question from the issue entirely — there's no strategy because there's no bulk operation.

Closes #87

## Test plan
- [x] Full test suite passes (186 tests, 0 failures)
- [x] `clears recipient_name and card_message when switching from gift=true to gift=false` test still passes — exercises the destroy path with one card line item present
- [x] Manual: switch gift toggle off in checkout, confirm card line item is removed and order saves