### PR TITLE
Add explicit forbid policies for create/update/destroy

### DIFF
--- a/lib/edenflowers/services/course.ex
+++ b/lib/edenflowers/services/course.ex
@@ -55,6 +55,11 @@ defmodule Edenflowers.Services.Course do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   attributes do

--- a/lib/edenflowers/services/course.ex
+++ b/lib/edenflowers/services/course.ex
@@ -58,6 +58,7 @@ defmodule Edenflowers.Services.Course do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -78,6 +78,11 @@ defmodule Edenflowers.Store.FulfillmentOption do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   validations do

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -81,6 +81,7 @@ defmodule Edenflowers.Store.FulfillmentOption do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/product.ex
+++ b/lib/edenflowers/store/product.ex
@@ -70,6 +70,11 @@ defmodule Edenflowers.Store.Product do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   attributes do

--- a/lib/edenflowers/store/product.ex
+++ b/lib/edenflowers/store/product.ex
@@ -73,6 +73,7 @@ defmodule Edenflowers.Store.Product do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/product_category.ex
+++ b/lib/edenflowers/store/product_category.ex
@@ -56,6 +56,7 @@ defmodule Edenflowers.Store.ProductCategory do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/product_category.ex
+++ b/lib/edenflowers/store/product_category.ex
@@ -53,6 +53,11 @@ defmodule Edenflowers.Store.ProductCategory do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   attributes do

--- a/lib/edenflowers/store/product_variant.ex
+++ b/lib/edenflowers/store/product_variant.ex
@@ -57,6 +57,7 @@ defmodule Edenflowers.Store.ProductVariant do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/product_variant.ex
+++ b/lib/edenflowers/store/product_variant.ex
@@ -54,6 +54,11 @@ defmodule Edenflowers.Store.ProductVariant do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   preparations do

--- a/lib/edenflowers/store/promotion.ex
+++ b/lib/edenflowers/store/promotion.ex
@@ -69,6 +69,7 @@ defmodule Edenflowers.Store.Promotion do
 
     # Only system/admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin or system actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/promotion.ex
+++ b/lib/edenflowers/store/promotion.ex
@@ -66,6 +66,11 @@ defmodule Edenflowers.Store.Promotion do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only system/admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   validations do

--- a/lib/edenflowers/store/tax_rate.ex
+++ b/lib/edenflowers/store/tax_rate.ex
@@ -32,6 +32,7 @@ defmodule Edenflowers.Store.TaxRate do
 
     # Only admin via bypass — all others forbidden
     policy action_type([:create, :update, :destroy]) do
+      description "All mutations require admin actor (covered by bypass above)."
       forbid_if always()
     end
   end

--- a/lib/edenflowers/store/tax_rate.ex
+++ b/lib/edenflowers/store/tax_rate.ex
@@ -29,6 +29,11 @@ defmodule Edenflowers.Store.TaxRate do
     policy action_type(:read) do
       authorize_if always()
     end
+
+    # Only admin via bypass — all others forbidden
+    policy action_type([:create, :update, :destroy]) do
+      forbid_if always()
+    end
   end
 
   attributes do

