### PR TITLE
Simplify LineItem creation by auto-populating variant data

### DIFF
--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -26,32 +26,16 @@ defmodule Edenflowers.Store.LineItem do
     defaults [:read]
 
     create :add_to_cart do
-      accept [
-        :order_id,
-        :product_id,
-        :product_variant_id,
-        :product_name,
-        :product_image_slug,
-        :quantity,
-        :unit_price,
-        :tax_rate
-      ]
+      accept [:order_id, :product_variant_id, :quantity]
+
+      change Edenflowers.Store.LineItem.Changes.PopulateFromVariant
     end
 
     create :add_card do
-      accept [
-        :order_id,
-        :product_id,
-        :product_variant_id,
-        :product_name,
-        :product_image_slug,
-        :card_size,
-        :quantity,
-        :unit_price,
-        :tax_rate
-      ]
+      accept [:order_id, :product_variant_id, :quantity]
 
       change set_attribute(:is_card, true)
+      change Edenflowers.Store.LineItem.Changes.PopulateFromVariant
     end
 
     destroy :remove_item do

--- a/lib/edenflowers/store/line_item/changes/populate_from_variant.ex
+++ b/lib/edenflowers/store/line_item/changes/populate_from_variant.ex
@@ -1,0 +1,38 @@
+defmodule Edenflowers.Store.LineItem.Changes.PopulateFromVariant do
+  use Ash.Resource.Change
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  alias Edenflowers.Store.ProductVariant
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    variant_id = Ash.Changeset.get_attribute(changeset, :product_variant_id)
+
+    with id when not is_nil(id) <- variant_id,
+         {:ok, variant} <-
+           Ash.get(ProductVariant, id, load: [product: [:tax_rate]], authorize?: false) do
+      attrs = %{
+        product_id: variant.product.id,
+        product_name: variant.product.name,
+        product_image_slug: variant.image_slug,
+        unit_price: variant.price,
+        tax_rate: variant.product.tax_rate.percentage
+      }
+
+      attrs =
+        if Ash.Changeset.get_attribute(changeset, :is_card) do
+          Map.put(attrs, :card_size, variant.size)
+        else
+          attrs
+        end
+
+      Ash.Changeset.force_change_attributes(changeset, attrs)
+    else
+      _ ->
+        Ash.Changeset.add_error(changeset, %Ash.Error.Changes.InvalidAttribute{
+          field: :product_variant_id,
+          message: ~t"is invalid"
+        })
+    end
+  end
+end

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -546,14 +546,8 @@ defmodule EdenflowersWeb.CheckoutLive do
 
     LineItem.add_card!(%{
       order_id: socket.assigns.order.id,
-      product_id: variant.product.id,
       product_variant_id: variant.id,
-      product_name: variant.product.name,
-      product_image_slug: variant.image_slug,
-      card_size: variant.size,
-      quantity: 1,
-      unit_price: variant.price,
-      tax_rate: variant.product.tax_rate.percentage
+      quantity: 1
     })
 
     socket = reload_order(socket)

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -201,13 +201,8 @@ defmodule EdenflowersWeb.ProductLive do
   def handle_event("submit", _params, socket) do
     LineItem.add_item(%{
       order_id: socket.assigns.order_id,
-      product_id: socket.assigns.product.id,
       product_variant_id: socket.assigns.selected_variant.id,
-      product_name: socket.assigns.product.name,
-      product_image_slug: socket.assigns.selected_variant.image_slug,
-      quantity: 1,
-      unit_price: socket.assigns.selected_variant.price,
-      tax_rate: socket.assigns.product.tax_rate.percentage
+      quantity: 1
     })
 
     {:noreply, socket}

