### PR TITLE
Drop authorize?: false bypass in OrderIsGiftInCheckout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ npm-debug.log
 images
 
 .DS_Store
+
+.playwright-mcp

--- a/lib/edenflowers/store/line_item/checks/order_is_gift_in_checkout.ex
+++ b/lib/edenflowers/store/line_item/checks/order_is_gift_in_checkout.ex
@@ -4,8 +4,10 @@ defmodule Edenflowers.Store.LineItem.Checks.OrderIsGiftInCheckout do
   in the checkout state.
 
   Expression-based filter policies cannot reference relationships on create
-  actions (no data exists yet to filter), so this check reads the order
-  directly from the `order_id` attribute on the changeset.
+  actions (no row exists yet to filter), so this check reads the order
+  directly from the `order_id` attribute on the changeset. The lookup goes
+  through `Order`'s own read policy — which authorizes `state == :checkout`
+  reads — so no `authorize?: false` bypass is needed.
   """
   use Ash.Policy.SimpleCheck
 
@@ -13,13 +15,13 @@ defmodule Edenflowers.Store.LineItem.Checks.OrderIsGiftInCheckout do
   def describe(_opts), do: "order is a gift in checkout state"
 
   @impl true
-  def match?(_actor, %{changeset: %Ash.Changeset{} = changeset}, _opts) do
+  def match?(actor, %{changeset: %Ash.Changeset{} = changeset}, _opts) do
     case Ash.Changeset.get_attribute(changeset, :order_id) do
       nil ->
         false
 
       order_id ->
-        case Edenflowers.Store.Order.get_by_id(order_id, authorize?: false) do
+        case Edenflowers.Store.Order.get_by_id(order_id, actor: actor) do
           {:ok, %{gift: true, state: :checkout}} -> true
           _ -> false
         end


### PR DESCRIPTION
## Summary

- Closes #91. Removes the `authorize?: false` lookup in `OrderIsGiftInCheckout` — `Order`'s own read policy already authorizes `state == :checkout` reads, so the bypass was unnecessary and brittle.
- Stays as a `SimpleCheck`. FilterCheck was the alternative the issue asked us to evaluate; it is not viable for this case (see issue comment for details — Ash rejects relationship references in create-action filter policies).
- Caching on `changeset.context` deferred — pays off only with a bulk-add path, which doesn't exist today.

## Test plan

- [x] `mix test test/line_item_test.exs` — 11/11 (gift+checkout add_card succeeds, non-gift rejected, non-checkout rejected)
- [x] `mix test` full suite — 196/196