### PR TITLE
Consolidate query filter patterns (#93)

### DIFF
--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -110,15 +110,7 @@ defmodule Edenflowers.Store.LineItem do
   end
 
   calculations do
-    calculate :promotion_applied?,
-              :boolean,
-              expr(
-                if(
-                  is_nil(order.promotion),
-                  do: false,
-                  else: true
-                )
-              )
+    calculate :promotion_applied?, :boolean, expr(not is_nil(order.promotion_id))
 
     # This is the base price for a specific item or service multiplied by the quantity, before any taxes or discounts are applied.
     calculate :line_subtotal, :decimal, expr(unit_price * quantity)

--- a/lib/edenflowers/store/product.ex
+++ b/lib/edenflowers/store/product.ex
@@ -22,50 +22,27 @@ defmodule Edenflowers.Store.Product do
     defaults [:read, :destroy]
 
     read :for_store do
-      filter expr(
-               draft == false and
-                 exists(product_variants) and
-                 product_category.draft == false
-             )
-
-      prepare build(load: [:cheapest_price, :product_variants, :product_category])
+      prepare Edenflowers.Store.Product.Preparations.VisibleInStore
     end
 
     read :featured do
-      filter expr(
-               featured == true and
-                 draft == false and
-                 exists(product_variants) and
-                 product_category.draft == false
-             )
-
-      prepare build(load: [:cheapest_price, :product_variants, :product_category])
+      filter expr(featured == true)
+      prepare Edenflowers.Store.Product.Preparations.VisibleInStore
     end
 
     read :by_category do
       argument :category_id, :uuid, allow_nil?: false
 
-      filter expr(
-               draft == false and
-                 exists(product_variants) and
-                 product_category_id == ^arg(:category_id) and
-                 product_category.draft == false
-             )
-
-      prepare build(load: [:cheapest_price, :product_variants, :product_category])
+      filter expr(product_category_id == ^arg(:category_id))
+      prepare Edenflowers.Store.Product.Preparations.VisibleInStore
     end
 
     read :get_by_category_slug do
       argument :slug, :string, allow_nil?: false
 
-      filter expr(
-               draft == false and
-                 exists(product_variants) and
-                 product_category.slug == ^arg(:slug) and
-                 product_category.draft == false
-             )
-
-      prepare build(load: [:cheapest_price, :product_variants, :product_category, :tax_rate])
+      filter expr(product_category.slug == ^arg(:slug))
+      prepare Edenflowers.Store.Product.Preparations.VisibleInStore
+      prepare build(load: [:tax_rate])
     end
 
     read :by_id do

--- a/lib/edenflowers/store/product/preparations/visible_in_store.ex
+++ b/lib/edenflowers/store/product/preparations/visible_in_store.ex
@@ -1,0 +1,18 @@
+defmodule Edenflowers.Store.Product.Preparations.VisibleInStore do
+  use Ash.Resource.Preparation
+  require Ash.Query
+
+  @impl true
+  def init(opts), do: {:ok, opts}
+
+  @impl true
+  def prepare(query, _opts, _context) do
+    Ash.Query.filter(
+      query,
+      draft == false and
+        exists(product_variants) and
+        product_category.draft == false
+    )
+    |> Ash.Query.load([:cheapest_price, :product_variants, :product_category])
+  end
+end

--- a/lib/edenflowers/store/promotion.ex
+++ b/lib/edenflowers/store/promotion.ex
@@ -32,9 +32,9 @@ defmodule Edenflowers.Store.Promotion do
 
       filter expr(
                code == ^arg(:code) and
-                 if(not is_nil(usage_limit), do: usage < usage_limit, else: true) and
-                 if(not is_nil(start_date), do: ^arg(:today) >= start_date, else: true) and
-                 if(not is_nil(expiration_date), do: ^arg(:today) <= expiration_date, else: true)
+                 (is_nil(usage_limit) or usage < usage_limit) and
+                 (is_nil(start_date) or ^arg(:today) >= start_date) and
+                 (is_nil(expiration_date) or ^arg(:today) <= expiration_date)
              )
     end
 


### PR DESCRIPTION
Closes #93.

## Changes

### 1. `Promotion.by_code` filter (CODE_REVIEW §20)

Rewrote the optional-bound clauses with `is_nil(...) or ...` instead of `if(not is_nil(...), do: ..., else: true)`. Same semantics, but a clean `OR` reads better for the PostgreSQL planner.

### 2. `LineItem.promotion_applied?` (CODE_REVIEW §22)

Replaced `is_nil(order.promotion)` with `not is_nil(order.promotion_id)`. The previous form forced Ash to resolve the `promotion` relationship just to check existence; the FK column on `orders` answers the same question with no extra JOIN to `promotions`.

`discount_amount` still references `order.promotion.discount_percentage` (it actually needs the percentage), so the JOIN to `promotions` happens only when computing the discount value. `:promotion` is already preloaded in `Order.@checkout_load`, and `Order.fulfillment_tax_amount` resolves through `fulfillment_option.tax_rate.percentage` as a single SQL JOIN via Ash's expression calculations.

### 3. Product visibility filter (CODE_REVIEW §23)

Extracted the shared filter (`draft == false and exists(product_variants) and product_category.draft == false`) and the common load list (`:cheapest_price, :product_variants, :product_category`) into `Edenflowers.Store.Product.Preparations.VisibleInStore`. The `for_store`, `featured`, `by_category`, and `get_by_category_slug` actions now all use it; action-specific filters (`featured == true`, `product_category_id == ...`, etc.) remain on the actions themselves.

## Test plan

- [ ] CI: `mix test` (mix isn't installed in this environment, so the suite hasn't been run locally — the existing tests in `test/promotion_test.exs` and `test/product_test.exs` cover both refactored areas)