--- a/test/edenflowers_web/live/checkout_address_live_test.exs
+++ b/test/edenflowers_web/live/checkout_address_live_test.exs
@@ -17,13 +17,8 @@ defmodule EdenflowersWeb.CheckoutAddressLiveTest do
 
     LineItem.add_item!(%{
       order_id: order.id,
-      product_id: product.id,
       product_variant_id: variant.id,
-      product_name: product.name,
-      product_image_slug: variant.image_slug,
-      quantity: 1,
-      unit_price: variant.price,
-      tax_rate: Decimal.new("0.24")
+      quantity: 1
     })
 
     stub(Edenflowers.StripeAPI.Mock, :create_payment_intent, fn _order ->

--- a/test/edenflowers_web/live/checkout_happy_path_test.exs
+++ b/test/edenflowers_web/live/checkout_happy_path_test.exs
@@ -30,13 +30,8 @@ defmodule EdenflowersWeb.CheckoutHappyPathTest do
 
     LineItem.add_item!(%{
       order_id: order.id,
-      product_id: product.id,
       product_variant_id: variant.id,
-      product_name: product.name,
-      product_image_slug: variant.image_slug,
-      quantity: 1,
-      unit_price: variant.price,
-      tax_rate: tax_rate.percentage
+      quantity: 1
     })
 
     payment_intent = %{

--- a/test/edenflowers_web/live/checkout_live_test.exs
+++ b/test/edenflowers_web/live/checkout_live_test.exs
@@ -20,13 +20,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
     {:ok, _line_item} =
       LineItem.add_item(%{
         order_id: order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
     order = Order.get_for_checkout!(order.id, actor: nil)
@@ -93,13 +88,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       conn
@@ -141,14 +131,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       assert {:ok, card_line_item} =
                LineItem.add_card(%{
                  order_id: order.id,
-                 product_id: card_product.id,
                  product_variant_id: card_variant.id,
-                 product_name: card_product.name,
-                 product_image_slug: card_variant.image_slug,
-                 card_size: card_variant.size,
-                 quantity: 1,
-                 unit_price: card_variant.price,
-                 tax_rate: Decimal.new("0.24")
+                 quantity: 1
                })
 
       assert card_line_item.is_card == true
@@ -162,14 +146,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       assert {:error, _} =
                LineItem.add_card(%{
                  order_id: order.id,
-                 product_id: card_product.id,
                  product_variant_id: card_variant.id,
-                 product_name: card_product.name,
-                 product_image_slug: card_variant.image_slug,
-                 card_size: card_variant.size,
-                 quantity: 1,
-                 unit_price: card_variant.price,
-                 tax_rate: Decimal.new("0.24")
+                 quantity: 1
                })
     end
 
@@ -186,14 +164,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       {:ok, _card} =
         LineItem.add_card(%{
           order_id: order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         })
 
       order
@@ -210,26 +182,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -247,13 +208,8 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       conn
@@ -271,26 +227,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -311,26 +256,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -351,26 +285,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -389,26 +312,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -430,26 +342,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -475,26 +376,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -516,26 +406,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )
@@ -557,26 +436,15 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       LineItem.add_item!(%{
         order_id: gift_order.id,
-        product_id: product.id,
         product_variant_id: variant.id,
-        product_name: product.name,
-        product_image_slug: variant.image_slug,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       })
 
       LineItem.add_card!(
         %{
           order_id: gift_order.id,
-          product_id: card_product.id,
           product_variant_id: card_variant.id,
-          product_name: card_product.name,
-          product_image_slug: card_variant.image_slug,
-          card_size: card_variant.size,
-          quantity: 1,
-          unit_price: card_variant.price,
-          tax_rate: Decimal.new("0.24")
+          quantity: 1
         },
         authorize?: false
       )

--- a/test/edenflowers_web/stripe_handler_test.exs
+++ b/test/edenflowers_web/stripe_handler_test.exs
@@ -36,12 +36,7 @@ defmodule EdenflowersWeb.StripeHandlerTest do
         generate(
           line_item(
             order_id: order.id,
-            product_id: product.id,
-            product_name: product.name,
-            product_image_slug: product.image_slug,
             product_variant_id: product_variant.id,
-            unit_price: product_variant.price,
-            tax_rate: tax_rate.percentage,
             quantity: 1
           )
         )

--- a/test/line_item_test.exs
+++ b/test/line_item_test.exs
@@ -13,80 +13,45 @@ defmodule Edenflowers.Store.LineItemTest do
   end
 
   describe "Order Item Resource" do
-    test "creates an order item", %{
-      order: order,
-      tax_rate: tax_rate,
-      product: product,
-      product_variant: product_variant
-    } do
+    test "creates an order item", %{order: order, product_variant: product_variant} do
       assert {:ok, _} =
                LineItem
                |> Ash.Changeset.for_create(:add_to_cart, %{
                  order_id: order.id,
-                 product_id: product.id,
-                 product_name: product.name,
-                 product_image_slug: product.image_slug,
-                 product_variant_id: product_variant.id,
-                 unit_price: product_variant.price,
-                 tax_rate: tax_rate.percentage
+                 product_variant_id: product_variant.id
                })
                |> Ash.create(authorize?: false)
     end
 
-    test "default quantity is 1", %{
-      order: order,
-      tax_rate: tax_rate,
-      product: product,
-      product_variant: product_variant
-    } do
+    test "default quantity is 1", %{order: order, product_variant: product_variant} do
       line_item =
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         })
         |> Ash.create!(authorize?: false)
 
       assert line_item.quantity == 1
     end
 
-    test "quantity can only be 1 or greater", %{
-      order: order,
-      tax_rate: tax_rate,
-      product: product,
-      product_variant: product_variant
-    } do
+    test "quantity can only be 1 or greater", %{order: order, product_variant: product_variant} do
       assert {:error, _} =
                LineItem
                |> Ash.Changeset.for_create(:add_to_cart, %{
                  order_id: order.id,
-                 product_id: product.id,
-                 product_name: product.name,
-                 product_image_slug: product.image_slug,
                  product_variant_id: product_variant.id,
-                 quantity: 0,
-                 unit_price: product_variant.price,
-                 tax_rate: tax_rate.percentage
+                 quantity: 0
                })
                |> Ash.create()
     end
 
-    test "increments quantity", %{order: order, tax_rate: tax_rate, product: product, product_variant: product_variant} do
+    test "increments quantity", %{order: order, product_variant: product_variant} do
       line_item =
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         })
         |> Ash.create!(authorize?: false)
         |> Ash.Changeset.for_update(:increment_quantity)
