### PR TITLE
Fix seeds translation locale keys

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -55,7 +55,7 @@ bouquets_category =
     draft: false,
     description: "Handcrafted floral arrangements featuring seasonal blooms in elegant compositions.",
     translations: %{
-      sv: %{
+      "sv-FI": %{
         name: "Buketter",
         description: "Handgjorda blomsterarrangemang med säsongens blommor i eleganta kompositioner."
       },
@@ -75,7 +75,7 @@ cards_category =
     draft: false,
     description: "Thoughtfully designed greeting cards for every occasion and sentiment.",
     translations: %{
-      sv: %{
+      "sv-FI": %{
         name: "Kort",
         description: "Omsorgsfullt designade gratulationskort för varje tillfälle och känsla."
       },
@@ -95,7 +95,7 @@ pre_loved_category =
     draft: false,
     description: "Curated vintage and gently used items finding new homes and stories.",
     translations: %{
-      sv: %{
+      "sv-FI": %{
         name: "Begagnat",
         description: "Utvalda vintage- och varsamt använda föremål som hittar nya hem och berättelser."
       },


### PR DESCRIPTION
## Summary
- Seed file used `sv:` translation keys, but the configured translatable locales are `:"sv-FI"` and `:fi` (`lib/edenflowers/locales.ex:6`).
- A clean `mix run priv/repo/seeds.exs` crashed on the first `ProductCategory.create` with `No such input \`sv\` for action Edenflowers.Store.ProductCategory.Translations.create`.
- Updated the three `translations:` maps in `priv/repo/seeds.exs` to use `"sv-FI":`.

## Test plan
- [x] `mix ecto.drop && mix ash.setup && mix run priv/repo/seeds.exs` runs to completion
- [x] Verified row counts: 1 tax rate, 2 fulfillment options, 3 categories, 13 products, 36 variants, 1 promotion