### PR TITLE
Preserve unsaved checkout input when applying a promo code

### DIFF
--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -594,8 +594,8 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   def handle_event("update_promotional", %{"form" => params}, socket) do
     case AshPhoenix.Form.submit(socket.assigns.promo_code_form, params: params) do
-      {:ok, _order} ->
-        {:noreply, reload_order(socket)}
+      {:ok, order} ->
+        {:noreply, assign_promo(socket, order)}
 
       {:error, promo_code_form} ->
         {:noreply, assign(socket, promo_code_form: promo_code_form)}
@@ -603,8 +603,8 @@ defmodule EdenflowersWeb.CheckoutLive do
   end
 
   def handle_event("clear_promo", _, socket) do
-    Order.clear_promotion!(socket.assigns.order, actor: actor(socket))
-    {:noreply, reload_order(socket)}
+    order = Order.clear_promotion!(socket.assigns.order, actor: actor(socket))
+    {:noreply, assign_promo(socket, order)}
   end
 
   # Stripe events
@@ -765,6 +765,14 @@ defmodule EdenflowersWeb.CheckoutLive do
     socket
     |> assign(order: order)
     |> assign(form: make_form(order, action_name(:save, order.step)))
+    |> assign(promo_code_form: make_form(order, :add_promotion_with_code))
+  end
+
+  # Refresh order + promo form only. The main step form is left alone so
+  # unsaved input the customer has typed into the current step survives.
+  defp assign_promo(socket, order) do
+    socket
+    |> assign(order: order)
     |> assign(promo_code_form: make_form(order, :add_promotion_with_code))
   end
 

--- a/test/edenflowers_web/live/checkout_happy_path_test.exs
+++ b/test/edenflowers_web/live/checkout_happy_path_test.exs
@@ -399,6 +399,35 @@ defmodule EdenflowersWeb.CheckoutHappyPathTest do
     end)
   end
 
+  test "applying a promo code preserves unsaved values typed into the current step", %{
+    conn: conn
+  } do
+    promotion = generate(promotion(code: "SAVE20", discount_percentage: "0.20"))
+
+    {:ok, view, _html} = live(conn, ~p"/checkout")
+
+    # Type into step 1 without submitting — phx-change ships the values
+    # to the server so they live on the form's params.
+    view
+    |> form("#checkout-form-1", %{
+      "form" => %{
+        "customer_name" => "Jane Doe",
+        "customer_email" => "jane@example.com"
+      }
+    })
+    |> render_change()
+
+    # Apply the promo from the cart sidebar.
+    html =
+      view
+      |> form("#checkout-form-promotional", %{"form" => %{"code" => promotion.code}})
+      |> render_submit()
+
+    assert html =~ ~s(data-testid="promo-code-badge")
+    assert html =~ "Jane Doe"
+    assert html =~ "jane@example.com"
+  end
+
   test "Stripe failure on step 4 keeps the order in checkout and sends no email", %{
     conn: conn,
     order: order,


### PR DESCRIPTION
## Summary
- `update_promotional` and `clear_promo` called `reload_order/1`, which rebuilt the main step form from persisted state and discarded any in-flight values the customer had typed into the current step.
- The Ash actions `add_promotion_with_code` and `clear_promotion` already return the order with `@checkout_load` calculations preloaded, so use that record directly.
- New `assign_promo/2` helper refreshes only `@order` and `@promo_code_form`; the main `@form` is left untouched so unsaved input survives.

Closes #131

## Test plan
- [x] New regression test in `checkout_happy_path_test.exs`: types into step 1 via `render_change`, applies a promo, asserts both the promo badge appears and the typed name/email survive in the rendered HTML. Test failed before the fix (form was reset) and passes after.
- [x] Existing "applies a promo code and the finalized order reflects the discount" happy-path test still passes — full step 1→4 promo flow unaffected.
- [x] Full suite green: 222/0.