### PR TITLE
Fix breadcrumb inconsistencies in store and product pages

### DIFF
--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -6,8 +6,10 @@ defmodule EdenflowersWeb.ProductLive do
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
 
   def mount(%{"id" => id}, %{"order_id" => order_id}, socket) do
+    locale = current_locale_atom()
     {:ok, product} = Product.get_by_id(id, load: [:product_variants, :tax_rate])
     product_variants = product.product_variants
+    product_category = product.product_category |> Ash.load!(:translations) |> AshTranslation.translate(locale)
 
     selected_variant =
       case length(product_variants) do
@@ -30,6 +32,7 @@ defmodule EdenflowersWeb.ProductLive do
      socket
      |> assign(order_id: order_id)
      |> assign(product: product)
+     |> assign(product_category: product_category)
      |> assign(product_variants: product_variants)
      |> assign(selected_variant: selected_variant)}
   end
@@ -41,7 +44,7 @@ defmodule EdenflowersWeb.ProductLive do
         <.breadcrumb>
           <:item navigate={~p"/"} label={~t"Home"} />
           <:item navigate={~p"/store"} label={~t"Store"} />
-          <:item navigate={~p"/store/#{@product.product_category.slug}"} label={@product.product_category.name} />
+          <:item navigate={~p"/store/#{@product.product_category.slug}"} label={@product_category.name} />
           <:item label={@product.name} />
         </.breadcrumb>
 
@@ -188,6 +191,8 @@ defmodule EdenflowersWeb.ProductLive do
     </Layouts.app>
     """
   end
+
+  defp current_locale_atom, do: Localize.get_locale().cldr_locale_id
 
   def handle_event("change", %{"product_variant_id" => id}, socket) do
     variant = Enum.find(socket.assigns.product_variants, &(&1.id == id))

--- a/lib/edenflowers_web/live/store_live.ex
+++ b/lib/edenflowers_web/live/store_live.ex
@@ -52,6 +52,7 @@ defmodule EdenflowersWeb.StoreLive do
         <.breadcrumb>
           <:item navigate={~p"/"} label={~t"Home"} />
           <:item navigate={~p"/store"} label={~t"Store"} />
+          <:item label={@selected_category.name} />
         </.breadcrumb>
 
         <div class="mb-10 max-w-2xl">


### PR DESCRIPTION
## Summary

- Store category page (`/store/:category`) now shows `Home > Store > [Category]` as the current page instead of stopping at `Store`
- Product page now loads and translates the product category via `AshTranslation`, so the category label in the breadcrumb respects the active locale (previously used the raw untranslated name from the preloaded association)

## Test plan

- [ ] Visit `/store/bouquets` — breadcrumb should show Home > Store > Bouquets with Bouquets as the current (non-linked) item
- [ ] Visit a product page — breadcrumb should show Home > Store > [Category] > [Product], with category name matching the translated name shown on the store page
- [ ] Switch locale (if applicable) and verify the category name in the product breadcrumb updates correctly