### PR TITLE
Close WCAG 2.2 AA gaps and remove dark mode

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -52,9 +52,6 @@
   --color-base-300: oklch(97% 0.001 106.424); /* stone-100 */
 }
 
-/* Use the data attribute for dark mode  */
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
-
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
@@ -74,6 +71,25 @@ summary {
 *:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
+}
+
+/* Skip link — visually hidden until keyboard focus, then anchored top-left
+   above all content. WCAG 2.4.1 Bypass Blocks. */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0.5rem;
+  z-index: 200;
+  padding: 0.75rem 1rem;
+  background: var(--color-base-100);
+  color: var(--color-base-content);
+  border: 2px solid var(--color-primary);
+  border-radius: 0.25rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+.skip-link:focus {
+  top: 0.5rem;
 }
 
 /* LiveView lifecycle feedback. The .phx-* classes are toggled by Phoenix:

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -113,11 +113,16 @@ Hooks.FeaturedCarousel = {
 
   buildDots() {
     if (!this.dotsNode) return;
+    // Localized template comes from a data attr on the viewport. Falls back
+    // to English if missing so the carousel still works.
+    // Sentinel "__N__" is replaced client-side. Using %{n} would trigger
+    // Gettext binding-validation warnings server-side at every render.
+    const tpl = this.el.dataset.dotLabelTemplate || "Go to slide __N__";
     const snapList = this.embla.scrollSnapList();
     this.dotsNode.innerHTML = snapList
       .map(
         (_, i) =>
-          `<button type="button" class="embla__dot" aria-label="Go to slide ${i + 1}"></button>`
+          `<button type="button" class="embla__dot" aria-label="${tpl.replace("__N__", i + 1)}" aria-current="false"></button>`
       )
       .join("");
     this.dotNodes = Array.from(this.dotsNode.querySelectorAll(".embla__dot"));
@@ -129,7 +134,9 @@ Hooks.FeaturedCarousel = {
   onSelect() {
     const selected = this.embla.selectedScrollSnap();
     this.dotNodes.forEach((node, i) => {
-      node.classList.toggle("embla__dot--selected", i === selected);
+      const isSelected = i === selected;
+      node.classList.toggle("embla__dot--selected", isSelected);
+      node.setAttribute("aria-current", isSelected ? "true" : "false");
     });
     const canScroll = this.embla.canScrollPrev() || this.embla.canScrollNext();
     this.el.closest("section")?.classList.toggle("embla--no-scroll", !canScroll);
@@ -667,7 +674,11 @@ Hooks.FlashHandler = {
     div.id = "flash-disconnected";
     div.className = "toast-item";
     div.dataset.key = "warning";
+    // role="alert" implies aria-live="assertive" but some AT/browser combos
+    // miss it on dynamically-added nodes — set both explicitly.
     div.setAttribute("role", "alert");
+    div.setAttribute("aria-live", "assertive");
+    div.setAttribute("aria-atomic", "true");
     div.innerHTML = `
       <div class="toast-item__head">
         <p class="toast-item__eyebrow">Notice</p>
@@ -680,7 +691,20 @@ Hooks.FlashHandler = {
   },
 
   reconnected() {
-    this.dismiss(document.getElementById("flash-disconnected"), null);
+    const banner = document.getElementById("flash-disconnected");
+    if (!banner) return;
+    this.dismiss(banner, null);
+
+    // Announce the resolution politely so SR users hear that connection is back.
+    const reconnectedMsg = this.el.getAttribute("data-reconnected-message");
+    if (!reconnectedMsg) return;
+    const note = document.createElement("div");
+    note.className = "sr-only";
+    note.setAttribute("role", "status");
+    note.setAttribute("aria-live", "polite");
+    note.textContent = reconnectedMsg;
+    this.el.appendChild(note);
+    setTimeout(() => note.remove(), 3000);
   },
 };
 

--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -57,8 +57,11 @@ defmodule EdenflowersWeb.CoreComponents do
     <div
       id="flash-group"
       class="z-[100] fixed top-6 right-6 flex flex-col items-end gap-3"
+      role="region"
+      aria-label={~t"Notifications"}
       phx-hook="FlashHandler"
       data-disconnected-message={~t"Disconnected from server. Reconnecting..."}
+      data-reconnected-message={~t"Reconnected"}
     >
       <div
         :for={{key, msg} <- @flash}
@@ -66,7 +69,7 @@ defmodule EdenflowersWeb.CoreComponents do
         class="toast-item"
         data-key={key}
         data-duration="5000"
-        role="alert"
+        role={flash_role(key)}
       >
         <div class="toast-item__head">
           <p class="toast-item__eyebrow">{flash_label(key)}</p>
@@ -79,6 +82,10 @@ defmodule EdenflowersWeb.CoreComponents do
     </div>
     """
   end
+
+  # Errors interrupt; everything else waits politely. WCAG 4.1.3.
+  defp flash_role("error"), do: "alert"
+  defp flash_role(_), do: "status"
 
   # Severity → eyebrow label. Restrained, conventional words — the message
   # itself does the heavy lifting; the eyebrow just orients the reader.
@@ -624,7 +631,12 @@ defmodule EdenflowersWeb.CoreComponents do
   def social_media_links(assigns) do
     ~H"""
     <div class="flex flex-row gap-4">
-      <a href="#" aria-label="Eden Flowers on Facebook">
+      <a
+        href="https://www.facebook.com/edenflowers.fi/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Eden Flowers on Facebook"
+      >
         <img
           class={"h-#{@size} w-#{@size}"}
           src={
@@ -636,7 +648,12 @@ defmodule EdenflowersWeb.CoreComponents do
           alt=""
         />
       </a>
-      <a href="#" aria-label="Eden Flowers on Instagram">
+      <a
+        href="https://www.instagram.com/edenflowers.fi/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Eden Flowers on Instagram"
+      >
         <img
           class={"h-#{@size} w-#{@size}"}
           src={
@@ -651,6 +668,87 @@ defmodule EdenflowersWeb.CoreComponents do
     </div>
     """
   end
+
+  @doc """
+  Icon-only button. `aria_label` is required so we can't ship a nameless
+  button — keyboard/SR users always get an accessible name.
+  """
+  attr :aria_label, :string, required: true
+  attr :class, :any, default: "h-12 w-12 cursor-pointer"
+  attr :rest, :global, include: ~w(type disabled name value form)
+  slot :inner_block, required: true
+
+  def icon_button(assigns) do
+    assigns = assign_new(assigns, :type, fn -> "button" end)
+
+    ~H"""
+    <button type={@type} class={@class} aria-label={@aria_label} {@rest}>
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  @doc """
+  Disclosure trigger — a button that controls a collapsible region (drawer,
+  menu, dialog). Sets `aria-expanded` and `aria-controls` so AT users know
+  the relationship. State must be tracked outside this component (LV
+  doesn't know if the drawer is open).
+  """
+  attr :aria_label, :string, required: true
+  attr :controls, :string, required: true, doc: "id of the controlled element"
+  attr :expanded, :boolean, default: false
+  attr :class, :any, default: "h-12 w-12 cursor-pointer"
+  attr :rest, :global, include: ~w(phx-click phx-target type)
+  slot :inner_block, required: true
+
+  def disclosure_trigger(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={@class}
+      aria-label={@aria_label}
+      aria-controls={@controls}
+      aria-expanded={to_string(@expanded)}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  @doc """
+  Cart count badge: a button that opens the cart drawer, with a screen-reader
+  accessible name that includes the current count, plus a polite live region
+  that announces updates. Replaces the previous unlabelled badge.
+  """
+  attr :count, :integer, default: 0
+  attr :rest, :global, include: ~w(phx-click)
+  slot :inner_block, required: true, doc: "Visible content (icon, badge, optional text)"
+
+  def cart_count_badge(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class="group relative flex h-10 w-10 cursor-pointer items-center justify-center gap-1 lg:h-auto lg:w-auto lg:gap-2"
+      aria-label={cart_aria_label(@count)}
+      aria-controls="cart-drawer"
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    <span class="sr-only" aria-live="polite" aria-atomic="true">
+      {cart_aria_label(@count)}
+    </span>
+    """
+  end
+
+  defp cart_aria_label(count) when is_integer(count) and count > 0,
+    do:
+      Gettext.dngettext(EdenflowersWeb.Gettext, "default", "Cart, %{count} item", "Cart, %{count} items", count, %{
+        count: count
+      })
+
+  defp cart_aria_label(_), do: ~t"Cart, empty"
 
   @placement %{
     "left" => %{

--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -11,6 +11,33 @@ defmodule EdenflowersWeb.Layouts do
   # and other static content.
   embed_templates "layouts/*"
 
+  @doc """
+  Renders the locale switcher as a single source of truth for header,
+  drawer, and footer. Uses `aria-current="true"` on the active locale so
+  AT users hear which language they're on.
+  """
+  attr :locales, :list, required: true, doc: "list of {code, name} tuples"
+  attr :current_locale_code, :string, required: true
+  attr :current_path, :string, required: true
+  attr :class, :any, default: nil
+  attr :item_class, :any, default: nil
+
+  def locale_list(assigns) do
+    ~H"""
+    <ul class={@class}>
+      <li :for={{code, name} <- @locales}>
+        <.link
+          href={~p"/locale/#{code}?redirect_to=#{@current_path}"}
+          class={[@item_class, code == @current_locale_code && "text-base-content font-semibold"]}
+          aria-current={code == @current_locale_code && "true"}
+        >
+          {name}
+        </.link>
+      </li>
+    </ul>
+    """
+  end
+
   attr :id, :string, required: true
   attr :current_path, :string, required: true
   attr :placement, :string, default: "top", values: ~w(top bottom)
@@ -61,7 +88,7 @@ defmodule EdenflowersWeb.Layouts do
         </.link>
       </header>
 
-      <main class="flex flex-grow items-center justify-center">
+      <main id="main-content" tabindex="-1" class="flex flex-grow items-center justify-center outline-hidden">
         <.flash_group flash={@flash} />
         {render_slot(@inner_block)}
       </main>
@@ -128,9 +155,9 @@ defmodule EdenflowersWeb.Layouts do
           Eden Flowers
         </.link>
 
-        <button type="button" phx-click={JS.exec("phx-hide", to: "#nav-drawer")} class="h-12 w-12 cursor-pointer">
+        <.icon_button aria_label={~t"Close navigation menu"} phx-click={JS.exec("phx-hide", to: "#nav-drawer")}>
           <.icon name="hero-x-mark" class="h-6 w-6 hover:text-base-content/60" />
-        </button>
+        </.icon_button>
       </header>
 
       <div class="flex flex-1 flex-col justify-between p-8">
@@ -160,16 +187,13 @@ defmodule EdenflowersWeb.Layouts do
       </div>
 
       <footer class="bg-base-300 flex flex-col gap-6 px-8 py-8">
-        <ul class="flex flex-wrap gap-x-5 gap-y-2">
-          <li :for={{code, name} <- @locales}>
-            <.link
-              href={~p"/locale/#{code}?redirect_to=#{@current_path}"}
-              class={["text-base-content/80 text-sm tracking-wide hover:decoration-(--color-accent-alt) hover:underline hover:underline-offset-4", code == @current_locale_code && "text-base-content font-semibold"]}
-            >
-              {name}
-            </.link>
-          </li>
-        </ul>
+        <.locale_list
+          locales={@locales}
+          current_locale_code={@current_locale_code}
+          current_path={@current_path}
+          class="flex flex-wrap gap-x-5 gap-y-2"
+          item_class="text-base-content/80 text-sm tracking-wide hover:decoration-(--color-accent-alt) hover:underline hover:underline-offset-4"
+        />
         <.social_media_links size={6} />
       </footer>
     </.drawer>
@@ -189,9 +213,9 @@ defmodule EdenflowersWeb.Layouts do
           <% end %>
         </h1>
 
-        <button phx-click={JS.exec("phx-hide", to: "#cart-drawer")} type="button" class="h-12 w-12 cursor-pointer">
+        <.icon_button aria_label={~t"Close cart"} phx-click={JS.exec("phx-hide", to: "#cart-drawer")}>
           <.icon name="hero-x-mark" class="h-6 w-6 hover:text-base-content/60" />
-        </button>
+        </.icon_button>
       </header>
 
       <div class="flex flex-1 flex-col justify-between overflow-y-auto p-8">
@@ -224,14 +248,13 @@ defmodule EdenflowersWeb.Layouts do
             <div class="flex flex-1 justify-start">
               <%!-- Mobile hamburger menu --%>
               <div class="block xl:hidden">
-                <button
+                <.disclosure_trigger
+                  aria_label={~t"Open navigation menu"}
+                  controls="nav-drawer"
                   phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#nav-drawer")}
-                  type="button"
-                  class="h-12 w-12 cursor-pointer"
-                  aria-label={~t"Open navigation menu"}
                 >
                   <.icon name="hero-bars-3-bottom-left" class="text-base-content h-6 w-6 hover:text-base-content/60" />
-                </button>
+                </.disclosure_trigger>
               </div>
 
               <%!-- Desktop navigation --%>
@@ -288,36 +311,39 @@ defmodule EdenflowersWeb.Layouts do
               </div>
 
               <%!-- Cart button --%>
-              <button
+              <.cart_count_badge
+                count={@order.total_items_in_cart || 0}
                 phx-click={JS.push_focus() |> JS.exec("phx-show", to: "#cart-drawer")}
-                type="button"
-                class="group relative flex h-10 w-10 cursor-pointer items-center justify-center gap-1 lg:h-auto lg:w-auto lg:gap-2"
               >
-                <.icon class="text-base-content h-5 w-5 group-hover:text-base-content/60" name="hero-shopping-bag" />
-
+                <.icon
+                  class="text-base-content h-5 w-5 group-hover:text-base-content/60"
+                  name="hero-shopping-bag"
+                />
                 <%= if not is_nil(@order.total_items_in_cart) && @order.total_items_in_cart > 0 do %>
-                  <span class="absolute top-0 right-0 lg:hidden">
+                  <span class="absolute top-0 right-0 lg:hidden" aria-hidden="true">
                     <div class="bg-primary text-primary-content border-base-100 text-[10px] inline-flex h-5 w-5 items-center justify-center rounded-full border-2 font-semibold leading-none">
                       {@order.total_items_in_cart}
                     </div>
                   </span>
                 <% end %>
-
-                <span class="text-base-content hidden text-sm group-hover:text-base-content/60 lg:inline-flex">
+                <span
+                  class="text-base-content hidden text-sm group-hover:text-base-content/60 lg:inline-flex"
+                  aria-hidden="true"
+                >
                   <%= if not is_nil(@order.total_items_in_cart) do %>
                     {~t"Cart"} ({@order.total_items_in_cart})
                   <% else %>
                     {~t"Cart"}
                   <% end %>
                 </span>
-              </button>
+              </.cart_count_badge>
             </div>
           </div>
         </section>
       </header>
     </div>
 
-    <main class="flex-grow">
+    <main id="main-content" tabindex="-1" class="flex-grow outline-hidden">
       <.flash_group flash={@flash} />
 
       {render_slot(@inner_block)}
@@ -377,31 +403,6 @@ defmodule EdenflowersWeb.Layouts do
         </span>
       </div>
     </footer>
-    """
-  end
-
-  @doc """
-  Provides dark vs light theme toggle based on themes defined in app.css.
-
-  See <head> in root.html.heex which applies the theme before page load.
-  """
-  def theme_toggle(assigns) do
-    ~H"""
-    <div class="card border-base-300 bg-base-300 relative flex flex-row items-center rounded-full border-2">
-      <div class="border-1 border-base-200 bg-base-100 [[data-theme=light]_&]:left-1/3 [[data-theme=dark]_&]:left-2/3 transition-[left] absolute left-0 h-full w-1/3 rounded-full brightness-200" />
-
-      <button class="flex w-1/3 cursor-pointer p-2" phx-click={JS.dispatch("phx:set-theme")} data-phx-theme="system">
-        <.icon name="hero-computer-desktop-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-
-      <button class="flex w-1/3 cursor-pointer p-2" phx-click={JS.dispatch("phx:set-theme")} data-phx-theme="light">
-        <.icon name="hero-sun-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-
-      <button class="flex w-1/3 cursor-pointer p-2" phx-click={JS.dispatch("phx:set-theme")} data-phx-theme="dark">
-        <.icon name="hero-moon-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-    </div>
     """
   end
 end

--- a/lib/edenflowers_web/components/layouts/root.html.heex
+++ b/lib/edenflowers_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light" class="w-full">
+<html lang={to_string(Localize.get_locale().cldr_locale_id)} class="w-full">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -30,27 +30,8 @@
     </script>
   </head>
   <body class="bg-base-200 flex min-h-screen flex-col antialiased">
+    <a href="#main-content" class="skip-link">{~t"Skip to main content"}</a>
     {@inner_content}
-
-    <script>
-      (() => {
-        const setTheme = (theme) => {
-          if (theme === "system") {
-            localStorage.removeItem("phx:theme");
-            document.documentElement.removeAttribute("data-theme");
-          } else {
-            localStorage.setItem("phx:theme", theme);
-            document.documentElement.setAttribute("data-theme", theme);
-          }
-        };
-        if (!document.documentElement.hasAttribute("data-theme")) {
-          setTheme(localStorage.getItem("phx:theme") || "system");
-        }
-        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
-
-        window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
-      })();
-    </script>
 
     <script>
       document.body.classList.add('ready');

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -54,36 +54,44 @@ defmodule EdenflowersWeb.HomeLive do
               <button
                 type="button"
                 class="embla__prev btn btn-circle btn-ghost"
-                aria-label={~t"Previous"}
+                aria-label={~t"Previous slide"}
+                aria-controls="featured-blooms-viewport"
               >
                 <.icon name="hero-chevron-left" class="h-5 w-5" />
               </button>
               <button
                 type="button"
                 class="embla__next btn btn-circle btn-ghost"
-                aria-label={~t"Next"}
+                aria-label={~t"Next slide"}
+                aria-controls="featured-blooms-viewport"
               >
                 <.icon name="hero-chevron-right" class="h-5 w-5" />
               </button>
             </div>
           </div>
 
-          <div class="embla">
+          <div
+            class="embla"
+            role="group"
+            aria-roledescription="carousel"
+            aria-label={~t"Featured Blooms"}
+          >
             <div
               id="featured-blooms-viewport"
               phx-hook="FeaturedCarousel"
               phx-update="ignore"
               class="embla__viewport"
-              role="region"
-              aria-label={~t"Featured Blooms"}
+              data-dot-label-template={~t"Go to slide __N__"}
             >
               <ul class="embla__container">
-                <li :for={product <- @products} class="embla__slide">
-                  <.link
-                    navigate={~p"/product/#{product}"}
-                    aria-labelledby={product.name}
-                    class="group flex flex-col"
-                  >
+                <li
+                  :for={{product, idx} <- Enum.with_index(@products)}
+                  class="embla__slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label={"#{idx + 1} / #{length(@products)}: #{product.name}"}
+                >
+                  <.link navigate={~p"/product/#{product}"} class="group flex flex-col">
                     <div class="mb-3 overflow-hidden rounded-lg">
                       <picture>
                         <%!-- Mobile: 4:5 portrait crop for an immersive feel.
@@ -98,16 +106,13 @@ defmodule EdenflowersWeb.HomeLive do
                           src={
                             product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 750, type: "fill") |> to_string()
                           }
-                          alt={product.name}
+                          alt=""
                           class="aspect-[4/5] w-full object-cover transition duration-500 ease-out group-hover:scale-[1.03] sm:aspect-square"
                         />
                       </picture>
                     </div>
                     <div class="text-base-content flex flex-col items-center gap-1">
-                      <h3
-                        id={product.name}
-                        class="card-title link-underline-group-hover-display"
-                      >
+                      <h3 class="card-title link-underline-group-hover-display">
                         {product.name}
                       </h3>
                       <p class="text-base-content/70 text-sm">

--- a/lib/edenflowers_web/live/store_live.ex
+++ b/lib/edenflowers_web/live/store_live.ex
@@ -63,15 +63,16 @@ defmodule EdenflowersWeb.StoreLive do
           </p>
         </div>
 
-        <div class="mb-10 flex flex-wrap gap-3">
+        <nav aria-label={~t"Categories"} class="mb-10 flex flex-wrap gap-3">
           <.button
             :for={category <- @categories}
             navigate={~p"/store/#{category.slug}"}
             variant={if(@selected_category.id == category.id, do: "primary", else: nil)}
+            aria-current={@selected_category.id == category.id && "page"}
           >
             {category.name}
           </.button>
-        </div>
+        </nav>
 
         <%= if Enum.empty?(@products) do %>
           <div class="bg-pastel-3 flex flex-col items-center gap-5 rounded-lg px-8 py-20 text-center sm:py-24">
@@ -93,12 +94,11 @@ defmodule EdenflowersWeb.StoreLive do
               <.link
                 class="flex h-full flex-col focus:outline-none"
                 navigate={~p"/product/#{product}"}
-                aria-labelledby={"product-#{product.id}"}
               >
                 <figure class="aspect-square relative overflow-hidden">
                   <img
                     src={product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 600, type: "fill") |> to_string()}
-                    alt={product.name}
+                    alt=""
                     class="h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.03]"
                     width="1"
                     height="1"
@@ -107,10 +107,7 @@ defmodule EdenflowersWeb.StoreLive do
                 </figure>
 
                 <div class="flex flex-1 flex-col gap-2 px-5 py-5 sm:px-6 sm:py-6">
-                  <h3
-                    id={"product-#{product.id}"}
-                    class="card-title text-base-content link-underline-group-hover-display"
-                  >
+                  <h3 class="card-title text-base-content link-underline-group-hover-display">
                     {product.name}
                   </h3>
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,69 +11,67 @@
 msgid ""
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:513
+#: lib/edenflowers_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:65
+#: lib/edenflowers_web/components/layouts.ex:138
 #: lib/edenflowers_web/live/about_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:162
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:353
+#: lib/edenflowers_web/live/checkout_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:111
-#: lib/edenflowers_web/components/layouts.ex:113
-#: lib/edenflowers_web/components/layouts.ex:231
-#: lib/edenflowers_web/components/layouts.ex:233
-#: lib/edenflowers_web/live/checkout_live.ex:335
+#: lib/edenflowers_web/components/layouts.ex:213
+#: lib/edenflowers_web/components/layouts.ex:215
+#: lib/edenflowers_web/components/layouts.ex:337
+#: lib/edenflowers_web/components/layouts.ex:339
+#: lib/edenflowers_web/live/checkout_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:64
+#: lib/edenflowers_web/components/layouts.ex:137
 #: lib/edenflowers_web/live/condolences_live.ex:14
-#: lib/edenflowers_web/live/home_live.ex:134
-#: lib/edenflowers_web/live/home_live.ex:138
+#: lib/edenflowers_web/live/home_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:66
+#: lib/edenflowers_web/components/layouts.ex:139
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:62
-#: lib/edenflowers_web/live/home_live.ex:122
-#: lib/edenflowers_web/live/home_live.ex:126
+#: lib/edenflowers_web/components/layouts.ex:135
+#: lib/edenflowers_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:363
+#: lib/edenflowers_web/live/checkout_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr ""
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:29
-#: lib/edenflowers_web/live/checkout_live.ex:376
+#: lib/edenflowers_web/live/checkout_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:368
+#: lib/edenflowers_web/live/checkout_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
@@ -93,82 +91,81 @@ msgstr ""
 msgid "Show current month"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:61
-#: lib/edenflowers_web/live/home_live.ex:98
-#: lib/edenflowers_web/live/home_live.ex:102
+#: lib/edenflowers_web/components/layouts.ex:134
+#: lib/edenflowers_web/live/home_live.ex:154
 #: lib/edenflowers_web/live/product_live.ex:43
-#: lib/edenflowers_web/live/store_live.ex:50
+#: lib/edenflowers_web/live/store_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr ""
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:31
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:63
-#: lib/edenflowers_web/live/home_live.ex:110
-#: lib/edenflowers_web/live/home_live.ex:114
+#: lib/edenflowers_web/components/layouts.ex:136
+#: lib/edenflowers_web/live/home_live.ex:159
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Weddings"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:33
+#: lib/edenflowers_web/live/home_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fresh flowers for everyday moments"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:142
+#: lib/edenflowers_web/components/layouts.ex:244
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:37
+#: lib/edenflowers_web/live/home_live.ex:42
 #, elixir-autogen, elixir-format
 msgid "Shop Now"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:81
+#: lib/edenflowers_web/live/home_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Crafted for those with discerning taste, our flowers blend quality and style and arrive perfectly arranged at your door."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:128
-#: lib/edenflowers_web/live/checkout_live.ex:25
+#: lib/edenflowers_web/components/layouts.ex:230
+#: lib/edenflowers_web/live/checkout_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Checkout"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:306
-#: lib/edenflowers_web/live/checkout_live.ex:639
+#: lib/edenflowers_web/live/checkout_live.ex:314
+#: lib/edenflowers_web/live/checkout_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:718
+#: lib/edenflowers_web/live/checkout_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:198
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:299
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:122
+#: lib/edenflowers_web/live/product_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Add to Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:299
+#: lib/edenflowers_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:164
+#: lib/edenflowers_web/live/product_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Can I include a personal message with my order?"
 msgstr ""
@@ -183,28 +180,28 @@ msgstr ""
 msgid "Decrement"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:259
+#: lib/edenflowers_web/live/checkout_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Delivery Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:212
-#: lib/edenflowers_web/live/checkout_live.ex:638
+#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Delivery Information"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Delivery Method *"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:59
+#: lib/edenflowers_web/components/core_components.ex:63
 #, elixir-autogen, elixir-format
 msgid "Disconnected from server. Reconnecting..."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:173
+#: lib/edenflowers_web/live/product_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Do you offer subscription services?"
 msgstr ""
@@ -215,27 +212,28 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:78
+#: lib/edenflowers_web/live/checkout_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr ""
 
-#: lib/edenflowers_web/magic_link_request_live.ex:95
+#: lib/edenflowers_web/magic_link_request_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Error sending magic link. Please try again later."
 msgstr ""
 
-#: lib/edenflowers_web/magic_link_complete_live.ex:89
+#: lib/edenflowers_web/magic_link_complete_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Error signing in. Please try again later."
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:45
+#: lib/edenflowers_web/live/home_live.ex:51
+#: lib/edenflowers_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Featured Blooms"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:141
+#: lib/edenflowers_web/live/product_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr ""
@@ -245,14 +243,14 @@ msgstr ""
 msgid "Get Magic Link"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:94
-#: lib/edenflowers_web/live/checkout_live.ex:637
+#: lib/edenflowers_web/live/checkout_live.ex:102
+#: lib/edenflowers_web/live/checkout_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Gift Options"
 msgstr ""
 
 #: lib/edenflowers_web/live/product_live.ex:42
-#: lib/edenflowers_web/live/store_live.ex:49
+#: lib/edenflowers_web/live/store_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -267,12 +265,12 @@ msgstr ""
 msgid "Increment"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:84
+#: lib/edenflowers_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:156
+#: lib/edenflowers_web/components/layouts.ex:255
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr ""
@@ -282,7 +280,7 @@ msgstr ""
 msgid "Order #1234"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:185
+#: lib/edenflowers_web/live/product_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Our delivery team will attempt to leave your flowers in a safe, shaded location. If no suitable location is available, they will leave a note with instructions for redelivery. You can also specify delivery instructions during checkout."
 msgstr ""
@@ -292,17 +290,17 @@ msgstr ""
 msgid "Our flowers are carefully selected and arranged to last 5-7 days with proper care. We recommend changing the water every 2-3 days, trimming the stems, and keeping them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:163
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:323
+#: lib/edenflowers_web/live/checkout_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:261
+#: lib/edenflowers_web/live/checkout_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr ""
@@ -317,22 +315,22 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:350
+#: lib/edenflowers_web/live/checkout_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Promo Code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:107
+#: lib/edenflowers_web/live/checkout_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:118
+#: lib/edenflowers_web/live/checkout_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr ""
 
-#: lib/edenflowers_web/components/line_items_component.ex:61
+#: lib/edenflowers_web/components/line_items_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -342,7 +340,8 @@ msgstr ""
 msgid "Select Size"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:199
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:300
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr ""
@@ -357,8 +356,7 @@ msgstr ""
 msgid "Sign in to your account"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:154
-#: lib/edenflowers_web/components/address_input_component.ex:164
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr ""
@@ -368,43 +366,43 @@ msgstr ""
 msgid "There was an error subscribing to the newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:158
+#: lib/edenflowers_web/live/product_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "We offer same-day delivery for orders placed before 2 PM on weekdays. For weekend deliveries, please place your order by Friday 2 PM. All our deliveries are carefully handled to ensure your flowers arrive in perfect condition."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:182
+#: lib/edenflowers_web/live/product_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "What happens if I'm not home for delivery?"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:155
+#: lib/edenflowers_web/live/product_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "What is your delivery policy?"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:167
+#: lib/edenflowers_web/live/product_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Yes! You can add a personal message during checkout. We'll include it on a beautiful card with your delivery. Messages can be up to 200 characters."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:176
+#: lib/edenflowers_web/live/product_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer weekly, bi-weekly, and monthly subscription services. You can customize your subscription to match your preferences and schedule. Subscribers receive a 10% discount on all orders."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:61
-#: lib/edenflowers_web/live/checkout_live.ex:636
+#: lib/edenflowers_web/live/checkout_live.ex:69
+#: lib/edenflowers_web/live/checkout_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Your Details"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:72
+#: lib/edenflowers_web/live/checkout_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr ""
 
-#: lib/edenflowers_web/components/line_items_component.ex:70
+#: lib/edenflowers_web/components/line_items_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your cart is empty."
 msgstr ""
@@ -523,18 +521,18 @@ msgstr ""
 msgid "Thank you for your order!"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:251
+#: lib/edenflowers_web/live/checkout_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:203
+#: lib/edenflowers_web/live/checkout_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Add a card"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:65
-#: lib/edenflowers_web/live/checkout_live.ex:717
+#: lib/edenflowers_web/components/address_input_component.ex:54
+#: lib/edenflowers_web/live/checkout_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "Address *"
 msgstr ""
@@ -549,12 +547,12 @@ msgstr ""
 msgid "CARD MESSAGE"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:136
+#: lib/edenflowers_web/live/checkout_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:35
+#: lib/edenflowers_web/live/checkout_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Cart is empty"
 msgstr ""
@@ -564,17 +562,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:154
+#: lib/edenflowers_web/live/checkout_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:243
+#: lib/edenflowers_web/live/checkout_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Delivery Instructions"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:669
+#: lib/edenflowers_web/live/checkout_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -584,19 +582,14 @@ msgstr ""
 msgid "Email Address"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:354
+#: lib/edenflowers_web/live/checkout_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Enter promo code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:39
+#: lib/edenflowers_web/live/checkout_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error loading checkout"
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Fresh stems loading soon"
 msgstr ""
 
 #: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
@@ -609,7 +602,7 @@ msgstr ""
 msgid "Incorrect email or password"
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:35
+#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:29
 #, elixir-autogen, elixir-format
 msgid "Invalid code"
 msgstr ""
@@ -624,24 +617,24 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:783
+#: lib/edenflowers_web/live/checkout_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:782
+#: lib/edenflowers_web/live/checkout_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:84
-#: lib/edenflowers_web/live/checkout_live.ex:207
-#: lib/edenflowers_web/live/checkout_live.ex:300
+#: lib/edenflowers_web/live/checkout_live.ex:92
+#: lib/edenflowers_web/live/checkout_live.ex:215
+#: lib/edenflowers_web/live/checkout_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:486
+#: lib/edenflowers_web/live/checkout_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
@@ -656,18 +649,18 @@ msgstr ""
 msgid "Register and enjoy 15% off your next order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:172
-#: lib/edenflowers_web/live/checkout_live.ex:175
+#: lib/edenflowers_web/live/checkout_live.ex:180
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:418
+#: lib/edenflowers_web/live/checkout_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:781
+#: lib/edenflowers_web/live/checkout_live.ex:859
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -692,19 +685,9 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/calculate_pickup_cost.ex:37
-#, elixir-autogen, elixir-format
-msgid "Unable to calculate fulfillment cost"
-msgstr ""
-
 #: lib/edenflowers_web/components/newsletter_signup_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "We send out only ocassional emails. Unsubscribe at any time."
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "We're refreshing our collection. Check back shortly for newly arranged bouquets ready to ship."
 msgstr ""
 
 #: lib/edenflowers/email.ex:86
@@ -757,29 +740,27 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:246
+#: lib/edenflowers_web/live/checkout_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:710
+#: lib/edenflowers_web/live/checkout_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:711
+#: lib/edenflowers_web/live/checkout_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_geocoded_address.ex:11
-#: lib/edenflowers_web/components/address_input_component.ex:42
-#: lib/edenflowers_web/components/address_input_component.ex:101
+#: lib/edenflowers/fulfillments.ex:41
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:207
+#: lib/edenflowers_web/components/address_input_component.ex:187
 #, elixir-autogen, elixir-format
 msgid "Free delivery! 🥳"
 msgstr ""
@@ -794,22 +775,17 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:266
+#: lib/edenflowers_web/components/layouts.ex:371
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_payment_intent.ex:10
-#, elixir-autogen, elixir-format
-msgid "Payment intent is required"
-msgstr ""
-
-#: lib/edenflowers_web/components/layouts.ex:276
+#: lib/edenflowers_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:92
+#: lib/edenflowers_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Start Here"
 msgstr ""
@@ -827,4 +803,116 @@ msgstr ""
 #: lib/edenflowers/store/order/validations/validate_card_message_length.ex:24
 #, elixir-autogen, elixir-format
 msgid "Select a card before writing a message"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:85
+#, elixir-autogen, elixir-format
+msgid "Browse bouquets"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:920
+#, elixir-autogen, elixir-format
+msgid "Cart changed but payment couldn't be updated. Please retry."
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:748
+#, elixir-autogen, elixir-format
+msgid "Cart, empty"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Categories"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:219
+#, elixir-autogen, elixir-format
+msgid "Close cart"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:161
+#, elixir-autogen, elixir-format
+msgid "Close navigation menu"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:94
+#, elixir-autogen, elixir-format
+msgid "Confirmed"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "Couldn't complete"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:76
+#, elixir-autogen, elixir-format
+msgid "Dismiss"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "Fresh stems on the way"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Go to slide __N__"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Next slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Notice"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:61
+#, elixir-autogen, elixir-format
+msgid "Notifications"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please refresh the page and try again."
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:337
+#: lib/edenflowers_web/live/checkout_live.ex:494
+#: lib/edenflowers_web/live/checkout_live.ex:927
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please try again in a moment."
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Previous slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:64
+#, elixir-autogen, elixir-format
+msgid "Reconnected"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts/root.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Skip to main content"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:82
+#, elixir-autogen, elixir-format
+msgid "We're refreshing this collection right now. Check back shortly — or browse another category in the meantime."
+msgstr ""
+
+#: lib/edenflowers/store/line_item/changes/populate_from_variant.ex:34
+#, elixir-autogen, elixir-format
+msgid "is invalid"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,69 +11,67 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:513
+#: lib/edenflowers_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:65
+#: lib/edenflowers_web/components/layouts.ex:138
 #: lib/edenflowers_web/live/about_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:162
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:353
+#: lib/edenflowers_web/live/checkout_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:111
-#: lib/edenflowers_web/components/layouts.ex:113
-#: lib/edenflowers_web/components/layouts.ex:231
-#: lib/edenflowers_web/components/layouts.ex:233
-#: lib/edenflowers_web/live/checkout_live.ex:335
+#: lib/edenflowers_web/components/layouts.ex:213
+#: lib/edenflowers_web/components/layouts.ex:215
+#: lib/edenflowers_web/components/layouts.ex:337
+#: lib/edenflowers_web/components/layouts.ex:339
+#: lib/edenflowers_web/live/checkout_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:64
+#: lib/edenflowers_web/components/layouts.ex:137
 #: lib/edenflowers_web/live/condolences_live.ex:14
-#: lib/edenflowers_web/live/home_live.ex:134
-#: lib/edenflowers_web/live/home_live.ex:138
+#: lib/edenflowers_web/live/home_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:66
+#: lib/edenflowers_web/components/layouts.ex:139
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:62
-#: lib/edenflowers_web/live/home_live.ex:122
-#: lib/edenflowers_web/live/home_live.ex:126
+#: lib/edenflowers_web/components/layouts.ex:135
+#: lib/edenflowers_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:363
+#: lib/edenflowers_web/live/checkout_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr ""
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:29
-#: lib/edenflowers_web/live/checkout_live.ex:376
+#: lib/edenflowers_web/live/checkout_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:368
+#: lib/edenflowers_web/live/checkout_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
@@ -93,82 +91,81 @@ msgstr ""
 msgid "Show current month"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:61
-#: lib/edenflowers_web/live/home_live.ex:98
-#: lib/edenflowers_web/live/home_live.ex:102
+#: lib/edenflowers_web/components/layouts.ex:134
+#: lib/edenflowers_web/live/home_live.ex:154
 #: lib/edenflowers_web/live/product_live.ex:43
-#: lib/edenflowers_web/live/store_live.ex:50
+#: lib/edenflowers_web/live/store_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr ""
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:31
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:63
-#: lib/edenflowers_web/live/home_live.ex:110
-#: lib/edenflowers_web/live/home_live.ex:114
+#: lib/edenflowers_web/components/layouts.ex:136
+#: lib/edenflowers_web/live/home_live.ex:159
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Weddings"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:33
+#: lib/edenflowers_web/live/home_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fresh flowers for everyday moments"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:142
+#: lib/edenflowers_web/components/layouts.ex:244
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:37
+#: lib/edenflowers_web/live/home_live.ex:42
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Shop Now"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:81
+#: lib/edenflowers_web/live/home_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Crafted for those with discerning taste, our flowers blend quality and style and arrive perfectly arranged at your door."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:128
-#: lib/edenflowers_web/live/checkout_live.ex:25
+#: lib/edenflowers_web/components/layouts.ex:230
+#: lib/edenflowers_web/live/checkout_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Checkout"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:306
-#: lib/edenflowers_web/live/checkout_live.ex:639
+#: lib/edenflowers_web/live/checkout_live.ex:314
+#: lib/edenflowers_web/live/checkout_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:718
+#: lib/edenflowers_web/live/checkout_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:198
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:299
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:122
+#: lib/edenflowers_web/live/product_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Add to Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:299
+#: lib/edenflowers_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:164
+#: lib/edenflowers_web/live/product_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Can I include a personal message with my order?"
 msgstr ""
@@ -183,28 +180,28 @@ msgstr ""
 msgid "Decrement"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:259
+#: lib/edenflowers_web/live/checkout_live.ex:267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:212
-#: lib/edenflowers_web/live/checkout_live.ex:638
+#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Delivery Information"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:59
+#: lib/edenflowers_web/components/core_components.ex:63
 #, elixir-autogen, elixir-format
 msgid "Disconnected from server. Reconnecting..."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:173
+#: lib/edenflowers_web/live/product_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Do you offer subscription services?"
 msgstr ""
@@ -215,27 +212,28 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:78
+#: lib/edenflowers_web/live/checkout_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr ""
 
-#: lib/edenflowers_web/magic_link_request_live.ex:95
+#: lib/edenflowers_web/magic_link_request_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Error sending magic link. Please try again later."
 msgstr ""
 
-#: lib/edenflowers_web/magic_link_complete_live.ex:89
+#: lib/edenflowers_web/magic_link_complete_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Error signing in. Please try again later."
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:45
+#: lib/edenflowers_web/live/home_live.ex:51
+#: lib/edenflowers_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Featured Blooms"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:141
+#: lib/edenflowers_web/live/product_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr ""
@@ -245,14 +243,14 @@ msgstr ""
 msgid "Get Magic Link"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:94
-#: lib/edenflowers_web/live/checkout_live.ex:637
+#: lib/edenflowers_web/live/checkout_live.ex:102
+#: lib/edenflowers_web/live/checkout_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Gift Options"
 msgstr ""
 
 #: lib/edenflowers_web/live/product_live.ex:42
-#: lib/edenflowers_web/live/store_live.ex:49
+#: lib/edenflowers_web/live/store_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -267,12 +265,12 @@ msgstr ""
 msgid "Increment"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:84
+#: lib/edenflowers_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:156
+#: lib/edenflowers_web/components/layouts.ex:255
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr ""
@@ -282,7 +280,7 @@ msgstr ""
 msgid "Order #1234"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:185
+#: lib/edenflowers_web/live/product_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Our delivery team will attempt to leave your flowers in a safe, shaded location. If no suitable location is available, they will leave a note with instructions for redelivery. You can also specify delivery instructions during checkout."
 msgstr ""
@@ -292,17 +290,17 @@ msgstr ""
 msgid "Our flowers are carefully selected and arranged to last 5-7 days with proper care. We recommend changing the water every 2-3 days, trimming the stems, and keeping them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:163
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:323
+#: lib/edenflowers_web/live/checkout_live.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:261
+#: lib/edenflowers_web/live/checkout_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr ""
@@ -317,22 +315,22 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:350
+#: lib/edenflowers_web/live/checkout_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Promo Code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:107
+#: lib/edenflowers_web/live/checkout_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:118
+#: lib/edenflowers_web/live/checkout_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr ""
 
-#: lib/edenflowers_web/components/line_items_component.ex:61
+#: lib/edenflowers_web/components/line_items_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -342,7 +340,8 @@ msgstr ""
 msgid "Select Size"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:199
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:300
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr ""
@@ -357,8 +356,7 @@ msgstr ""
 msgid "Sign in to your account"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:154
-#: lib/edenflowers_web/components/address_input_component.ex:164
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr ""
@@ -368,43 +366,43 @@ msgstr ""
 msgid "There was an error subscribing to the newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:158
+#: lib/edenflowers_web/live/product_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "We offer same-day delivery for orders placed before 2 PM on weekdays. For weekend deliveries, please place your order by Friday 2 PM. All our deliveries are carefully handled to ensure your flowers arrive in perfect condition."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:182
+#: lib/edenflowers_web/live/product_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "What happens if I'm not home for delivery?"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:155
+#: lib/edenflowers_web/live/product_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "What is your delivery policy?"
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:167
+#: lib/edenflowers_web/live/product_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Yes! You can add a personal message during checkout. We'll include it on a beautiful card with your delivery. Messages can be up to 200 characters."
 msgstr ""
 
-#: lib/edenflowers_web/live/product_live.ex:176
+#: lib/edenflowers_web/live/product_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer weekly, bi-weekly, and monthly subscription services. You can customize your subscription to match your preferences and schedule. Subscribers receive a 10% discount on all orders."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:61
-#: lib/edenflowers_web/live/checkout_live.ex:636
+#: lib/edenflowers_web/live/checkout_live.ex:69
+#: lib/edenflowers_web/live/checkout_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Your Details"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:72
+#: lib/edenflowers_web/live/checkout_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr ""
 
-#: lib/edenflowers_web/components/line_items_component.ex:70
+#: lib/edenflowers_web/components/line_items_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your cart is empty."
 msgstr ""
@@ -523,18 +521,18 @@ msgstr ""
 msgid "Thank you for your order!"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:251
+#: lib/edenflowers_web/live/checkout_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:203
+#: lib/edenflowers_web/live/checkout_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Add a card"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:65
-#: lib/edenflowers_web/live/checkout_live.ex:717
+#: lib/edenflowers_web/components/address_input_component.ex:54
+#: lib/edenflowers_web/live/checkout_live.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr ""
@@ -549,12 +547,12 @@ msgstr ""
 msgid "CARD MESSAGE"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:136
+#: lib/edenflowers_web/live/checkout_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:35
+#: lib/edenflowers_web/live/checkout_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Cart is empty"
 msgstr ""
@@ -564,17 +562,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:154
+#: lib/edenflowers_web/live/checkout_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:243
+#: lib/edenflowers_web/live/checkout_live.ex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:669
+#: lib/edenflowers_web/live/checkout_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -584,19 +582,14 @@ msgstr ""
 msgid "Email Address"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:354
+#: lib/edenflowers_web/live/checkout_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Enter promo code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:39
+#: lib/edenflowers_web/live/checkout_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error loading checkout"
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Fresh stems loading soon"
 msgstr ""
 
 #: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
@@ -609,7 +602,7 @@ msgstr ""
 msgid "Incorrect email or password"
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:35
+#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:29
 #, elixir-autogen, elixir-format
 msgid "Invalid code"
 msgstr ""
@@ -624,24 +617,24 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:783
+#: lib/edenflowers_web/live/checkout_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:782
+#: lib/edenflowers_web/live/checkout_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:84
-#: lib/edenflowers_web/live/checkout_live.ex:207
-#: lib/edenflowers_web/live/checkout_live.ex:300
+#: lib/edenflowers_web/live/checkout_live.ex:92
+#: lib/edenflowers_web/live/checkout_live.ex:215
+#: lib/edenflowers_web/live/checkout_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:486
+#: lib/edenflowers_web/live/checkout_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
@@ -656,18 +649,18 @@ msgstr ""
 msgid "Register and enjoy 15% off your next order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:172
-#: lib/edenflowers_web/live/checkout_live.ex:175
+#: lib/edenflowers_web/live/checkout_live.ex:180
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:418
+#: lib/edenflowers_web/live/checkout_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:781
+#: lib/edenflowers_web/live/checkout_live.ex:859
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -692,19 +685,9 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/calculate_pickup_cost.ex:37
-#, elixir-autogen, elixir-format
-msgid "Unable to calculate fulfillment cost"
-msgstr ""
-
 #: lib/edenflowers_web/components/newsletter_signup_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "We send out only ocassional emails. Unsubscribe at any time."
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "We're refreshing our collection. Check back shortly for newly arranged bouquets ready to ship."
 msgstr ""
 
 #: lib/edenflowers/email.ex:86
@@ -757,29 +740,27 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:246
+#: lib/edenflowers_web/live/checkout_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:710
+#: lib/edenflowers_web/live/checkout_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:711
+#: lib/edenflowers_web/live/checkout_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_geocoded_address.ex:11
-#: lib/edenflowers_web/components/address_input_component.ex:42
-#: lib/edenflowers_web/components/address_input_component.ex:101
+#: lib/edenflowers/fulfillments.ex:41
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Delivery address required"
 
-#: lib/edenflowers_web/components/address_input_component.ex:207
+#: lib/edenflowers_web/components/address_input_component.ex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Free delivery! 🥳"
 msgstr ""
@@ -794,22 +775,17 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:266
+#: lib/edenflowers_web/components/layouts.ex:371
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_payment_intent.ex:10
-#, elixir-autogen, elixir-format
-msgid "Payment intent is required"
-msgstr ""
-
-#: lib/edenflowers_web/components/layouts.ex:276
+#: lib/edenflowers_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:92
+#: lib/edenflowers_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Start Here"
 msgstr ""
@@ -827,4 +803,116 @@ msgstr ""
 #: lib/edenflowers/store/order/validations/validate_card_message_length.ex:24
 #, elixir-autogen, elixir-format
 msgid "Select a card before writing a message"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:85
+#, elixir-autogen, elixir-format
+msgid "Browse bouquets"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:920
+#, elixir-autogen, elixir-format
+msgid "Cart changed but payment couldn't be updated. Please retry."
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:748
+#, elixir-autogen, elixir-format
+msgid "Cart, empty"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Categories"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:219
+#, elixir-autogen, elixir-format
+msgid "Close cart"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:161
+#, elixir-autogen, elixir-format
+msgid "Close navigation menu"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:94
+#, elixir-autogen, elixir-format
+msgid "Confirmed"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "Couldn't complete"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:76
+#, elixir-autogen, elixir-format
+msgid "Dismiss"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "Fresh stems on the way"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Go to slide __N__"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Next slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Notice"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:61
+#, elixir-autogen, elixir-format
+msgid "Notifications"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please refresh the page and try again."
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:337
+#: lib/edenflowers_web/live/checkout_live.ex:494
+#: lib/edenflowers_web/live/checkout_live.ex:927
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please try again in a moment."
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Previous slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:64
+#, elixir-autogen, elixir-format
+msgid "Reconnected"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts/root.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Skip to main content"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:82
+#, elixir-autogen, elixir-format
+msgid "We're refreshing this collection right now. Check back shortly — or browse another category in the meantime."
+msgstr ""
+
+#: lib/edenflowers/store/line_item/changes/populate_from_variant.ex:34
+#, elixir-autogen, elixir-format
+msgid "is invalid"
 msgstr ""

--- a/priv/gettext/fi/LC_MESSAGES/default.po
+++ b/priv/gettext/fi/LC_MESSAGES/default.po
@@ -11,69 +11,67 @@ msgstr ""
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:513
+#: lib/edenflowers_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Toiminnot"
 
-#: lib/edenflowers_web/components/layouts.ex:65
+#: lib/edenflowers_web/components/layouts.ex:138
 #: lib/edenflowers_web/live/about_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Tietoa meistä"
 
-#: lib/edenflowers_web/components/address_input_component.ex:162
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr "Osoitetta ei löytynyt"
 
-#: lib/edenflowers_web/live/checkout_live.ex:353
+#: lib/edenflowers_web/live/checkout_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr "Käytä"
 
-#: lib/edenflowers_web/components/layouts.ex:111
-#: lib/edenflowers_web/components/layouts.ex:113
-#: lib/edenflowers_web/components/layouts.ex:231
-#: lib/edenflowers_web/components/layouts.ex:233
-#: lib/edenflowers_web/live/checkout_live.ex:335
+#: lib/edenflowers_web/components/layouts.ex:213
+#: lib/edenflowers_web/components/layouts.ex:215
+#: lib/edenflowers_web/components/layouts.ex:337
+#: lib/edenflowers_web/components/layouts.ex:339
+#: lib/edenflowers_web/live/checkout_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr "Ostoskori"
 
-#: lib/edenflowers_web/components/layouts.ex:64
+#: lib/edenflowers_web/components/layouts.ex:137
 #: lib/edenflowers_web/live/condolences_live.ex:14
-#: lib/edenflowers_web/live/home_live.ex:134
-#: lib/edenflowers_web/live/home_live.ex:138
+#: lib/edenflowers_web/live/home_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr "Suruvalittelut"
 
-#: lib/edenflowers_web/components/layouts.ex:66
+#: lib/edenflowers_web/components/layouts.ex:139
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Yhteystiedot"
 
-#: lib/edenflowers_web/components/layouts.ex:62
-#: lib/edenflowers_web/live/home_live.ex:122
-#: lib/edenflowers_web/live/home_live.ex:126
+#: lib/edenflowers_web/components/layouts.ex:135
+#: lib/edenflowers_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr "Kurssit"
 
-#: lib/edenflowers_web/live/checkout_live.ex:363
+#: lib/edenflowers_web/live/checkout_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr "Toimitus"
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:29
-#: lib/edenflowers_web/live/checkout_live.ex:376
+#: lib/edenflowers_web/live/checkout_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr "Alennus"
 
-#: lib/edenflowers_web/live/checkout_live.ex:368
+#: lib/edenflowers_web/live/checkout_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Ilmainen"
@@ -93,82 +91,81 @@ msgstr "Edellinen kuukausi"
 msgid "Show current month"
 msgstr "Näytä nykyinen kuukausi"
 
-#: lib/edenflowers_web/components/layouts.ex:61
-#: lib/edenflowers_web/live/home_live.ex:98
-#: lib/edenflowers_web/live/home_live.ex:102
+#: lib/edenflowers_web/components/layouts.ex:134
+#: lib/edenflowers_web/live/home_live.ex:154
 #: lib/edenflowers_web/live/product_live.ex:43
-#: lib/edenflowers_web/live/store_live.ex:50
+#: lib/edenflowers_web/live/store_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr "Kauppa"
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:31
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr "Yhteensä"
 
-#: lib/edenflowers_web/components/layouts.ex:63
-#: lib/edenflowers_web/live/home_live.ex:110
-#: lib/edenflowers_web/live/home_live.ex:114
+#: lib/edenflowers_web/components/layouts.ex:136
+#: lib/edenflowers_web/live/home_live.ex:159
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Weddings"
 msgstr "Häät"
 
-#: lib/edenflowers_web/live/home_live.ex:33
+#: lib/edenflowers_web/live/home_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fresh flowers for everyday moments"
 msgstr "Tuoreita kukkia arkipäivän hetkiin"
 
-#: lib/edenflowers_web/components/layouts.ex:142
+#: lib/edenflowers_web/components/layouts.ex:244
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr "Kerro meille mitä mieltä olet uudesta verkkosivustosta! 🚀"
 
-#: lib/edenflowers_web/live/home_live.ex:37
+#: lib/edenflowers_web/live/home_live.ex:42
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Shop Now"
 msgstr "Osta nyt"
 
-#: lib/edenflowers_web/live/home_live.ex:81
+#: lib/edenflowers_web/live/home_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Crafted for those with discerning taste, our flowers blend quality and style and arrive perfectly arranged at your door."
 msgstr "Valmistettu hienostuneille maistajille, kukkamme yhdistävät laadun ja tyylin ja saapuvat täydellisesti järjestettyinä ovellesi."
 
-#: lib/edenflowers_web/components/layouts.ex:128
-#: lib/edenflowers_web/live/checkout_live.ex:25
+#: lib/edenflowers_web/components/layouts.ex:230
+#: lib/edenflowers_web/live/checkout_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Checkout"
 msgstr "Kassa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:306
-#: lib/edenflowers_web/live/checkout_live.ex:639
+#: lib/edenflowers_web/live/checkout_live.ex:314
+#: lib/edenflowers_web/live/checkout_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr "Maksu"
 
-#: lib/edenflowers_web/live/checkout_live.ex:718
+#: lib/edenflowers_web/live/checkout_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr "Puhelinnumero"
 
-#: lib/edenflowers_web/components/layouts.ex:198
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:299
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Tili"
 
-#: lib/edenflowers_web/live/product_live.ex:122
+#: lib/edenflowers_web/live/product_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Add to Cart"
 msgstr "Lisää ostoskoriin"
 
-#: lib/edenflowers_web/components/layouts.ex:299
+#: lib/edenflowers_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr "Rakennettu "
 
-#: lib/edenflowers_web/live/product_live.ex:164
+#: lib/edenflowers_web/live/product_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Can I include a personal message with my order?"
 msgstr "Voinko sisällyttää henkilökohtaisen viestin tilaukseeni?"
@@ -183,28 +180,28 @@ msgstr "Viimeistele kirjautuminen"
 msgid "Decrement"
 msgstr "Vähennä"
 
-#: lib/edenflowers_web/live/checkout_live.ex:259
+#: lib/edenflowers_web/live/checkout_live.ex:267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr "Toimituspäivä *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:212
-#: lib/edenflowers_web/live/checkout_live.ex:638
+#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Delivery Information"
 msgstr "Toimitus­tiedot"
 
-#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr "Toimitustapa *"
 
-#: lib/edenflowers_web/components/core_components.ex:59
+#: lib/edenflowers_web/components/core_components.ex:63
 #, elixir-autogen, elixir-format
 msgid "Disconnected from server. Reconnecting..."
 msgstr "Yhteys palvelimeen katkennut. Yhdistetään uudelleen..."
 
-#: lib/edenflowers_web/live/product_live.ex:173
+#: lib/edenflowers_web/live/product_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Do you offer subscription services?"
 msgstr "Tarjoatteko tilauspalveluita?"
@@ -215,27 +212,28 @@ msgstr "Tarjoatteko tilauspalveluita?"
 msgid "Email"
 msgstr "Sähköposti"
 
-#: lib/edenflowers_web/live/checkout_live.ex:78
+#: lib/edenflowers_web/live/checkout_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr "Sähköposti *"
 
-#: lib/edenflowers_web/magic_link_request_live.ex:95
+#: lib/edenflowers_web/magic_link_request_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Error sending magic link. Please try again later."
 msgstr "Virhe kirjautumislinkin lähetyksessä. Yritä myöhemmin uudelleen."
 
-#: lib/edenflowers_web/magic_link_complete_live.ex:89
+#: lib/edenflowers_web/magic_link_complete_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Error signing in. Please try again later."
 msgstr "Virhe kirjautuessa. Yritä myöhemmin uudelleen."
 
-#: lib/edenflowers_web/live/home_live.ex:45
+#: lib/edenflowers_web/live/home_live.ex:51
+#: lib/edenflowers_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Featured Blooms"
 msgstr "Esittelyssä"
 
-#: lib/edenflowers_web/live/product_live.ex:141
+#: lib/edenflowers_web/live/product_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr "Usein kysytyt kysymykset"
@@ -245,14 +243,14 @@ msgstr "Usein kysytyt kysymykset"
 msgid "Get Magic Link"
 msgstr "Hanki kirjautumislinkki"
 
-#: lib/edenflowers_web/live/checkout_live.ex:94
-#: lib/edenflowers_web/live/checkout_live.ex:637
+#: lib/edenflowers_web/live/checkout_live.ex:102
+#: lib/edenflowers_web/live/checkout_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Gift Options"
 msgstr "Lahjavalinnat"
 
 #: lib/edenflowers_web/live/product_live.ex:42
-#: lib/edenflowers_web/live/store_live.ex:49
+#: lib/edenflowers_web/live/store_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Etusivu"
@@ -267,12 +265,12 @@ msgstr "Kuinka kauan kukkani pysyvät tuoreina?"
 msgid "Increment"
 msgstr "Lisää"
 
-#: lib/edenflowers_web/live/home_live.ex:84
+#: lib/edenflowers_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr "Lue lisää"
 
-#: lib/edenflowers_web/components/layouts.ex:156
+#: lib/edenflowers_web/components/layouts.ex:255
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr "Avaa navigointivalikko"
@@ -282,7 +280,7 @@ msgstr "Avaa navigointivalikko"
 msgid "Order #1234"
 msgstr "Tilaus #1234"
 
-#: lib/edenflowers_web/live/product_live.ex:185
+#: lib/edenflowers_web/live/product_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Our delivery team will attempt to leave your flowers in a safe, shaded location. If no suitable location is available, they will leave a note with instructions for redelivery. You can also specify delivery instructions during checkout."
 msgstr "Toimitustiimimme yrittää jättää kukkasi turvalliseen varjoiseen paikkaan. Jos sopivaa paikkaa ei ole, he jättävät ohjeet uudelleen toimitusta varten. Voit myös määrittää toimitusohjeita kassalla."
@@ -292,17 +290,17 @@ msgstr "Toimitustiimimme yrittää jättää kukkasi turvalliseen varjoiseen pai
 msgid "Our flowers are carefully selected and arranged to last 5-7 days with proper care. We recommend changing the water every 2-3 days, trimming the stems, and keeping them away from direct sunlight and drafts."
 msgstr "Kukkamme on huolellisesti valittu ja järjestetty kestämään 5-7 päivää oikealla hoidolla. Suosittelemme veden vaihtamista 2-3 päivän välein, varsien leikkaamista ja pitämistä poissa suorasta auringonvalosta ja vedosta."
 
-#: lib/edenflowers_web/components/address_input_component.ex:163
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr "Toimitusalueen ulkopuolella"
 
-#: lib/edenflowers_web/live/checkout_live.ex:323
+#: lib/edenflowers_web/live/checkout_live.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr "Maksa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:261
+#: lib/edenflowers_web/live/checkout_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr "Noutopäivä *"
@@ -317,22 +315,22 @@ msgstr "Tarkista sähköpostisi viimeistelläksesi kirjautumisen."
 msgid "Featured"
 msgstr "Featured"
 
-#: lib/edenflowers_web/live/checkout_live.ex:350
+#: lib/edenflowers_web/live/checkout_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Promo Code"
 msgstr "Tarjouskoodi"
 
-#: lib/edenflowers_web/live/checkout_live.ex:107
+#: lib/edenflowers_web/live/checkout_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr "Vastaanottaja *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:118
+#: lib/edenflowers_web/live/checkout_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr "Vastaanottajan nimi *"
 
-#: lib/edenflowers_web/components/line_items_component.ex:61
+#: lib/edenflowers_web/components/line_items_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Poista"
@@ -342,7 +340,8 @@ msgstr "Poista"
 msgid "Select Size"
 msgstr "Valitse koko"
 
-#: lib/edenflowers_web/components/layouts.ex:199
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:300
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr "Kirjaudu sisään"
@@ -357,8 +356,7 @@ msgstr "Kirjaudu sisään"
 msgid "Sign in to your account"
 msgstr "Kirjaudu tilillesi"
 
-#: lib/edenflowers_web/components/address_input_component.ex:154
-#: lib/edenflowers_web/components/address_input_component.ex:164
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr "Toimituskulujen laskemisessa tapahtui virhe, yritä myöhemmin uudelleen"
@@ -368,43 +366,43 @@ msgstr "Toimituskulujen laskemisessa tapahtui virhe, yritä myöhemmin uudelleen
 msgid "There was an error subscribing to the newsletter."
 msgstr "Uutiskirjeen tilaamisessa tapahtui virhe."
 
-#: lib/edenflowers_web/live/product_live.ex:158
+#: lib/edenflowers_web/live/product_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "We offer same-day delivery for orders placed before 2 PM on weekdays. For weekend deliveries, please place your order by Friday 2 PM. All our deliveries are carefully handled to ensure your flowers arrive in perfect condition."
 msgstr "Tarjoamme saman päivän toimituksen tilauksille, jotka on tehty ennen klo 14 arkisin. Viikonlopputoimituksiin, tee tilauksesi perjantaihin klo 14 mennessä. Kaikki toimituksemme käsitellään huolellisesti varmistaaksemme, että kukkasi saapuvat täydellisessä kunnossa."
 
-#: lib/edenflowers_web/live/product_live.ex:182
+#: lib/edenflowers_web/live/product_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "What happens if I'm not home for delivery?"
 msgstr "Mitä tapahtuu, jos en ole kotona toimituksen aikana?"
 
-#: lib/edenflowers_web/live/product_live.ex:155
+#: lib/edenflowers_web/live/product_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "What is your delivery policy?"
 msgstr "Mikä on toimituspolitiikkanne?"
 
-#: lib/edenflowers_web/live/product_live.ex:167
+#: lib/edenflowers_web/live/product_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Yes! You can add a personal message during checkout. We'll include it on a beautiful card with your delivery. Messages can be up to 200 characters."
 msgstr "Kyllä! Voit lisätä henkilökohtaisen viestin kassalla. Sisällytämme sen kauniiseen korttiin toimituksen mukana. Viestit voivat olla enintään 200 merkkiä."
 
-#: lib/edenflowers_web/live/product_live.ex:176
+#: lib/edenflowers_web/live/product_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer weekly, bi-weekly, and monthly subscription services. You can customize your subscription to match your preferences and schedule. Subscribers receive a 10% discount on all orders."
 msgstr "Kyllä, tarjoamme viikottaisia, kahden viikon välein ja kuukausittaisia tilauspalveluita. Voit mukauttaa tilauksesi mieltymyksesi ja aikataulusi mukaan. Tilaajat saavat 10 % alennuksen kaikista tilauksista."
 
-#: lib/edenflowers_web/live/checkout_live.ex:61
-#: lib/edenflowers_web/live/checkout_live.ex:636
+#: lib/edenflowers_web/live/checkout_live.ex:69
+#: lib/edenflowers_web/live/checkout_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Your Details"
 msgstr "Tietosi"
 
-#: lib/edenflowers_web/live/checkout_live.ex:72
+#: lib/edenflowers_web/live/checkout_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr "Nimesi *"
 
-#: lib/edenflowers_web/components/line_items_component.ex:70
+#: lib/edenflowers_web/components/line_items_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your cart is empty."
 msgstr "Ostoskorisi on tyhjä."
@@ -523,18 +521,18 @@ msgstr "Vero"
 msgid "Thank you for your order!"
 msgstr "Kiitos tilauksestasi!"
 
-#: lib/edenflowers_web/live/checkout_live.ex:251
+#: lib/edenflowers_web/live/checkout_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:203
+#: lib/edenflowers_web/live/checkout_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Add a card"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:65
-#: lib/edenflowers_web/live/checkout_live.ex:717
+#: lib/edenflowers_web/components/address_input_component.ex:54
+#: lib/edenflowers_web/live/checkout_live.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr "Osoite"
@@ -549,12 +547,12 @@ msgstr ""
 msgid "CARD MESSAGE"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:136
+#: lib/edenflowers_web/live/checkout_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:35
+#: lib/edenflowers_web/live/checkout_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Cart is empty"
 msgstr ""
@@ -564,17 +562,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:154
+#: lib/edenflowers_web/live/checkout_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:243
+#: lib/edenflowers_web/live/checkout_live.ex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr "Toimitus­tiedot"
 
-#: lib/edenflowers_web/live/checkout_live.ex:669
+#: lib/edenflowers_web/live/checkout_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -584,19 +582,14 @@ msgstr ""
 msgid "Email Address"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:354
+#: lib/edenflowers_web/live/checkout_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Enter promo code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:39
+#: lib/edenflowers_web/live/checkout_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error loading checkout"
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Fresh stems loading soon"
 msgstr ""
 
 #: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
@@ -609,7 +602,7 @@ msgstr ""
 msgid "Incorrect email or password"
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:35
+#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:29
 #, elixir-autogen, elixir-format
 msgid "Invalid code"
 msgstr ""
@@ -624,24 +617,24 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:783
+#: lib/edenflowers_web/live/checkout_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:782
+#: lib/edenflowers_web/live/checkout_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:84
-#: lib/edenflowers_web/live/checkout_live.ex:207
-#: lib/edenflowers_web/live/checkout_live.ex:300
+#: lib/edenflowers_web/live/checkout_live.ex:92
+#: lib/edenflowers_web/live/checkout_live.ex:215
+#: lib/edenflowers_web/live/checkout_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:486
+#: lib/edenflowers_web/live/checkout_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
@@ -656,18 +649,18 @@ msgstr "Ilmoittaudu nyt"
 msgid "Register and enjoy 15% off your next order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:172
-#: lib/edenflowers_web/live/checkout_live.ex:175
+#: lib/edenflowers_web/live/checkout_live.ex:180
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr "Poista"
 
-#: lib/edenflowers_web/live/checkout_live.ex:418
+#: lib/edenflowers_web/live/checkout_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:781
+#: lib/edenflowers_web/live/checkout_live.ex:859
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -692,19 +685,9 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/calculate_pickup_cost.ex:37
-#, elixir-autogen, elixir-format
-msgid "Unable to calculate fulfillment cost"
-msgstr ""
-
 #: lib/edenflowers_web/components/newsletter_signup_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "We send out only ocassional emails. Unsubscribe at any time."
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "We're refreshing our collection. Check back shortly for newly arranged bouquets ready to ship."
 msgstr ""
 
 #: lib/edenflowers/email.ex:86
@@ -757,29 +740,27 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:246
+#: lib/edenflowers_web/live/checkout_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:710
+#: lib/edenflowers_web/live/checkout_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:711
+#: lib/edenflowers_web/live/checkout_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_geocoded_address.ex:11
-#: lib/edenflowers_web/components/address_input_component.ex:42
-#: lib/edenflowers_web/components/address_input_component.ex:101
+#: lib/edenflowers/fulfillments.ex:41
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Toimitusosoite vaaditaan"
 
-#: lib/edenflowers_web/components/address_input_component.ex:207
+#: lib/edenflowers_web/components/address_input_component.ex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Free delivery! 🥳"
 msgstr "Ilmainen toimitus!"
@@ -794,22 +775,17 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:266
+#: lib/edenflowers_web/components/layouts.ex:371
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_payment_intent.ex:10
-#, elixir-autogen, elixir-format
-msgid "Payment intent is required"
-msgstr ""
-
-#: lib/edenflowers_web/components/layouts.ex:276
+#: lib/edenflowers_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:92
+#: lib/edenflowers_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Start Here"
 msgstr ""
@@ -828,3 +804,115 @@ msgstr "Saa olla enintään %{max} merkkiä"
 #, elixir-autogen, elixir-format
 msgid "Select a card before writing a message"
 msgstr "Valitse kortti ennen viestin kirjoittamista"
+
+#: lib/edenflowers_web/live/store_live.ex:85
+#, elixir-autogen, elixir-format
+msgid "Browse bouquets"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:920
+#, elixir-autogen, elixir-format
+msgid "Cart changed but payment couldn't be updated. Please retry."
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:748
+#, elixir-autogen, elixir-format
+msgid "Cart, empty"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Categories"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:219
+#, elixir-autogen, elixir-format
+msgid "Close cart"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:161
+#, elixir-autogen, elixir-format
+msgid "Close navigation menu"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:94
+#, elixir-autogen, elixir-format
+msgid "Confirmed"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "Couldn't complete"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:76
+#, elixir-autogen, elixir-format
+msgid "Dismiss"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "Fresh stems on the way"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Go to slide __N__"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Next slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Notice"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:61
+#, elixir-autogen, elixir-format
+msgid "Notifications"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please refresh the page and try again."
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:337
+#: lib/edenflowers_web/live/checkout_live.ex:494
+#: lib/edenflowers_web/live/checkout_live.ex:927
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please try again in a moment."
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Previous slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:64
+#, elixir-autogen, elixir-format
+msgid "Reconnected"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts/root.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Skip to main content"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:82
+#, elixir-autogen, elixir-format
+msgid "We're refreshing this collection right now. Check back shortly — or browse another category in the meantime."
+msgstr ""
+
+#: lib/edenflowers/store/line_item/changes/populate_from_variant.ex:34
+#, elixir-autogen, elixir-format
+msgid "is invalid"
+msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -11,69 +11,67 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:513
+#: lib/edenflowers_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: lib/edenflowers_web/components/layouts.ex:65
+#: lib/edenflowers_web/components/layouts.ex:138
 #: lib/edenflowers_web/live/about_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Om oss"
 
-#: lib/edenflowers_web/components/address_input_component.ex:162
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr "Adressen hittades inte"
 
-#: lib/edenflowers_web/live/checkout_live.ex:353
+#: lib/edenflowers_web/live/checkout_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr "Tillämpa"
 
-#: lib/edenflowers_web/components/layouts.ex:111
-#: lib/edenflowers_web/components/layouts.ex:113
-#: lib/edenflowers_web/components/layouts.ex:231
-#: lib/edenflowers_web/components/layouts.ex:233
-#: lib/edenflowers_web/live/checkout_live.ex:335
+#: lib/edenflowers_web/components/layouts.ex:213
+#: lib/edenflowers_web/components/layouts.ex:215
+#: lib/edenflowers_web/components/layouts.ex:337
+#: lib/edenflowers_web/components/layouts.ex:339
+#: lib/edenflowers_web/live/checkout_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr "Varukorg"
 
-#: lib/edenflowers_web/components/layouts.ex:64
+#: lib/edenflowers_web/components/layouts.ex:137
 #: lib/edenflowers_web/live/condolences_live.ex:14
-#: lib/edenflowers_web/live/home_live.ex:134
-#: lib/edenflowers_web/live/home_live.ex:138
+#: lib/edenflowers_web/live/home_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr "Kondoleanser"
 
-#: lib/edenflowers_web/components/layouts.ex:66
+#: lib/edenflowers_web/components/layouts.ex:139
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
 
-#: lib/edenflowers_web/components/layouts.ex:62
-#: lib/edenflowers_web/live/home_live.ex:122
-#: lib/edenflowers_web/live/home_live.ex:126
+#: lib/edenflowers_web/components/layouts.ex:135
+#: lib/edenflowers_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr "Kurser"
 
-#: lib/edenflowers_web/live/checkout_live.ex:363
+#: lib/edenflowers_web/live/checkout_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr "Leverans"
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:29
-#: lib/edenflowers_web/live/checkout_live.ex:376
+#: lib/edenflowers_web/live/checkout_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr "Rabatt"
 
-#: lib/edenflowers_web/live/checkout_live.ex:368
+#: lib/edenflowers_web/live/checkout_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratis"
@@ -93,82 +91,81 @@ msgstr "Föregående månad"
 msgid "Show current month"
 msgstr "Visa aktuell månad"
 
-#: lib/edenflowers_web/components/layouts.ex:61
-#: lib/edenflowers_web/live/home_live.ex:98
-#: lib/edenflowers_web/live/home_live.ex:102
+#: lib/edenflowers_web/components/layouts.ex:134
+#: lib/edenflowers_web/live/home_live.ex:154
 #: lib/edenflowers_web/live/product_live.ex:43
-#: lib/edenflowers_web/live/store_live.ex:50
+#: lib/edenflowers_web/live/store_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr "Butik"
 
 #: lib/edenflowers/email/templates/order_confirmation.text.eex:31
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr "Totalt"
 
-#: lib/edenflowers_web/components/layouts.ex:63
-#: lib/edenflowers_web/live/home_live.ex:110
-#: lib/edenflowers_web/live/home_live.ex:114
+#: lib/edenflowers_web/components/layouts.ex:136
+#: lib/edenflowers_web/live/home_live.ex:159
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Weddings"
 msgstr "Bröllop"
 
-#: lib/edenflowers_web/live/home_live.ex:33
+#: lib/edenflowers_web/live/home_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fresh flowers for everyday moments"
 msgstr "Färska blommor för vardagliga stunder"
 
-#: lib/edenflowers_web/components/layouts.ex:142
+#: lib/edenflowers_web/components/layouts.ex:244
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr "Låt oss veta vad du tycker om den nya webbplatsen! 🚀"
 
-#: lib/edenflowers_web/live/home_live.ex:37
+#: lib/edenflowers_web/live/home_live.ex:42
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Shop Now"
 msgstr "Handla nu"
 
-#: lib/edenflowers_web/live/home_live.ex:81
+#: lib/edenflowers_web/live/home_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Crafted for those with discerning taste, our flowers blend quality and style and arrive perfectly arranged at your door."
 msgstr "Skapade för dem med kräsen smak, våra blommor kombinerar kvalitet och stil och levereras perfekt arrangerade till din dörr."
 
-#: lib/edenflowers_web/components/layouts.ex:128
-#: lib/edenflowers_web/live/checkout_live.ex:25
+#: lib/edenflowers_web/components/layouts.ex:230
+#: lib/edenflowers_web/live/checkout_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Checkout"
 msgstr "Kassa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:306
-#: lib/edenflowers_web/live/checkout_live.ex:639
+#: lib/edenflowers_web/live/checkout_live.ex:314
+#: lib/edenflowers_web/live/checkout_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr "Betalning"
 
-#: lib/edenflowers_web/live/checkout_live.ex:718
+#: lib/edenflowers_web/live/checkout_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: lib/edenflowers_web/components/layouts.ex:198
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:299
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/edenflowers_web/live/product_live.ex:122
+#: lib/edenflowers_web/live/product_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Add to Cart"
 msgstr "Lägg i varukorgen"
 
-#: lib/edenflowers_web/components/layouts.ex:299
+#: lib/edenflowers_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr "Byggd med "
 
-#: lib/edenflowers_web/live/product_live.ex:164
+#: lib/edenflowers_web/live/product_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Can I include a personal message with my order?"
 msgstr "Kan jag inkludera ett personligt meddelande med min beställning?"
@@ -183,28 +180,28 @@ msgstr "Slutför inloggning"
 msgid "Decrement"
 msgstr "Minska"
 
-#: lib/edenflowers_web/live/checkout_live.ex:259
+#: lib/edenflowers_web/live/checkout_live.ex:267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr "Leveransdatum *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:212
-#: lib/edenflowers_web/live/checkout_live.ex:638
+#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Delivery Information"
 msgstr "Leverans­information"
 
-#: lib/edenflowers_web/live/checkout_live.ex:220
+#: lib/edenflowers_web/live/checkout_live.ex:228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr "Leveransmetod *"
 
-#: lib/edenflowers_web/components/core_components.ex:59
+#: lib/edenflowers_web/components/core_components.ex:63
 #, elixir-autogen, elixir-format
 msgid "Disconnected from server. Reconnecting..."
 msgstr "Frånkopplad från servern. Återansluter..."
 
-#: lib/edenflowers_web/live/product_live.ex:173
+#: lib/edenflowers_web/live/product_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Do you offer subscription services?"
 msgstr "Erbjuder ni prenumerationstjänster?"
@@ -215,27 +212,28 @@ msgstr "Erbjuder ni prenumerationstjänster?"
 msgid "Email"
 msgstr "E-post"
 
-#: lib/edenflowers_web/live/checkout_live.ex:78
+#: lib/edenflowers_web/live/checkout_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr "E-post *"
 
-#: lib/edenflowers_web/magic_link_request_live.ex:95
+#: lib/edenflowers_web/magic_link_request_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Error sending magic link. Please try again later."
 msgstr "Fel vid skickande av inloggningslänk. Försök igen senare."
 
-#: lib/edenflowers_web/magic_link_complete_live.ex:89
+#: lib/edenflowers_web/magic_link_complete_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Error signing in. Please try again later."
 msgstr "Fel vid inloggning. Försök igen senare."
 
-#: lib/edenflowers_web/live/home_live.ex:45
+#: lib/edenflowers_web/live/home_live.ex:51
+#: lib/edenflowers_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Featured Blooms"
 msgstr "Utvalda blommor"
 
-#: lib/edenflowers_web/live/product_live.ex:141
+#: lib/edenflowers_web/live/product_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr "Vanliga frågor"
@@ -245,14 +243,14 @@ msgstr "Vanliga frågor"
 msgid "Get Magic Link"
 msgstr "Få inloggningslänk"
 
-#: lib/edenflowers_web/live/checkout_live.ex:94
-#: lib/edenflowers_web/live/checkout_live.ex:637
+#: lib/edenflowers_web/live/checkout_live.ex:102
+#: lib/edenflowers_web/live/checkout_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Gift Options"
 msgstr "Presentalternativ"
 
 #: lib/edenflowers_web/live/product_live.ex:42
-#: lib/edenflowers_web/live/store_live.ex:49
+#: lib/edenflowers_web/live/store_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Hem"
@@ -267,12 +265,12 @@ msgstr "Hur länge håller mina blommor sig fräscha?"
 msgid "Increment"
 msgstr "Öka"
 
-#: lib/edenflowers_web/live/home_live.ex:84
+#: lib/edenflowers_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr "Läs mer"
 
-#: lib/edenflowers_web/components/layouts.ex:156
+#: lib/edenflowers_web/components/layouts.ex:255
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr "Öppna navigeringsmeny"
@@ -282,7 +280,7 @@ msgstr "Öppna navigeringsmeny"
 msgid "Order #1234"
 msgstr "Beställning #1234"
 
-#: lib/edenflowers_web/live/product_live.ex:185
+#: lib/edenflowers_web/live/product_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Our delivery team will attempt to leave your flowers in a safe, shaded location. If no suitable location is available, they will leave a note with instructions for redelivery. You can also specify delivery instructions during checkout."
 msgstr "Vårt leveransteam kommer att försöka lämna dina blommor på en säker, skuggig plats. Om ingen lämplig plats finns tillgänglig lämnar de en lapp med instruktioner för återleverans. Du kan även ange leveransinstruktioner vid kassan."
@@ -292,17 +290,17 @@ msgstr "Vårt leveransteam kommer att försöka lämna dina blommor på en säke
 msgid "Our flowers are carefully selected and arranged to last 5-7 days with proper care. We recommend changing the water every 2-3 days, trimming the stems, and keeping them away from direct sunlight and drafts."
 msgstr "Våra blommor är noggrant utvalda och arrangerade för att hålla 5-7 dagar med rätt skötsel. Vi rekommenderar att byta vattnet var 2-3:e dag, trimma stjälkarna och hålla dem borta från direkt solljus och drag."
 
-#: lib/edenflowers_web/components/address_input_component.ex:163
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr "Utanför leveransområdet"
 
-#: lib/edenflowers_web/live/checkout_live.ex:323
+#: lib/edenflowers_web/live/checkout_live.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr "Betala"
 
-#: lib/edenflowers_web/live/checkout_live.ex:261
+#: lib/edenflowers_web/live/checkout_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr "Upphämtningsdatum *"
@@ -317,22 +315,22 @@ msgstr "Kontrollera din e-post för att slutföra inloggningen."
 msgid "Featured"
 msgstr "Featured"
 
-#: lib/edenflowers_web/live/checkout_live.ex:350
+#: lib/edenflowers_web/live/checkout_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Promo Code"
 msgstr "Kampanjkod"
 
-#: lib/edenflowers_web/live/checkout_live.ex:107
+#: lib/edenflowers_web/live/checkout_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr "Mottagare *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:118
+#: lib/edenflowers_web/live/checkout_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr "Mottagarens namn *"
 
-#: lib/edenflowers_web/components/line_items_component.ex:61
+#: lib/edenflowers_web/components/line_items_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Ta bort"
@@ -342,7 +340,8 @@ msgstr "Ta bort"
 msgid "Select Size"
 msgstr "Välj storlek"
 
-#: lib/edenflowers_web/components/layouts.ex:199
+#: lib/edenflowers_web/components/layouts.ex:185
+#: lib/edenflowers_web/components/layouts.ex:300
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr "Logga in"
@@ -357,8 +356,7 @@ msgstr "Logga in"
 msgid "Sign in to your account"
 msgstr "Logga in på ditt konto"
 
-#: lib/edenflowers_web/components/address_input_component.ex:154
-#: lib/edenflowers_web/components/address_input_component.ex:164
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr "Det uppstod ett problem med att beräkna leveranskostnaden, försök igen senare"
@@ -368,43 +366,43 @@ msgstr "Det uppstod ett problem med att beräkna leveranskostnaden, försök ige
 msgid "There was an error subscribing to the newsletter."
 msgstr "Det uppstod ett fel vid prenumeration på nyhetsbrevet."
 
-#: lib/edenflowers_web/live/product_live.ex:158
+#: lib/edenflowers_web/live/product_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "We offer same-day delivery for orders placed before 2 PM on weekdays. For weekend deliveries, please place your order by Friday 2 PM. All our deliveries are carefully handled to ensure your flowers arrive in perfect condition."
 msgstr "Vi erbjuder leverans samma dag för beställningar som läggs före kl. 14 på vardagar. För helgleveranser, vänligen lägg din beställning senast fredag ​​kl. 14. Alla våra leveranser hanteras noggrant för att säkerställa att dina blommor anländer i perfekt skick."
 
-#: lib/edenflowers_web/live/product_live.ex:182
+#: lib/edenflowers_web/live/product_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "What happens if I'm not home for delivery?"
 msgstr "Vad händer om jag inte är hemma vid leverans?"
 
-#: lib/edenflowers_web/live/product_live.ex:155
+#: lib/edenflowers_web/live/product_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "What is your delivery policy?"
 msgstr "Vad är er leveranspolicy?"
 
-#: lib/edenflowers_web/live/product_live.ex:167
+#: lib/edenflowers_web/live/product_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Yes! You can add a personal message during checkout. We'll include it on a beautiful card with your delivery. Messages can be up to 200 characters."
 msgstr "Ja! Du kan lägga till ett personligt meddelande vid kassan. Vi inkluderar det på ett vackert kort med din leverans. Meddelanden kan vara upp till 200 tecken."
 
-#: lib/edenflowers_web/live/product_live.ex:176
+#: lib/edenflowers_web/live/product_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer weekly, bi-weekly, and monthly subscription services. You can customize your subscription to match your preferences and schedule. Subscribers receive a 10% discount on all orders."
 msgstr "Ja, vi erbjuder veckovisa, varannan vecka och månatliga prenumerationstjänster. Du kan anpassa din prenumeration för att matcha dina preferenser och schema. Prenumeranter får 10% rabatt på alla beställningar."
 
-#: lib/edenflowers_web/live/checkout_live.ex:61
-#: lib/edenflowers_web/live/checkout_live.ex:636
+#: lib/edenflowers_web/live/checkout_live.ex:69
+#: lib/edenflowers_web/live/checkout_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Your Details"
 msgstr "Dina uppgifter"
 
-#: lib/edenflowers_web/live/checkout_live.ex:72
+#: lib/edenflowers_web/live/checkout_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr "Ditt namn *"
 
-#: lib/edenflowers_web/components/line_items_component.ex:70
+#: lib/edenflowers_web/components/line_items_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your cart is empty."
 msgstr "Din varukorg är tom."
@@ -523,18 +521,18 @@ msgstr "Moms"
 msgid "Thank you for your order!"
 msgstr "Tack för din beställning!"
 
-#: lib/edenflowers_web/live/checkout_live.ex:251
+#: lib/edenflowers_web/live/checkout_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:203
+#: lib/edenflowers_web/live/checkout_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Add a card"
 msgstr ""
 
-#: lib/edenflowers_web/components/address_input_component.ex:65
-#: lib/edenflowers_web/live/checkout_live.ex:717
+#: lib/edenflowers_web/components/address_input_component.ex:54
+#: lib/edenflowers_web/live/checkout_live.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr "Adress"
@@ -549,12 +547,12 @@ msgstr ""
 msgid "CARD MESSAGE"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:136
+#: lib/edenflowers_web/live/checkout_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:35
+#: lib/edenflowers_web/live/checkout_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Cart is empty"
 msgstr ""
@@ -564,17 +562,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:154
+#: lib/edenflowers_web/live/checkout_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:243
+#: lib/edenflowers_web/live/checkout_live.ex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr "Leverans­information"
 
-#: lib/edenflowers_web/live/checkout_live.ex:669
+#: lib/edenflowers_web/live/checkout_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -584,19 +582,14 @@ msgstr ""
 msgid "Email Address"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:354
+#: lib/edenflowers_web/live/checkout_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Enter promo code"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:39
+#: lib/edenflowers_web/live/checkout_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error loading checkout"
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Fresh stems loading soon"
 msgstr ""
 
 #: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
@@ -609,7 +602,7 @@ msgstr ""
 msgid "Incorrect email or password"
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:35
+#: lib/edenflowers/store/order/changes/lookup_promotion_code.ex:29
 #, elixir-autogen, elixir-format
 msgid "Invalid code"
 msgstr ""
@@ -624,24 +617,24 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:783
+#: lib/edenflowers_web/live/checkout_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:782
+#: lib/edenflowers_web/live/checkout_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:84
-#: lib/edenflowers_web/live/checkout_live.ex:207
-#: lib/edenflowers_web/live/checkout_live.ex:300
+#: lib/edenflowers_web/live/checkout_live.ex:92
+#: lib/edenflowers_web/live/checkout_live.ex:215
+#: lib/edenflowers_web/live/checkout_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:486
+#: lib/edenflowers_web/live/checkout_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
@@ -656,18 +649,18 @@ msgstr "Anmäl dig nu"
 msgid "Register and enjoy 15% off your next order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:172
-#: lib/edenflowers_web/live/checkout_live.ex:175
+#: lib/edenflowers_web/live/checkout_live.ex:180
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr "Ta bort"
 
-#: lib/edenflowers_web/live/checkout_live.ex:418
+#: lib/edenflowers_web/live/checkout_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:781
+#: lib/edenflowers_web/live/checkout_live.ex:859
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -692,19 +685,9 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/store/order/changes/calculate_pickup_cost.ex:37
-#, elixir-autogen, elixir-format
-msgid "Unable to calculate fulfillment cost"
-msgstr ""
-
 #: lib/edenflowers_web/components/newsletter_signup_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "We send out only ocassional emails. Unsubscribe at any time."
-msgstr ""
-
-#: lib/edenflowers_web/live/store_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "We're refreshing our collection. Check back shortly for newly arranged bouquets ready to ship."
 msgstr ""
 
 #: lib/edenflowers/email.ex:86
@@ -757,29 +740,27 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:246
+#: lib/edenflowers_web/live/checkout_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:710
+#: lib/edenflowers_web/live/checkout_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:711
+#: lib/edenflowers_web/live/checkout_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_geocoded_address.ex:11
-#: lib/edenflowers_web/components/address_input_component.ex:42
-#: lib/edenflowers_web/components/address_input_component.ex:101
+#: lib/edenflowers/fulfillments.ex:41
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Leveransadress krävs"
 
-#: lib/edenflowers_web/components/address_input_component.ex:207
+#: lib/edenflowers_web/components/address_input_component.ex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Free delivery! 🥳"
 msgstr "Gratis leverans!"
@@ -794,22 +775,17 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:266
+#: lib/edenflowers_web/components/layouts.ex:371
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_payment_intent.ex:10
-#, elixir-autogen, elixir-format
-msgid "Payment intent is required"
-msgstr ""
-
-#: lib/edenflowers_web/components/layouts.ex:276
+#: lib/edenflowers_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
 
-#: lib/edenflowers_web/live/home_live.ex:92
+#: lib/edenflowers_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Start Here"
 msgstr ""
@@ -828,3 +804,115 @@ msgstr "Får vara högst %{max} tecken"
 #, elixir-autogen, elixir-format
 msgid "Select a card before writing a message"
 msgstr "Välj ett kort innan du skriver ett meddelande"
+
+#: lib/edenflowers_web/live/store_live.ex:85
+#, elixir-autogen, elixir-format
+msgid "Browse bouquets"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:920
+#, elixir-autogen, elixir-format
+msgid "Cart changed but payment couldn't be updated. Please retry."
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:748
+#, elixir-autogen, elixir-format
+msgid "Cart, empty"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Categories"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:219
+#, elixir-autogen, elixir-format
+msgid "Close cart"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:161
+#, elixir-autogen, elixir-format
+msgid "Close navigation menu"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:94
+#, elixir-autogen, elixir-format
+msgid "Confirmed"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "Couldn't complete"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:76
+#, elixir-autogen, elixir-format
+msgid "Dismiss"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "Fresh stems on the way"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Go to slide __N__"
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Next slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Notice"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:61
+#, elixir-autogen, elixir-format
+msgid "Notifications"
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:598
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please refresh the page and try again."
+msgstr ""
+
+#: lib/edenflowers_web/live/checkout_live.ex:337
+#: lib/edenflowers_web/live/checkout_live.ex:494
+#: lib/edenflowers_web/live/checkout_live.ex:927
+#, elixir-autogen, elixir-format
+msgid "Payment is temporarily unavailable. Please try again in a moment."
+msgstr ""
+
+#: lib/edenflowers_web/live/home_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Previous slide"
+msgstr ""
+
+#: lib/edenflowers_web/components/core_components.ex:64
+#, elixir-autogen, elixir-format
+msgid "Reconnected"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts/root.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Skip to main content"
+msgstr ""
+
+#: lib/edenflowers_web/live/store_live.ex:82
+#, elixir-autogen, elixir-format
+msgid "We're refreshing this collection right now. Check back shortly — or browse another category in the meantime."
+msgstr ""
+
+#: lib/edenflowers/store/line_item/changes/populate_from_variant.ex:34
+#, elixir-autogen, elixir-format
+msgid "is invalid"
+msgstr ""


### PR DESCRIPTION
## Summary

Addresses regressions and gaps left by recent PRs against the #140 WCAG 2.2 AA baseline, plus pre-existing storefront a11y issues found in a full review. Also removes dark mode (it was dead code — only one theme ships).

### Critical fixes
- `<html lang>` now reflects the active locale (was hard-coded `en`, but the site is FI/SV/EN)
- Cart count badge has accessible name + polite live region (PR #141 gap)
- Mobile hamburger and cart triggers expose `aria-expanded`/`aria-controls` (PR #144 gap)
- Carousel follows APG pattern: `aria-roledescription`, slide labels, `aria-controls` on prev/next, `aria-current` on dots (PR #145 gap)
- Disconnected banner explicitly sets `aria-live="assertive"` + `aria-atomic`; reconnect is now politely announced
- Skip link added to root layout

### Major fixes
- Toast `role` per severity (`alert` for errors, `status` otherwise) — PR #142 follow-up
- Removed broken `aria-labelledby={product.name}` on home + store cards (multi-word product names produced invalid IDs and resolved to no name on most AT)
- Store category filters wrapped in `<nav aria-label="Categories">` with `aria-current="page"`
- Real Facebook/Instagram URLs replace `href="#"` placeholders (with `target="_blank" rel="noopener noreferrer"`)
- Locale links surface active locale via `aria-current="true"`

### Reusable components added
Compile-time enforcement of a11y contracts (the next developer can't forget the label):
- `<.icon_button>` — `aria_label` is a required attr
- `<.disclosure_trigger>` — wires `aria-expanded` + `aria-controls`
- `<.cart_count_badge>` — bundles accessible name + sr-only live region
- `<.locale_list>` — single source of truth for header / drawer / footer

### Dark mode removed
The theme toggle was defined but never rendered (dead code). Removed the toggle component, the theme-setting `<script>` in `root.html.heex`, the `[data-theme=dark]` custom variant in CSS, and the `localStorage` persistence. Site ships only the light theme — simplifies future contrast verification to one theme.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 233/233 passing
- [x] `mix gettext.extract && mix gettext.merge` — 22 new translatable strings extracted across en/fi/sv
- [ ] Manual: tab through home → focus reaches skip link first, then nav, then carousel, then cart
- [ ] Manual: open cart drawer with VoiceOver — hears "Cart, 3 items" not silence
- [ ] Manual: open mobile nav with VoiceOver — hears "expanded" / "collapsed" state
- [ ] Manual: tab through carousel — slides announce "1 / 4: Spring Bouquet" etc., dots announce current
- [ ] Manual: trigger a flash error vs. success — error interrupts SR speech, success waits politely
- [ ] Manual: verify Finnish/Swedish locale — `<html lang="fi">` / `lang="sv-FI">` set correctly