--- a/test/policies_test.exs
+++ b/test/policies_test.exs
@@ -1,0 +1,242 @@
+defmodule Edenflowers.PoliciesTest do
+  @moduledoc """
+  Verifies that create/update/destroy on resources without an authenticated
+  admin (or system actor, where applicable) are explicitly forbidden.
+  """
+  use Edenflowers.DataCase
+  import Generator
+
+  alias Edenflowers.Services.Course
+
+  alias Edenflowers.Store.{
+    FulfillmentOption,
+    Product,
+    ProductCategory,
+    ProductVariant,
+    Promotion,
+    TaxRate
+  }
+
+  describe "Promotion mutations require admin or system actor" do
+    setup do
+      {:ok, promotion: generate(promotion())}
+    end
+
+    test "create is forbidden for unauthenticated actor" do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Promotion
+               |> Ash.Changeset.for_create(:create, %{
+                 name: "Test",
+                 code: "TEST",
+                 discount_percentage: "0.10",
+                 minimum_cart_total: "0"
+               })
+               |> Ash.create()
+    end
+
+    test "update (increment_usage) is forbidden for unauthenticated actor", %{promotion: promotion} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               promotion
+               |> Ash.Changeset.for_update(:increment_usage, %{})
+               |> Ash.update()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{promotion: promotion} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(promotion)
+    end
+
+    test "create is forbidden for non-admin actor" do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Promotion
+               |> Ash.Changeset.for_create(:create, %{
+                 name: "Test",
+                 code: "TEST",
+                 discount_percentage: "0.10",
+                 minimum_cart_total: "0"
+               })
+               |> Ash.create(actor: %{admin: false})
+    end
+  end
+
+  describe "Product mutations require admin actor" do
+    setup do
+      tax_rate = generate(tax_rate())
+      product_category = generate(product_category())
+      {:ok, product: generate(product()), tax_rate: tax_rate, product_category: product_category}
+    end
+
+    test "create is forbidden for unauthenticated actor", %{tax_rate: tax_rate, product_category: pc} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Product
+               |> Ash.Changeset.for_create(:create, %{
+                 name: "Test product",
+                 description: "",
+                 image_slug: "x.png",
+                 tax_rate_id: tax_rate.id,
+                 product_category_id: pc.id
+               })
+               |> Ash.create()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{product: product} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(product)
+    end
+  end
+
+  describe "ProductVariant mutations require admin actor" do
+    setup do
+      product = generate(product())
+      variant = generate(product_variant(product_id: product.id))
+      {:ok, product: product, variant: variant}
+    end
+
+    test "create is forbidden for unauthenticated actor", %{product: product} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               ProductVariant
+               |> Ash.Changeset.for_create(:create, %{
+                 price: "10.00",
+                 size: :small,
+                 image_slug: "x.png",
+                 product_id: product.id
+               })
+               |> Ash.create()
+    end
+
+    test "update is forbidden for unauthenticated actor", %{variant: variant} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               variant
+               |> Ash.Changeset.for_update(:update, %{price: "20.00"})
+               |> Ash.update()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{variant: variant} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(variant)
+    end
+  end
+
+  describe "ProductCategory mutations require admin actor" do
+    setup do
+      {:ok, category: generate(product_category())}
+    end
+
+    test "create is forbidden for unauthenticated actor" do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               ProductCategory
+               |> Ash.Changeset.for_create(:create, %{name: "Test", slug: "test"})
+               |> Ash.create()
+    end
+
+    test "update is forbidden for unauthenticated actor", %{category: category} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               category
+               |> Ash.Changeset.for_update(:update, %{name: "Renamed"})
+               |> Ash.update()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{category: category} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(category)
+    end
+  end
+
+  describe "TaxRate mutations require admin actor" do
+    setup do
+      {:ok, tax_rate: generate(tax_rate())}
+    end
+
+    test "create is forbidden for unauthenticated actor" do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               TaxRate
+               |> Ash.Changeset.for_create(:create, %{name: "VAT", percentage: "0.24"})
+               |> Ash.create()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{tax_rate: tax_rate} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(tax_rate)
+    end
+  end
+
+  describe "FulfillmentOption mutations require admin actor" do
+    setup do
+      tax_rate = generate(tax_rate())
+      option = generate(fulfillment_option(tax_rate_id: tax_rate.id))
+      {:ok, option: option, tax_rate: tax_rate}
+    end
+
+    test "create is forbidden for unauthenticated actor", %{tax_rate: tax_rate} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               FulfillmentOption
+               |> Ash.Changeset.for_create(:create, %{
+                 name: "Test",
+                 fulfillment_method: :pickup,
+                 rate_type: :fixed,
+                 base_price: "0.00",
+                 tax_rate_id: tax_rate.id
+               })
+               |> Ash.create()
+    end
+
+    test "update is forbidden for unauthenticated actor", %{option: option} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               option
+               |> Ash.Changeset.for_update(:update, %{base_price: "9.99"})
+               |> Ash.update()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{option: option} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(option)
+    end
+  end
+
+  describe "Course mutations require admin actor" do
+    setup do
+      course =
+        Course
+        |> Ash.Changeset.for_create(:create, %{
+          name: "Course",
+          description: "Description",
+          location_name: "Studio",
+          location_address: "1 Street",
+          image_slug: "x.png",
+          date: ~D[2030-01-01],
+          start_time: ~T[10:00:00],
+          end_time: ~T[12:00:00],
+          register_before: ~D[2029-12-25],
+          total_places: 10,
+          price: "50.00"
+        })
+        |> Ash.create!(authorize?: false)
+
+      {:ok, course: course}
+    end
+
+    test "create is forbidden for unauthenticated actor" do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Course
+               |> Ash.Changeset.for_create(:create, %{
+                 name: "Course",
+                 description: "Description",
+                 location_name: "Studio",
+                 location_address: "1 Street",
+                 image_slug: "x.png",
+                 date: ~D[2030-01-01],
+                 start_time: ~T[10:00:00],
+                 end_time: ~T[12:00:00],
+                 register_before: ~D[2029-12-25],
+                 total_places: 10,
+                 price: "50.00"
+               })
+               |> Ash.create()
+    end
+
+    test "update is forbidden for unauthenticated actor", %{course: course} do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               course
+               |> Ash.Changeset.for_update(:update, %{total_places: 20})
+               |> Ash.update()
+    end
+
+    test "destroy is forbidden for unauthenticated actor", %{course: course} do
+      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(course)
+    end
+  end
+end

