### PR TITLE
Lock down CourseRegistration.register status field

### DIFF
--- a/lib/edenflowers/services/course_registrations.ex
+++ b/lib/edenflowers/services/course_registrations.ex
@@ -16,10 +16,11 @@ defmodule Edenflowers.Services.CourseRegistration do
   end
 
   actions do
-    defaults [:read, :destroy, update: :*]
+    defaults [:read, :destroy]
 
     create :register do
-      accept [:name, :email, :course_id, :status]
+      accept [:name, :email, :course_id]
+      change set_attribute(:status, :pending)
       change {Edenflowers.Services.CourseRegistration.Changes.SetUserFromActor, []}
     end
 
@@ -50,7 +51,11 @@ defmodule Edenflowers.Services.CourseRegistration do
     uuid_primary_key :id
     attribute :name, :string, allow_nil?: false
     attribute :email, :string, allow_nil?: false
-    attribute :status, :atom, default: :pending
+
+    attribute :status, :atom,
+      default: :pending,
+      constraints: [one_of: [:pending, :confirmed, :cancelled]]
+
     timestamps()
   end
 


### PR DESCRIPTION
## Summary

- Removes `:status` from `register` action's accept list and sets it to `:pending` via `set_attribute`, so clients can't submit `status: :confirmed` and skip payment
- Constrains the `:status` attribute to `one_of: [:pending, :confirmed, :cancelled]`
- Drops `update: :*` from defaults — no callers exist outside the resource, and the only legitimate status mutation path is `:confirm_payment`

Closes #80

## Test plan
- [x] `mix test` (186 passing)
- [x] Manual: register form still creates a pending registration
- [x] Manual: status transitions to `:confirmed` only via `:confirm_payment`