### PR TITLE
Drop trailing error icon from input component

### DIFF
--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -372,11 +372,11 @@ defmodule EdenflowersWeb.CoreComponents do
             name={@name}
             id={@id}
             value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-            class={[@class || "input input-lg w-full", (@loading or @confirmed or @errors != [] or @trailing != []) && "pr-10", @errors != [] && (@error_class || "input-error")]}
+            class={[@class || "input input-lg w-full", (@loading or @confirmed or @trailing != []) && "pr-10", @errors != [] && (@error_class || "input-error")]}
             {@rest}
           />
           <div
-            :if={@loading or @confirmed or @errors != [] or @trailing != []}
+            :if={@loading or @confirmed or @trailing != []}
             class="pointer-events-none absolute inset-y-0 right-3 z-10 flex items-center"
           >
             <span
@@ -387,11 +387,6 @@ defmodule EdenflowersWeb.CoreComponents do
             <span :if={not @loading and @confirmed} data-testid="input-confirmed">
               <.icon name="hero-check-circle-mini" class="text-success size-5" />
             </span>
-            <.icon
-              :if={not @loading and not @confirmed and @errors != []}
-              name="hero-exclamation-circle-mini"
-              class="text-error size-5"
-            />
             {render_slot(@trailing)}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Removes the trailing `hero-exclamation-circle-mini` icon from the `<.input>` component on error.
- The error state is already signalled by the red `input-error` border and the inline error message below the field, so the icon was visual noise.
- Simplifies the trailing-adornment wrapper condition: it now renders only when there's loading state, a confirmation, or a `:trailing` slot.

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` passes (221 tests, 0 failures)
- [x] Manually verify in a browser that an input with errors still shows the red border and error message, and the previously rendered icon is gone