### PR TITLE
Codebase-wide style consistency pass

### DIFF
--- a/lib/edenflowers/accounts/user.ex
+++ b/lib/edenflowers/accounts/user.ex
@@ -63,9 +63,7 @@ defmodule Edenflowers.Accounts.User do
       description "Looks up a user by their email"
       get? true
 
-      argument :email, :ci_string do
-        allow_nil? false
-      end
+      argument :email, :ci_string, allow_nil?: false
 
       filter expr(email == ^arg(:email))
     end
@@ -77,8 +75,6 @@ defmodule Edenflowers.Accounts.User do
     end
 
     update :update do
-      description "Users can update their own safe fields (admin is NOT writable)"
-      # Explicitly exclude admin field - it's already writable?: false but this is defense in depth
       accept [:name, :newsletter_opt_in]
     end
 
@@ -103,9 +99,7 @@ defmodule Edenflowers.Accounts.User do
     end
 
     action :request_magic_link do
-      argument :email, :ci_string do
-        allow_nil? false
-      end
+      argument :email, :ci_string, allow_nil?: false
 
       run AshAuthentication.Strategy.MagicLink.Request
     end
@@ -168,7 +162,6 @@ defmodule Edenflowers.Accounts.User do
     attribute :email, :ci_string, allow_nil?: false, public?: true
     attribute :newsletter_opt_in, :boolean, default: false, public?: true
 
-    # Admin field - readable but not writable to prevent privilege escalation
     attribute :admin, :boolean, default: false, public?: true, writable?: false
   end
 

--- a/lib/edenflowers/services.ex
+++ b/lib/edenflowers/services.ex
@@ -1,5 +1,6 @@
 defmodule Edenflowers.Services do
-  use Ash.Domain
+  use Ash.Domain,
+    otp_app: :edenflowers
 
   resources do
     resource Edenflowers.Services.Course

--- a/lib/edenflowers/store.ex
+++ b/lib/edenflowers/store.ex
@@ -1,5 +1,6 @@
 defmodule Edenflowers.Store do
-  use Ash.Domain
+  use Ash.Domain,
+    otp_app: :edenflowers
 
   resources do
     resource Edenflowers.Store.Product

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -24,7 +24,42 @@ defmodule Edenflowers.Store.FulfillmentOption do
   end
 
   actions do
-    defaults [:read, :destroy, create: :*, update: :*]
+    defaults [
+      :read,
+      :destroy,
+      create: [
+        :name,
+        :minimum_cart_total,
+        :fulfillment_method,
+        :rate_type,
+        :base_price,
+        :price_per_km,
+        :free_dist_km,
+        :max_dist_km,
+        :same_day,
+        :order_deadline,
+        :available_days,
+        :enabled_dates,
+        :disabled_dates,
+        :tax_rate_id
+      ],
+      update: [
+        :name,
+        :minimum_cart_total,
+        :fulfillment_method,
+        :rate_type,
+        :base_price,
+        :price_per_km,
+        :free_dist_km,
+        :max_dist_km,
+        :same_day,
+        :order_deadline,
+        :available_days,
+        :enabled_dates,
+        :disabled_dates,
+        :tax_rate_id
+      ]
+    ]
 
     read :by_id do
       argument :id, :uuid, allow_nil?: false

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -9,26 +9,7 @@ defmodule Edenflowers.Store.Order do
 
   require Ash.Resource.Change.Builtins
 
-  alias __MODULE__.Changes.{
-    CalculatePickupCost,
-    ClearDeliveryFields,
-    ClearGiftFields,
-    CopyFulfillmentMethod,
-    GenerateOrderReference,
-    LookupPromotionCode,
-    ResetCheckout,
-    TrimCardMessage,
-    UpdatePromotionUsageCount,
-    UpsertUserAndAssignToOrder
-  }
-
-  alias __MODULE__.Validations.{
-    ValidateCardMessageLength,
-    ValidateFulfillmentDate,
-    ValidateGeocodedAddress,
-    ValidateMinimumCartTotal
-  }
-
+  alias __MODULE__.{Changes, Validations}
   alias Edenflowers.Store.FulfillmentOption
 
   @checkout_load [
@@ -110,7 +91,7 @@ defmodule Edenflowers.Store.Order do
     # Create Actions
     create :create_for_checkout do
       change set_attribute(:step, 1)
-      change {GenerateOrderReference, []}
+      change {Changes.GenerateOrderReference, []}
     end
 
     # Step-specific Update Actions
@@ -122,7 +103,7 @@ defmodule Edenflowers.Store.Order do
     update :save_step_1 do
       accept [:customer_name, :customer_email]
       require_attributes [:customer_name, :customer_email]
-      change {UpsertUserAndAssignToOrder, []}
+      change {Changes.UpsertUserAndAssignToOrder, []}
       change set_attribute(:step, 2)
       change load(@checkout_load)
       require_atomic? false
@@ -136,10 +117,10 @@ defmodule Edenflowers.Store.Order do
     update :save_step_2 do
       accept [:gift, :recipient_name, :card_message]
       change set_attribute(:step, 3)
-      change {TrimCardMessage, []}
+      change {Changes.TrimCardMessage, []}
       validate present(:recipient_name), where: [attribute_equals(:gift, true)]
-      validate {ValidateCardMessageLength, []}
-      change {ClearGiftFields, []}
+      validate {Validations.ValidateCardMessageLength, []}
+      change {Changes.ClearGiftFields, []}
       change load(@checkout_load)
       require_atomic? false
     end
@@ -164,10 +145,10 @@ defmodule Edenflowers.Store.Order do
         :fulfillment_amount
       ]
 