@@ -95,18 +60,13 @@ defmodule Edenflowers.Store.LineItemTest do
       assert line_item.quantity == 2
     end
 
-    test "decrements quantity", %{order: order, tax_rate: tax_rate, product: product, product_variant: product_variant} do
+    test "decrements quantity", %{order: order, product_variant: product_variant} do
       line_item =
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          quantity: 3,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          quantity: 3
         })
         |> Ash.create!(authorize?: false)
         |> Ash.Changeset.for_update(:decrement_quantity)
@@ -115,22 +75,12 @@ defmodule Edenflowers.Store.LineItemTest do
       assert line_item.quantity == 2
     end
 
-    test "decrements quantity no lower than 1", %{
-      order: order,
-      tax_rate: tax_rate,
-      product: product,
-      product_variant: product_variant
-    } do
+    test "decrements quantity no lower than 1", %{order: order, product_variant: product_variant} do
       line_item =
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         })
         |> Ash.create!(authorize?: false)
         |> Ash.Changeset.for_update(:decrement_quantity)
@@ -139,11 +89,7 @@ defmodule Edenflowers.Store.LineItemTest do
       assert line_item.quantity == 1
     end
 
-    test "promotion_applied? returns true if promotion applied to order", %{
-      tax_rate: tax_rate,
-      product: product,
-      product_variant: product_variant
-    } do
+    test "promotion_applied? returns true if promotion applied to order", %{product_variant: product_variant} do
       promotion = generate(promotion(discount_percentage: "0.20", minimum_cart_total: "0"))
       order = generate(order())
 
