### PR TITLE
Increment quantity on duplicate add-to-cart

### DIFF
--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -27,7 +27,12 @@ defmodule Edenflowers.Store.LineItem do
     create :add_to_cart do
       accept [:order_id, :product_variant_id, :quantity, :is_card]
 
+      upsert? true
+      upsert_identity :unique_product_variant
+      upsert_fields [:quantity]
+
       change Edenflowers.Store.LineItem.Changes.PopulateFromVariant
+      change atomic_update(:quantity, expr(quantity + ^atomic_ref(:quantity)))
     end
 
     destroy :remove_item do

--- a/test/line_item_test.exs
+++ b/test/line_item_test.exs
@@ -126,4 +126,115 @@ defmodule Edenflowers.Store.LineItemTest do
       assert line_item.promotion_applied? == false
     end
   end
+
+  describe "duplicate-variant upsert" do
+    test "adding the same variant twice produces one row with quantity 2", %{
+      order: order,
+      product_variant: product_variant
+    } do
+      first =
+        LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: product_variant.id
+        })
+        |> Ash.create!(authorize?: false)
+
+      second =
+        LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: product_variant.id
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert first.id == second.id
+      assert second.quantity == 2
+
+      line_items = Ash.read!(LineItem, authorize?: false)
+      assert length(line_items) == 1
+    end
+
+    test "adding with explicit quantities sums the existing and incoming values", %{
+      order: order,
+      product_variant: product_variant
+    } do
+      LineItem
+      |> Ash.Changeset.for_create(:add_to_cart, %{
+        order_id: order.id,
+        product_variant_id: product_variant.id,
+        quantity: 3
+      })
+      |> Ash.create!(authorize?: false)
+
+      line_item =
+        LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: product_variant.id,
+          quantity: 1
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert line_item.quantity == 4
+    end
+
+    test "adding different variants produces separate rows", %{
+      order: order,
+      product: product,
+      product_variant: first_variant
+    } do
+      second_variant = generate(product_variant(product_id: product.id))
+
+      LineItem
+      |> Ash.Changeset.for_create(:add_to_cart, %{
+        order_id: order.id,
+        product_variant_id: first_variant.id
+      })
+      |> Ash.create!(authorize?: false)
+
+      LineItem
+      |> Ash.Changeset.for_create(:add_to_cart, %{
+        order_id: order.id,
+        product_variant_id: second_variant.id
+      })
+      |> Ash.create!(authorize?: false)
+
+      line_items = Ash.read!(LineItem, authorize?: false)
+      assert length(line_items) == 2
+      assert Enum.all?(line_items, &(&1.quantity == 1))
+    end
+
+    test "duplicate add preserves the original price snapshot", %{
+      order: order,
+      product_variant: product_variant
+    } do
+      original_price = product_variant.price
+
+      first =
+        LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: product_variant.id
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert Decimal.equal?(first.unit_price, original_price)
+
+      product_variant
+      |> Ash.Changeset.for_update(:update, %{price: Decimal.add(original_price, 99)})
+      |> Ash.update!(authorize?: false)
+
+      second =
+        LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: product_variant.id
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert Decimal.equal?(second.unit_price, original_price)
+      assert second.quantity == 2
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Closes #88.
- `LineItem.add_to_cart` now uses `upsert?: true` keyed on the existing `unique_product_variant` identity. Adding the same variant twice produces one row at qty=2 instead of a unique-constraint violation.
- `upsert_fields [:quantity]` keeps the price/tax/name/image snapshot from the first add frozen on subsequent adds — a customer's cart shouldn't silently re-price if the store updates the variant between adds.
- Increment runs as `atomic_update(:quantity, expr(quantity + ^atomic_ref(:quantity)))` so the whole add compiles to one `INSERT ... ON CONFLICT DO UPDATE` statement; concurrent clicks can't race to produce duplicate rows or lose an increment.

## Strategy: upsert (vs. friendly changeset error)

The issue gave us a choice. **Upsert wins** here because:

1. **Better UX.** A user who clicks "Add to Cart" twice expects qty=2, not a "this is already in your cart" message they then have to act on by hunting for the `+` button in the sidebar. Every major cart (Amazon, Etsy, Shopify defaults) increments.
2. **Race-safe by construction.** `INSERT ... ON CONFLICT DO UPDATE` is a single SQL statement. The friendly-error alternative requires either catching `Ecto.ConstraintError` (which hides a query roundtrip on every duplicate) or wrapping a read+create in a transaction with retries — more code and more failure modes.
3. **The card-swap path is unaffected.** `Order.add_card` goes through `SwapCardLineItem`, which destroys any existing card line item *before* calling `add_to_cart`. The upsert branch never fires for cards.

## Test plan

- [x] New `duplicate-variant upsert` describe block in `test/line_item_test.exs` covers:
  - same-variant-twice → one row, qty=2
  - explicit qty=3 then qty=1 → qty=4 (verifies the increment expression sums existing + incoming, not just `+1`)
  - two different variants on one order → two rows, each at qty=1
  - **price-snapshot invariant**: variant price changes between adds, line item keeps the original `unit_price` (verifies `upsert_fields: [:quantity]` is doing its job and not letting `PopulateFromVariant`'s force-changes leak into the UPDATE branch)
- [x] `mix test test/line_item_test.exs` — 12/12
- [x] `mix test` full suite — 233/233 (pre-push hook also ran, clean)
- [ ] Manual: on a product page, click "Add to Cart" twice for the same variant — confirm the cart sidebar shows one row at qty=2 (not two rows or an error)
- [ ] Manual: add variant A, then variant B, then A again — confirm A is at qty=2 and B is at qty=1