-      change {CopyFulfillmentMethod, []}
-      validate {ValidateFulfillmentDate, []}
-      validate {ValidateGeocodedAddress, []}
-      change {CalculatePickupCost, []}
+      change {Changes.CopyFulfillmentMethod, []}
+      validate {Validations.ValidateFulfillmentDate, []}
+      validate {Validations.ValidateGeocodedAddress, []}
+      change {Changes.CalculatePickupCost, []}
       change set_attribute(:step, 4)
       change load(@checkout_load)
       require_atomic? false
@@ -183,15 +164,15 @@ defmodule Edenflowers.Store.Order do
       change transition_state(:placed)
       change set_attribute(:payment_status, :paid)
       change set_attribute(:ordered_at, &DateTime.utc_now/0)
-      change {UpdatePromotionUsageCount, []}
+      change {Changes.UpdatePromotionUsageCount, []}
       require_atomic? false
     end
 
     update :update_fulfillment_option do
       accept [:fulfillment_option_id]
-      change {CopyFulfillmentMethod, []}
+      change {Changes.CopyFulfillmentMethod, []}
       change set_attribute(:fulfillment_date, nil)
-      change {ClearDeliveryFields, []}
+      change {Changes.ClearDeliveryFields, []}
       change load(@checkout_load)
       require_atomic? false
     end
@@ -217,7 +198,7 @@ defmodule Edenflowers.Store.Order do
 
     update :add_promotion_with_id do
       argument :promotion_id, :uuid, allow_nil?: false
-      validate {ValidateMinimumCartTotal, []}
+      validate {Validations.ValidateMinimumCartTotal, []}
       change atomic_update(:promotion_id, expr(^arg(:promotion_id)))
       change load(@checkout_load)
       require_atomic? false
@@ -225,8 +206,8 @@ defmodule Edenflowers.Store.Order do
 
     update :add_promotion_with_code do
       argument :code, :string
-      change {LookupPromotionCode, []}
-      validate {ValidateMinimumCartTotal, []}
+      change {Changes.LookupPromotionCode, []}
+      validate {Validations.ValidateMinimumCartTotal, []}
       change load(@checkout_load)
       require_atomic? false
     end
@@ -238,7 +219,7 @@ defmodule Edenflowers.Store.Order do
 
     update :restart_checkout do
       require_atomic? false
-      change {ResetCheckout, []}
+      change {Changes.ResetCheckout, []}
     end
   end
 

--- a/lib/edenflowers/store/product_fulfillment_option.ex
+++ b/lib/edenflowers/store/product_fulfillment_option.ex
@@ -18,7 +18,12 @@ defmodule Edenflowers.Store.ProductFulfillmentOption do
   end
 
   actions do
-    defaults [:read, :destroy, create: :*, update: :*]
+    defaults [
+      :read,
+      :destroy,
+      create: [:product_id, :fulfillment_option_id],
+      update: [:product_id, :fulfillment_option_id]
+    ]
   end
 
   attributes do


### PR DESCRIPTION
Five small style/consistency fixes (no functional change):

- Add `otp_app: :edenflowers` to `Edenflowers.Store` and `Edenflowers.Services` domains (Accounts already had it). Enables Ash config/codegen features.
- Replace `create: :*` / `update: :*` defaults with explicit accept lists in `ProductFulfillmentOption` and `FulfillmentOption`. Prevents future attributes from accidentally becoming publicly writable. (`CourseRegistration` was already explicit.)
- Use the keyword `argument` form when only `allow_nil?` is set; reserve the block form for arguments with `description`/`constraints` (per the Ash style guide). Two updates in `User`.
- Trim Order's 22-line `Changes`/`Validations` alias block down to `alias __MODULE__.{Changes, Validations}` and prefix call sites.
- Remove redundant prose comments on `User.update` and `User.admin` that duplicate what the `accept` list and `writable?: false` already say.

> Superseded by #113, which lands these changes with conflicts against `main` resolved.

Closes #95.
