### PR TITLE
Drop FOUCE guard for Shoelace custom elements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -58,16 +58,10 @@
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
-/* https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/ */
 body {
-  opacity: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-}
-body.ready {
-  transition: 0.25s opacity;
-  opacity: 1;
 }
 
 /*

--- a/lib/edenflowers_web/components/layouts/root.html.heex
+++ b/lib/edenflowers_web/components/layouts/root.html.heex
@@ -55,22 +55,5 @@
         window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
       })();
     </script>
-
-    <script type="module">
-      // https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/
-      async function ensureCustomElementDefined(elementName) {
-        const elementExists = document.querySelector(elementName);
-        if (elementExists) {
-          await customElements.whenDefined(elementName);
-        }
-      }
-
-      await Promise.allSettled([
-        ensureCustomElementDefined("sl-alert"),
-        ensureCustomElementDefined("sl-icon"),
-      ]);
-
-      document.body.classList.add('ready');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Removes the inline module script in `root.html.heex` that hid the body until `sl-alert` and `sl-icon` were registered, plus the matching `body { opacity: 0 }` / `body.ready` CSS in `assets/css/app.css`.
- The guard prevented a brief flash of undefined custom elements while the Shoelace CDN autoloader registered them. The flicker is acceptable in exchange for one fewer inline script and simpler body styling.
- Font-smoothing rules on `body` are preserved.

## Test plan

- [x] `mix format --check-formatted` (enforced by pre-push hook)
- [x] `mix test` — 221 tests, 0 failures
- [ ] Manual: load a page that renders a flash (`sl-alert`); the alert appears without a long invisible-page period. A brief flash of unstyled icon/alert is the expected new behaviour.