@@ -152,12 +98,7 @@ defmodule Edenflowers.Store.LineItemTest do
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         })
         |> Ash.create!(authorize?: false)
 
@@ -171,20 +112,13 @@ defmodule Edenflowers.Store.LineItemTest do
 
     test "promotion_applied? returns false if no promotion applied to order", %{
       order: order,
-      tax_rate: tax_rate,
-      product: product,
       product_variant: product_variant
     } do
       line_item =
         LineItem
         |> Ash.Changeset.for_create(:add_to_cart, %{
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         })
         |> Ash.create!(authorize?: false)
         |> Ash.load!(:promotion_applied?)
@@ -214,43 +148,30 @@ defmodule Edenflowers.Store.LineItemTest do
     end
 
     test "add_card creates a line item with is_card set to true and copies card_size",
-         %{gift_order: gift_order, card_product: card_product, card_variant: card_variant} do
+         %{gift_order: gift_order, card_variant: card_variant} do
       assert {:ok, line_item} =
                LineItem.add_card(%{
                  order_id: gift_order.id,
-                 product_id: card_product.id,
                  product_variant_id: card_variant.id,
-                 product_name: card_product.name,
-                 product_image_slug: card_variant.image_slug,
-                 card_size: card_variant.size,
-                 quantity: 1,
-                 unit_price: card_variant.price,
-                 tax_rate: Decimal.new("0.24")
+                 quantity: 1
                })
 
       assert line_item.is_card == true
       assert line_item.card_size == card_variant.size
     end
 
-    test "add_card is rejected for non-gift orders",
-         %{card_product: card_product, card_variant: card_variant} do
+    test "add_card is rejected for non-gift orders", %{card_variant: card_variant} do
       non_gift_order = generate(order())
 
       assert {:error, _} =
                LineItem.add_card(%{
                  order_id: non_gift_order.id,
-                 product_id: card_product.id,
                  product_variant_id: card_variant.id,
-                 product_name: card_product.name,
-                 product_image_slug: card_variant.image_slug,
-                 quantity: 1,
-                 unit_price: card_variant.price,
-                 tax_rate: Decimal.new("0.24")
+                 quantity: 1
                })
     end
 
-    test "add_card is rejected when order is not in checkout state",
-         %{card_product: card_product, card_variant: card_variant} do
+    test "add_card is rejected when order is not in checkout state", %{card_variant: card_variant} do
       completed_order =
         generate(order(state: :placed))
         |> Ash.Changeset.for_update(:set_gift, %{gift: true})
@@ -259,13 +180,8 @@ defmodule Edenflowers.Store.LineItemTest do
       assert {:error, _} =
                LineItem.add_card(%{
                  order_id: completed_order.id,
-                 product_id: card_product.id,
                  product_variant_id: card_variant.id,
-                 product_name: card_product.name,
-                 product_image_slug: card_variant.image_slug,
-                 quantity: 1,
-                 unit_price: card_variant.price,
-                 tax_rate: Decimal.new("0.24")
+                 quantity: 1
                })
     end
   end

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -22,12 +22,7 @@ defmodule Edenflowers.Store.OrderTest do
         generate(
           line_item(
             order_id: order.id,
-            product_id: product_1.id,
-            product_name: product_1.name,
-            product_image_slug: product_1.image_slug,
             product_variant_id: product_1_product_variant_1.id,
-            unit_price: product_1_product_variant_1.price,
-            tax_rate: tax_rate.percentage,
             quantity: 2
           )
         )
@@ -36,12 +31,7 @@ defmodule Edenflowers.Store.OrderTest do
         generate(
           line_item(
             order_id: order.id,
-            product_id: product_2.id,
-            product_name: product_2.name,
-            product_image_slug: product_2.image_slug,
             product_variant_id: product_2_product_variant_1.id,
-            unit_price: product_2_product_variant_1.price,
-            tax_rate: tax_rate.percentage,
             quantity: 1
           )
         )
