### PR TITLE
Experiment: morph featured bloom card into product hero

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -348,6 +348,29 @@ body.ready {
   display: none;
 }
 
+/* View Transitions: Featured Bloom card → Product page hero.
+   The browser interpolates size, position, and border-radius between the
+   thumbnail (`.product-hero-source`) and the destination figure
+   (`.product-hero-target`) when both share `view-transition-name:
+   product-hero`. The thumbnail's name is set transiently by the JS hook
+   in app.js; the destination's is static. */
+::view-transition-old(product-hero),
+::view-transition-new(product-hero) {
+  /* Cover keeps both snapshots filling their box during the morph, so the
+     ratio change (4:5 mobile thumb → 1:1 hero) reads as a smooth zoom
+     rather than a letterboxed crossfade. */
+  object-fit: cover;
+  animation-duration: 360ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(product-hero),
+  ::view-transition-new(product-hero) {
+    animation: none;
+  }
+}
+
 .auth-background-pattern {
   background-color: #fafaf9;
   background-image: url("data:image/svg+xml,%3Csvg width='52' height='26' viewBox='0 0 52 26' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23294735' fill-opacity='0.04'%3E%3Cpath d='M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E");

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,10 +29,65 @@ import { hooks as colocatedHooks } from "phoenix-colocated/edenflowers";
 const csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
+
+// View Transitions API integration.
+//
+// Elements opt in via `data-vt-name="<name>"`. A capture-phase click listener
+// stamps `view-transition-name` on the element synchronously so the browser
+// has the name in place when LiveView's link handler initiates navigation.
+//
+// We can't use `phx-click` + `JS.dispatch` here because LV's link click
+// handler shadows `phx-click` on descendants of `<.link navigate>` — the
+// navigation fires but the dispatch silently doesn't.
+//
+// onDocumentPatch wraps LV's DOM patch in `document.startViewTransition()`
+// only when something has opted in; otherwise the patch runs normally with
+// zero overhead. Fallback path covers Firefox <=144 (no callbackOptions).
+let transitionTags = [];
+let scheduleTransition = false;
+
+document.addEventListener(
+  "click",
+  (e) => {
+    const el =
+      e.target instanceof Element
+        ? e.target.closest("[data-vt-name]")
+        : null;
+    if (!el) return;
+    const name = el.getAttribute("data-vt-name");
+    if (!name) return;
+    el.style.viewTransitionName = name;
+    transitionTags.push(el);
+    scheduleTransition = true;
+  },
+  { capture: true }
+);
+
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: { _csrf_token: csrfToken },
   hooks: { ...Hooks, ...colocatedHooks },
+  dom: {
+    onDocumentPatch(start) {
+      const update = () => {
+        transitionTags.forEach((el) => (el.style.viewTransitionName = ""));
+        transitionTags = [];
+        scheduleTransition = false;
+        start();
+      };
+
+      if (!scheduleTransition || !document.startViewTransition) {
+        update();
+        return;
+      }
+
+      try {
+        document.startViewTransition({ update });
+      } catch (_err) {
+        document.startViewTransition(update);
+      }
+    },
+  },
 });
 
 // Show progress bar on live navigation and form submits

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -84,7 +84,16 @@ defmodule EdenflowersWeb.HomeLive do
                     aria-labelledby={product.name}
                     class="group flex flex-col"
                   >
-                    <div class="mb-3 overflow-hidden rounded-lg">
+                    <%!-- The wrapping <div> is the morph source: a capture-
+                         phase click listener in app.js sees `data-vt-name`
+                         and stamps `view-transition-name: product-hero` on
+                         it before LV navigates. The product page's <figure>
+                         carries the same name as a static style, so the
+                         browser pairs them and morphs the size/position. --%>
+                    <div
+                      class="mb-3 overflow-hidden rounded-lg"
+                      data-vt-name="product-hero"
+                    >
                       <picture>
                         <%!-- Mobile: 4:5 portrait crop for an immersive feel.
                              Desktop (sm+): 1:1 square so cards sit cleanly in a row. --%>

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -46,8 +46,15 @@ defmodule EdenflowersWeb.ProductLive do
         </.breadcrumb>
 
         <div class="grid gap-12 md:grid-cols-2 md:items-start">
-          <%!-- Product Image --%>
-          <figure class="aspect-square bg-base-200 relative w-full overflow-hidden rounded shadow-md">
+          <%!-- Product Image. The `view-transition-name: product-hero`
+               pairs with the clicked card on the home carousel (which gets
+               the same name stamped on it via app.js) so the thumbnail
+               morphs into this figure on navigate. The name is page-local
+               (one product per page) so a fixed name is safe. --%>
+          <figure
+            class="aspect-square bg-base-200 relative w-full overflow-hidden rounded shadow-md"
+            style="view-transition-name: product-hero;"
+          >
             <img
               data-testid="product-image"
               src={@selected_variant.image_slug |> Imgproxy.new() |> Imgproxy.resize(800, 800, type: "fill") |> to_string()}


### PR DESCRIPTION
## Summary
- Initial experiment wiring the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) into LiveView so the clicked Featured Bloom card visually morphs into the product page hero image.
- Adds a `data-vt-name` opt-in attribute, a capture-phase click listener in `app.js` that stamps `view-transition-name` synchronously, and an `onDocumentPatch` hook on `LiveSocket` that wraps LV's DOM patch in `document.startViewTransition({ update })`.
- Matching CSS animates the morph (360ms cubic-bezier ease-out) and is silenced by `prefers-reduced-motion`.

## Why a capture-phase listener instead of `phx-click` + `JS.dispatch`?
The obvious approach — chaining `JS.dispatch("phx:start-view-transition", ...)` onto a `phx-click` on the card — silently doesn't fire. LiveView's link click handler intercepts clicks on `<.link navigate>` and starts the navigation before any `phx-click` JS commands on a descendant element run. The capture-phase listener guarantees we set the transition name *before* LV's nav handler sees the click.

## Notes
- Branched from `feat/featured-blooms-embla-carousel` so the diff only contains the experiment, not the carousel work it builds on. Will auto-retarget to `main` when the carousel PR merges.
- Cross-LiveView nav (`HomeLive` → `ProductLive`) goes through `onDocumentPatch` because the `LiveSocket` survives — this is *not* the cross-document `@view-transition` path. If we ever introduce hard `<.link href>` navigations between the carousel and the product page, the morph would silently stop working there.
- The destination uses a static `view-transition-name: product-hero` (one product per page, so no collision risk). The source uses `data-vt-name` because the carousel renders many cards.

## Test plan
- [ ] Click any Featured Bloom card on `/` → product page hero animates in from the card's position/size (Chromium + WebKit).
- [ ] Verify nothing animates with `prefers-reduced-motion: reduce` enabled.
- [ ] Verify the carousel itself still works (drag, prev/next, dots) — no regression from added DOM attributes.
- [ ] Confirm `mix test` is green (229 tests passed locally on push).