--- a/test/policies_test.exs
+++ b/test/policies_test.exs
@@ -23,7 +23,7 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor" do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                Promotion
                |> Ash.Changeset.for_create(:create, %{
                  name: "Test",
@@ -31,30 +31,23 @@ defmodule Edenflowers.PoliciesTest do
                  discount_percentage: "0.10",
                  minimum_cart_total: "0"
                })
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "update (increment_usage) is forbidden for unauthenticated actor", %{promotion: promotion} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                promotion
-               |> Ash.Changeset.for_update(:increment_usage, %{})
-               |> Ash.update()
+               |> Ash.Changeset.for_update(:increment_usage, %{}, actor: nil)
+               |> Ash.update(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{promotion: promotion} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(promotion)
-    end
-
-    test "create is forbidden for non-admin actor" do
-      assert {:error, %Ash.Error.Forbidden{}} =
-               Promotion
-               |> Ash.Changeset.for_create(:create, %{
-                 name: "Test",
-                 code: "TEST",
-                 discount_percentage: "0.10",
-                 minimum_cart_total: "0"
-               })
-               |> Ash.create(actor: %{admin: false})
+      assert {:error, error} = Ash.destroy(promotion, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -66,7 +59,7 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor", %{tax_rate: tax_rate, product_category: pc} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                Product
                |> Ash.Changeset.for_create(:create, %{
                  name: "Test product",
@@ -75,11 +68,14 @@ defmodule Edenflowers.PoliciesTest do
                  tax_rate_id: tax_rate.id,
                  product_category_id: pc.id
                })
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{product: product} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(product)
+      assert {:error, error} = Ash.destroy(product, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -91,7 +87,7 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor", %{product: product} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                ProductVariant
                |> Ash.Changeset.for_create(:create, %{
                  price: "10.00",
@@ -99,18 +95,23 @@ defmodule Edenflowers.PoliciesTest do
                  image_slug: "x.png",
                  product_id: product.id
                })
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "update is forbidden for unauthenticated actor", %{variant: variant} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                variant
                |> Ash.Changeset.for_update(:update, %{price: "20.00"})
-               |> Ash.update()
+               |> Ash.update(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{variant: variant} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(variant)
+      assert {:error, error} = Ash.destroy(variant, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -120,21 +121,26 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor" do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                ProductCategory
                |> Ash.Changeset.for_create(:create, %{name: "Test", slug: "test"})
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "update is forbidden for unauthenticated actor", %{category: category} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                category
                |> Ash.Changeset.for_update(:update, %{name: "Renamed"})
-               |> Ash.update()
+               |> Ash.update(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{category: category} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(category)
+      assert {:error, error} = Ash.destroy(category, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -144,14 +150,17 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor" do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                TaxRate
                |> Ash.Changeset.for_create(:create, %{name: "VAT", percentage: "0.24"})
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{tax_rate: tax_rate} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(tax_rate)
+      assert {:error, error} = Ash.destroy(tax_rate, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -163,7 +172,7 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor", %{tax_rate: tax_rate} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                FulfillmentOption
                |> Ash.Changeset.for_create(:create, %{
                  name: "Test",
@@ -172,18 +181,23 @@ defmodule Edenflowers.PoliciesTest do
                  base_price: "0.00",
                  tax_rate_id: tax_rate.id
                })
-               |> Ash.create()
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "update is forbidden for unauthenticated actor", %{option: option} do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                option
                |> Ash.Changeset.for_update(:update, %{base_price: "9.99"})
-               |> Ash.update()
+               |> Ash.update(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{option: option} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(option)
+      assert {:error, error} = Ash.destroy(option, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 
@@ -210,7 +224,7 @@ defmodule Edenflowers.PoliciesTest do
     end
 
     test "create is forbidden for unauthenticated actor" do
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, error} =
                Course
                |> Ash.Changeset.for_create(:create, %{
                  name: "Course",
@@ -225,18 +239,14 @@ defmodule Edenflowers.PoliciesTest do
                  total_places: 10,
                  price: "50.00"
                })
-               |> Ash.create()
-    end
+               |> Ash.create(actor: nil)
 
-    test "update is forbidden for unauthenticated actor", %{course: course} do
-      assert {:error, %Ash.Error.Forbidden{}} =
-               course
-               |> Ash.Changeset.for_update(:update, %{total_places: 20})
-               |> Ash.update()
+      assert %Ash.Error.Forbidden{} = error
     end
 
     test "destroy is forbidden for unauthenticated actor", %{course: course} do
-      assert {:error, %Ash.Error.Forbidden{}} = Ash.destroy(course)
+      assert {:error, error} = Ash.destroy(course, actor: nil)
+      assert %Ash.Error.Forbidden{} = error
     end
   end
 end

--- a/test/policies_test.exs
+++ b/test/policies_test.exs
@@ -63,7 +63,7 @@ defmodule Edenflowers.PoliciesTest do
                Product
                |> Ash.Changeset.for_create(:create, %{
                  name: "Test product",
-                 description: "",
+                 description: "Test description",
                  image_slug: "x.png",
                  tax_rate_id: tax_rate.id,
                  product_category_id: pc.id


### PR DESCRIPTION
## Summary

Closes #84.

Adds an explicit non-bypass `forbid_if always()` policy on `action_type([:create, :update, :destroy])` to seven resources that previously relied on Ash's default-forbid behaviour:

- `Edenflowers.Store.Promotion`
- `Edenflowers.Store.Product`
- `Edenflowers.Store.ProductVariant`
- `Edenflowers.Store.ProductCategory`
- `Edenflowers.Store.TaxRate`
- `Edenflowers.Store.FulfillmentOption`
- `Edenflowers.Services.Course`

Each policy carries a one-line descriptive comment explaining the intent ("only system/admin via bypass — all others forbidden"). Existing admin/system bypasses and public-read policies are untouched, so behaviour is identical for legitimate callers (admin actors and workers using `system_actor()`).

## Why

The default-forbid path is brittle: adding a future bypass or new policy could widen access without an explicit decision. Making the forbid explicit means a reviewer has to consciously remove or relax it.

## Test plan

- [x] New `test/policies_test.exs` asserts that an unauthenticated actor receives `Ash.Error.Forbidden` on create/update/destroy for each affected resource (and on `Promotion.increment_usage`).
- [x] Existing test fixtures use `authorize?: false`, so no other tests should regress.
- [ ] CI: `mix test`, `mix compile --warnings-as-errors`.
- [ ] Manual: confirm admin actor still passes through the bypass on each resource (covered structurally — the bypass is unchanged).
