### PR TITLE
Restore focus to drawer trigger on close

### DIFF
--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -682,6 +682,7 @@ defmodule EdenflowersWeb.CoreComponents do
           time: @time
         )
         |> JS.toggle_class("overflow-hidden", to: "html")
+        |> JS.pop_focus()
       }
       class="z-100 relative"
     >

--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -150,7 +150,7 @@ defmodule EdenflowersWeb.Layouts do
               <%!-- Mobile hamburger menu --%>
               <div class="block xl:hidden">
                 <button
-                  phx-click={JS.exec("phx-show", to: "#nav-drawer")}
+                  phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#nav-drawer")}
                   type="button"
                   class="h-12 w-12 cursor-pointer"
                   aria-label={~t"Open navigation menu"}
@@ -212,7 +212,7 @@ defmodule EdenflowersWeb.Layouts do
 
               <%!-- Cart button --%>
               <button
-                phx-click={JS.exec("phx-show", to: "#cart-drawer")}
+                phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#cart-drawer")}
                 type="button"
                 class="group relative flex h-10 w-10 cursor-pointer items-center justify-center gap-1 lg:h-auto lg:w-auto lg:gap-2"
               >

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -151,7 +151,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                                 <div class="relative">
                                   <button
                                     type="button"
-                                    phx-click={JS.exec("phx-show", to: "#card-drawer")}
+                                    phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#card-drawer")}
                                     class="block shrink-0 cursor-pointer"
                                     data-testid="card-image-button"
                                     title={gettext("Change card")}
@@ -198,7 +198,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                       <button
                         :if={is_nil(card_line_item)}
                         type="button"
-                        phx-click={JS.exec("phx-show", to: "#card-drawer")}
+                        phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#card-drawer")}
                         class="btn btn-dash w-full"
                         data-testid="select-card-button"
                       >

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -113,7 +113,7 @@ defmodule EdenflowersWeb.ProductLive do
 
                 <button
                   type="submit"
-                  phx-click={JS.exec("phx-show", to: "#cart-drawer")}
+                  phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#cart-drawer")}
                   class="btn btn-primary btn-lg"
                   data-testid="add-to-cart-button"
                 >


### PR DESCRIPTION
## Summary
- Closes #69.
- Closing a drawer left focus inside the hidden dialog, so the browser fell back to `<body>` and Tab order restarted at the top of the page. Per the WAI-ARIA Authoring Practices Dialog Pattern, focus should return to the element that invoked the dialog.
- Each drawer trigger chains `JS.push_focus()` onto its `phx-click` to record the trigger button before opening; the shared drawer component appends `JS.pop_focus()` to `phx-hide` so every close path (Escape, click-away, in-drawer close button) restores focus.

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test test/edenflowers_web/live/checkout_happy_path_test.exs` passes
- [x] Full suite (`mix test`) passes — 221 tests, 0 failures
- [x] Manually verify each drawer in a browser:
  - [x] **Nav drawer** (mobile viewport): Tab to hamburger → Enter → drawer opens → Escape → focus is back on hamburger
  - [x] **Cart drawer** (header): Tab to cart icon → Enter → drawer opens → click backdrop → focus is back on cart icon
  - [x] **Cart drawer** (product page): click "Add to Cart" → cart drawer opens → close → focus is on the Add to Cart button (or falls through cleanly if the page re-rendered)
  - [x] **Card drawer** (checkout): focus card-image button → Enter → drawer opens → Escape → focus is back on card-image button
  - [x] **Card drawer** (checkout, "Add a card"): same flow as above