@@ -65,12 +55,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product_1.id,
-          product_name: product_1.name,
-          product_image_slug: product_1.image_slug,
           product_variant_id: product_1_product_variant_1.id,
-          unit_price: product_1_product_variant_1.price,
-          tax_rate: tax_rate_1.percentage,
           quantity: 2
         )
       )
@@ -78,12 +63,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product_2.id,
-          product_name: product_2.name,
-          product_image_slug: product_2.image_slug,
           product_variant_id: product_2_product_variant_1.id,
-          unit_price: product_2_product_variant_1.price,
-          tax_rate: tax_rate_2.percentage,
           quantity: 1
         )
       )
@@ -106,12 +86,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant_1.id,
-          unit_price: product_variant_1.price,
-          tax_rate: tax_rate.percentage,
           quantity: 1
         )
       )
@@ -119,12 +94,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant_2.id,
-          unit_price: product_variant_2.price,
-          tax_rate: tax_rate.percentage,
           quantity: 2
         )
       )
@@ -154,12 +124,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         )
       )
 
@@ -202,12 +167,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate_2.percentage,
           quantity: 2
         )
       )
@@ -365,14 +325,8 @@ defmodule Edenflowers.Store.OrderTest do
     LineItem.add_card!(
       %{
         order_id: order.id,
-        product_id: card_product.id,
         product_variant_id: variant.id,
-        product_name: card_product.name,
-        product_image_slug: variant.image_slug,
-        card_size: size,
-        quantity: 1,
-        unit_price: variant.price,
-        tax_rate: Decimal.new("0.24")
+        quantity: 1
       },
       authorize?: false
     )
@@ -596,12 +550,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         )
       )
 
@@ -620,12 +569,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         )
       )
 
@@ -823,12 +767,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage,
           quantity: 2
         )
       )
@@ -854,12 +793,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage,
           quantity: 2
         )
       )
@@ -883,12 +817,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage,
           quantity: 1
         )
       )
@@ -925,12 +854,7 @@ defmodule Edenflowers.Store.OrderTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
           product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage,
           quantity: 1
         )
       )

--- a/test/promotion_test.exs
+++ b/test/promotion_test.exs
@@ -192,12 +192,7 @@ defmodule Edenflowers.Store.PromotionTest do
         generate(
           line_item(
             order_id: order.id,
-            product_id: product.id,
-            product_name: product.name,
-            product_image_slug: product.image_slug,
-            product_variant_id: product_variant.id,
-            unit_price: product_variant.price,
-            tax_rate: tax_rate.percentage
+            product_variant_id: product_variant.id
           )
         )
 
@@ -324,12 +319,7 @@ defmodule Edenflowers.Store.PromotionTest do
       generate(
         line_item(
           order_id: order.id,
-          product_id: product.id,
-          product_name: product.name,
-          product_image_slug: product.image_slug,
-          product_variant_id: product_variant.id,
-          unit_price: product_variant.price,
-          tax_rate: tax_rate.percentage
+          product_variant_id: product_variant.id
         )
       )
 


### PR DESCRIPTION
## Summary

Auto-populates product and pricing on `LineItem` creation from the `ProductVariant`, removing the need to pass redundant data.

## Key changes

- **`PopulateFromVariant` change**: loads variant data and populates `product_id`, `product_name`, `product_image_slug`, `unit_price`, `tax_rate`, and `card_size` (for card line items).
- **Action surface**: `add_to_cart` and `add_card` now accept only `order_id`, `product_variant_id`, and `quantity`. The change populates everything else.
- **Call sites simplified**: `CheckoutLive`, `ProductLive`, and all test fixtures (`checkout_live_test`, `line_item_test`, `order_test`, `promotion_test`, …) drop manual passing of product details, prices, and tax rates.

## Benefits

- Eliminates duplicating data already on the variant.
- Single source of truth — product/pricing always fresh from the variant.
- Simpler API — callers provide variant id and quantity.
