### PR TITLE
CI cache test (do not merge)

### DIFF
--- a/lib/edenflowers.ex
+++ b/lib/edenflowers.ex
@@ -6,6 +6,6 @@ defmodule Edenflowers do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
 
-  (CI cache test — commit 1)
+  (CI cache test — commit 2)
   """
 end

--- a/lib/edenflowers.ex
+++ b/lib/edenflowers.ex
@@ -5,5 +5,7 @@ defmodule Edenflowers do
 
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
+
+  (CI cache test — commit 1)
   """
 end


### PR DESCRIPTION
Throwaway PR to validate the new split-cache CI config in `.github/workflows/ci.yml`.

## What this is testing
- **Commit 1 (cold cache):** First run after cache key prefix change — no matching cache exists, so `_build/` rebuilds from scratch. Establishes baseline.
- **Commit 2 (warm cache):** Second run should hit the rolling restore-key from commit 1's saved cache. With a one-line moduledoc edit, the `mix compile` step should recompile only 1 file.

If commit 2 still recompiles many files, the cache layout needs more work (likely an Ash/Spark recompile-cascade issue rather than a cache config issue).

## Plan
- [ ] Run 1 finishes — note duration of `mix compile --warnings-as-errors` step
- [ ] Push commit 2
- [ ] Run 2 finishes — compare timing
- [ ] Close without merging