### PR TITLE
Scope gettext locale changes to render lifetime

### DIFF
--- a/lib/edenflowers/email.ex
+++ b/lib/edenflowers/email.ex
@@ -43,13 +43,13 @@ defmodule Edenflowers.Email do
   Builds an order confirmation email
   """
   def order_confirmation(order) do
-    Gettext.put_locale(EdenflowersWeb.Gettext, order.locale)
-
-    new()
-    |> from(@from_address)
-    |> to(order.customer_email)
-    |> subject("#{~t"Order Confirmation"} - #{order.order_reference}")
-    |> text_body(render_order_confirmation(order, order.locale))
+    Gettext.with_locale(EdenflowersWeb.Gettext, order.locale, fn ->
+      new()
+      |> from(@from_address)
+      |> to(order.customer_email)
+      |> subject("#{~t"Order Confirmation"} - #{order.order_reference}")
+      |> text_body(render_order_confirmation(order, order.locale))
+    end)
   end
 
   defp render_order_confirmation(order, locale) do

--- a/lib/edenflowers/workers/send_newsletter_promo_email.ex
+++ b/lib/edenflowers/workers/send_newsletter_promo_email.ex
@@ -15,25 +15,25 @@ defmodule Edenflowers.Workers.SendNewsletterPromoEmail do
   end
 
   def perform(%Oban.Job{args: %{"email" => email, "locale" => locale}}) do
-    Gettext.put_locale(EdenflowersWeb.Gettext, locale)
+    Gettext.with_locale(EdenflowersWeb.Gettext, locale, fn ->
+      case User.get_by_email(email, authorize?: false, load: [:newsletter_promo]) do
+        {:ok, %{newsletter_promo: nil} = user} ->
+          {:ok, promo} = Promotion.create_for_newsletter(actor: system_actor())
+          Email.newsletter_promo(email, promo.code) |> Mailer.deliver()
+          {:ok, _} = User.set_newsletter_promo(user, promo.id, actor: system_actor())
+          :ok
 
-    case User.get_by_email(email, authorize?: false, load: [:newsletter_promo]) do
-      {:ok, %{newsletter_promo: nil} = user} ->
-        {:ok, promo} = Promotion.create_for_newsletter(actor: system_actor())
-        Email.newsletter_promo(email, promo.code) |> Mailer.deliver()
-        {:ok, _} = User.set_newsletter_promo(user, promo.id, actor: system_actor())
-        :ok
+        {:ok, %{newsletter_promo: %{usage: 0, code: code}}} ->
+          Email.newsletter_already_subscribed(email, code) |> Mailer.deliver()
+          :ok
 
-      {:ok, %{newsletter_promo: %{usage: 0, code: code}}} ->
-        Email.newsletter_already_subscribed(email, code) |> Mailer.deliver()
-        :ok
+        {:ok, %{newsletter_promo: _used}} ->
+          Email.newsletter_resubscribed(email) |> Mailer.deliver()
+          :ok
 
-      {:ok, %{newsletter_promo: _used}} ->
-        Email.newsletter_resubscribed(email) |> Mailer.deliver()
-        :ok
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
   end
 end

--- a/test/edenflowers/workers/send_newsletter_promo_email_test.exs
+++ b/test/edenflowers/workers/send_newsletter_promo_email_test.exs
@@ -55,4 +55,15 @@ defmodule Edenflowers.Workers.SendNewsletterPromoEmailTest do
       end)
     end
   end
+
+  describe "locale scoping" do
+    test "does not leak job's locale into the caller's process state" do
+      Gettext.put_locale(EdenflowersWeb.Gettext, "en")
+      {:ok, _user} = User.subscribe_to_newsletter("scope@example.com", authorize?: false)
+
+      assert :ok = perform_job(SendNewsletterPromoEmail, %{"email" => "scope@example.com", "locale" => "fi"})
+
+      assert Gettext.get_locale(EdenflowersWeb.Gettext) == "en"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Email.order_confirmation/1` and `SendNewsletterPromoEmail.perform/1` mutated the BEAM process's gettext locale via `Gettext.put_locale/2`. In an Oban worker — and in tests using `perform_job/2`, which runs the job in the test process — that mutation outlives the call and leaks into whatever runs next.
- Both call sites now use `Gettext.with_locale/3`, which scopes the locale to the function and restores the prior value on exit (including on raise).
- Adds a regression test asserting the worker no longer leaks its locale to the caller's process.

## Background

This is the second pass of a `/improve-codebase-architecture` review. The first pass landed in #150 (checkout state machine). Candidate \"Locale seam\" was the next-highest-leverage independent change.

The original analysis flagged seven locale touch points across the codebase. Only two of them are actually broken: the worker and the email module, both of which set locale as a side effect outside any request context. The other five (`layouts.ex`, `store_live.ex`, the `PutLocale` plug and `PutOrder` hook) read locale during a request where the global is correctly populated by the plug pipeline — they're working as designed and are out of scope here.

## Why `with_locale/3` rather than a new module

`Gettext.with_locale/3` is already the gettext-native primitive for this. Wrapping it in a project-level `Locale` module would be a layer that adds nothing.

## Test plan

- [x] `mix test` — 234 tests, 0 failures
- [x] New test: `SendNewsletterPromoEmailTest \"locale scoping\"` — fails on `main` (locale leaks), passes on this branch