### PR TITLE
Reset checkout when cart drawer empties (fix #159)

### DIFF
--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -14,13 +14,6 @@ defmodule Edenflowers.Store.LineItem do
     end
   end
 
-  code_interface do
-    define :add_item, action: :add_to_cart
-    define :remove_item, action: :remove_item
-    define :increment_quantity, action: :increment_quantity
-    define :decrement_quantity, action: :decrement_quantity
-  end
-
   actions do
     defaults [:read]
 

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -3,6 +3,7 @@ defmodule Edenflowers.Store.Order do
     domain: Edenflowers.Store,
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer],
+    notifiers: [Ash.Notifier.PubSub],
     extensions: [AshStateMachine]
 
   use GettextSigils, backend: EdenflowersWeb.Gettext
@@ -36,24 +37,6 @@ defmodule Edenflowers.Store.Order do
 
   @checkout_states [:contact_details, :gift_options, :delivery, :payment]
 
-  state_machine do
-    initial_states([:contact_details])
-    default_initial_state(:contact_details)
-
-    transitions do
-      transition(:submit_contact_details, from: :contact_details, to: :gift_options)
-      transition(:submit_gift_options, from: :gift_options, to: :delivery)
-      transition(:submit_delivery, from: :delivery, to: :payment)
-      transition(:finalize_checkout, from: :payment, to: :placed)
-
-      transition(:return_to_contact_details, from: [:gift_options, :delivery, :payment], to: :contact_details)
-      transition(:return_to_gift_options, from: [:delivery, :payment], to: :gift_options)
-      transition(:return_to_delivery, from: :payment, to: :delivery)
-
-      transition(:restart_checkout, from: @checkout_states, to: :contact_details)
-    end
-  end
-
   code_interface do
     define :create_for_checkout, action: :create_for_checkout
     define :get_by_id, action: :by_id, args: [:id]
@@ -78,6 +61,28 @@ defmodule Edenflowers.Store.Order do
     define :restart_checkout, action: :restart_checkout
     define :add_card, action: :add_card, args: [:product_variant_id]
     define :remove_card, action: :remove_card
+    define :remove_line_item, action: :remove_line_item, args: [:line_item_id]
+    define :add_line_item, action: :add_line_item, args: [:product_variant_id, :quantity]
+    define :increment_line_item, action: :increment_line_item, args: [:line_item_id]
+    define :decrement_line_item, action: :decrement_line_item, args: [:line_item_id]
+  end
+
+  state_machine do
+    initial_states([:contact_details])
+    default_initial_state(:contact_details)
+
+    transitions do
+      transition(:submit_contact_details, from: :contact_details, to: :gift_options)
+      transition(:submit_gift_options, from: :gift_options, to: :delivery)
+      transition(:submit_delivery, from: :delivery, to: :payment)
+      transition(:finalize_checkout, from: :payment, to: :placed)
+
+      transition(:return_to_contact_details, from: [:gift_options, :delivery, :payment], to: :contact_details)
+      transition(:return_to_gift_options, from: [:delivery, :payment], to: :gift_options)
+      transition(:return_to_delivery, from: :payment, to: :delivery)
+
+      transition(:restart_checkout, from: @checkout_states, to: :contact_details)
+    end
   end
 
   actions do
@@ -247,6 +252,35 @@ defmodule Edenflowers.Store.Order do
       change load(@checkout_load)
       require_atomic? false
     end
+
+    update :remove_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.RemoveLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :add_line_item do
+      argument :product_variant_id, :uuid, allow_nil?: false
+      argument :quantity, :integer, allow_nil?: false, constraints: [min: 1]
+      change {Changes.AddLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :increment_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.AdjustLineItemQuantity, direction: :increment}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :decrement_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.AdjustLineItemQuantity, direction: :decrement}
+      change load(@checkout_load)
+      require_atomic? false
+    end
   end
 
   policies do
@@ -273,6 +307,12 @@ defmodule Edenflowers.Store.Order do
     policy action_type(:update) do
       authorize_if expr(state in ^@checkout_states)
     end
+  end
+
+  pub_sub do
+    module EdenflowersWeb.Endpoint
+
+    publish :restart_checkout, ["order", "checkout_restarted", :id]
   end
 
   attributes do

--- a/lib/edenflowers/store/order/changes/add_line_item.ex
+++ b/lib/edenflowers/store/order/changes/add_line_item.ex
@@ -1,0 +1,30 @@
+defmodule Edenflowers.Store.Order.Changes.AddLineItem do
+  @moduledoc """
+  Adds a line item to the order via LineItem's `:add_to_cart` upsert. The
+  Order-side action is the public seam for adding items so cart-mutation
+  rules stay near the aggregate root; this change wires the create through.
+  """
+  use Ash.Resource.Change
+
+  alias Edenflowers.Store.LineItem
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    product_variant_id = Ash.Changeset.get_argument(changeset, :product_variant_id)
+    quantity = Ash.Changeset.get_argument(changeset, :quantity)
+
+    Ash.Changeset.after_action(changeset, fn _changeset, order ->
+      LineItem
+      |> Ash.Changeset.for_create(:add_to_cart, %{
+        order_id: order.id,
+        product_variant_id: product_variant_id,
+        quantity: quantity
+      })
+      |> Ash.create(authorize?: false)
+      |> case do
+        {:ok, _line_item} -> {:ok, order}
+        {:error, error} -> {:error, error}
+      end
+    end)
+  end
+end

--- a/lib/edenflowers/store/order/changes/adjust_line_item_quantity.ex
+++ b/lib/edenflowers/store/order/changes/adjust_line_item_quantity.ex
@@ -1,0 +1,56 @@
+defmodule Edenflowers.Store.Order.Changes.AdjustLineItemQuantity do
+  @moduledoc """
+  Increments or decrements the quantity of a line item belonging to the
+  order. The action argument `:direction` chooses between `:increment` and
+  `:decrement`, both of which delegate to LineItem's matching update action.
+  """
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Edenflowers.Store.LineItem
+
+  @impl true
+  def init(opts) do
+    case Keyword.fetch(opts, :direction) do
+      {:ok, direction} when direction in [:increment, :decrement] -> {:ok, opts}
+      _ -> {:error, "expected :direction to be :increment or :decrement"}
+    end
+  end
+
+  @impl true
+  def change(changeset, opts, _context) do
+    line_item_id = Ash.Changeset.get_argument(changeset, :line_item_id)
+    direction = Keyword.fetch!(opts, :direction)
+
+    Ash.Changeset.after_action(changeset, fn _changeset, order ->
+      with {:ok, line_item} <- fetch_line_item(line_item_id, order.id),
+           {:ok, _line_item} <- adjust(line_item, direction) do
+        {:ok, order}
+      end
+    end)
+  end
+
+  defp fetch_line_item(line_item_id, order_id) do
+    LineItem
+    |> Ash.Query.filter(id == ^line_item_id and order_id == ^order_id)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, nil} -> {:error, :line_item_not_found}
+      {:ok, line_item} -> {:ok, line_item}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp adjust(line_item, :increment) do
+    line_item
+    |> Ash.Changeset.for_update(:increment_quantity)
+    |> Ash.update(authorize?: false)
+  end
+
+  defp adjust(line_item, :decrement) do
+    line_item
+    |> Ash.Changeset.for_update(:decrement_quantity)
+    |> Ash.update(authorize?: false)
+  end
+end

--- a/lib/edenflowers/store/order/changes/remove_line_item.ex
+++ b/lib/edenflowers/store/order/changes/remove_line_item.ex
@@ -1,0 +1,46 @@
+defmodule Edenflowers.Store.Order.Changes.RemoveLineItem do
+  @moduledoc """
+  Destroys a line item belonging to the order. If removing it leaves the
+  order with no non-card line items, the order's checkout state is also
+  reset so a new browsing session starts from a clean slate.
+  """
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Edenflowers.Store.{LineItem, Order}
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    line_item_id = Ash.Changeset.get_argument(changeset, :line_item_id)
+
+    Ash.Changeset.after_action(changeset, fn _changeset, order ->
+      with {:ok, line_item} <- fetch_line_item(line_item_id, order.id),
+           :ok <- Ash.destroy(line_item, action: :remove_item, authorize?: false),
+           {:ok, order} <- maybe_restart_checkout(order) do
+        {:ok, order}
+      end
+    end)
+  end
+
+  defp fetch_line_item(line_item_id, order_id) do
+    LineItem
+    |> Ash.Query.filter(id == ^line_item_id and order_id == ^order_id)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, nil} -> {:error, :line_item_not_found}
+      {:ok, line_item} -> {:ok, line_item}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp maybe_restart_checkout(order) do
+    order = Ash.load!(order, :non_card_line_item_count, authorize?: false)
+
+    if order.non_card_line_item_count == 0 do
+      Order.restart_checkout(order, authorize?: false)
+    else
+      {:ok, order}
+    end
+  end
+end

--- a/lib/edenflowers_web/components/line_items_component.ex
+++ b/lib/edenflowers_web/components/line_items_component.ex
@@ -1,7 +1,7 @@
 defmodule EdenflowersWeb.LineItemsComponent do
   use EdenflowersWeb, :live_component
 
-  alias Edenflowers.Store.LineItem
+  alias Edenflowers.Store.Order
 
   attr :id, :string, required: true
   attr :order, :any, required: true
@@ -75,17 +75,17 @@ defmodule EdenflowersWeb.LineItemsComponent do
   end
 
   def handle_event("remove_item", %{"id" => id}, socket) do
-    LineItem.remove_item(id)
+    Order.remove_line_item(socket.assigns.order, id)
     {:noreply, socket}
   end
 
   def handle_event("increment_line_item", %{"id" => id}, socket) do
-    LineItem.increment_quantity(id)
+    Order.increment_line_item(socket.assigns.order, id)
     {:noreply, socket}
   end
 
   def handle_event("decrement_line_item", %{"id" => id}, socket) do
-    LineItem.decrement_quantity(id)
+    Order.decrement_line_item(socket.assigns.order, id)
     {:noreply, socket}
   end
 end

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -23,6 +23,7 @@ defmodule EdenflowersWeb.CheckoutLive do
   def mount(_params, _session, %{assigns: %{order: order}} = socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Edenflowers.PubSub, "line_item:changed:#{order.id}")
+      Phoenix.PubSub.subscribe(Edenflowers.PubSub, "order:checkout_restarted:#{order.id}")
     end
 
     with :ok <- cart_has_items?(order),
@@ -616,20 +617,18 @@ defmodule EdenflowersWeb.CheckoutLive do
     actor = actor(socket)
     order = Order.get_for_checkout!(socket.assigns.order.id, actor: actor)
 
-    cond do
-      order.cart_effectively_empty? ->
-        Order.restart_checkout!(order, actor: actor)
-        {:noreply, push_navigate(socket, to: ~p"/")}
-
-      # Cart changed while the customer is on the payment step. The PaymentIntent's
-      # amount must follow the new total, otherwise `confirmPayment` would charge
-      # the previous amount.
-      order.state == :payment and not is_nil(order.payment_intent_id) ->
-        {:noreply, sync_payment_intent(assign(socket, order: order), order)}
-
-      true ->
-        {:noreply, assign(socket, order: order)}
+    # Cart changed while the customer is on the payment step. The PaymentIntent's
+    # amount must follow the new total, otherwise `confirmPayment` would charge
+    # the previous amount.
+    if order.state == :payment and not is_nil(order.payment_intent_id) do
+      {:noreply, sync_payment_intent(assign(socket, order: order), order)}
+    else
+      {:noreply, assign(socket, order: order)}
     end
+  end
+
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "order:checkout_restarted:" <> _}, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/")}
   end
 
   def handle_info({:date_selected, date}, socket) do

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -1,7 +1,7 @@
 defmodule EdenflowersWeb.ProductLive do
   use EdenflowersWeb, :live_view
 
-  alias Edenflowers.Store.{Product, LineItem}
+  alias Edenflowers.Store.{Product, Order}
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
 
@@ -200,11 +200,7 @@ defmodule EdenflowersWeb.ProductLive do
   end
 
   def handle_event("submit", _params, socket) do
-    LineItem.add_item(%{
-      order_id: socket.assigns.order_id,
-      product_variant_id: socket.assigns.selected_variant.id,
-      quantity: 1
-    })
+    Order.add_line_item(socket.assigns.order, socket.assigns.selected_variant.id, 1)
 
     {:noreply, socket}
   end

--- a/test/edenflowers_web/live/checkout_address_live_test.exs
+++ b/test/edenflowers_web/live/checkout_address_live_test.exs
@@ -5,7 +5,7 @@ defmodule EdenflowersWeb.CheckoutAddressLiveTest do
   import Generator
   import Mox
 
-  alias Edenflowers.Store.{LineItem, Order}
+  alias Edenflowers.Store.Order
 
   setup :verify_on_exit!
 
@@ -15,11 +15,7 @@ defmodule EdenflowersWeb.CheckoutAddressLiveTest do
     delivery_option = generate(fulfillment_option(fulfillment_method: :delivery, rate_type: :fixed, base_price: "5.00"))
     order = generate(order(state: :delivery, customer_name: "Jane", customer_email: "jane@example.com"))
 
-    LineItem.add_item!(%{
-      order_id: order.id,
-      product_variant_id: variant.id,
-      quantity: 1
-    })
+    Order.add_line_item!(order, variant.id, 1, authorize?: false)
 
     stub(Edenflowers.StripeAPI.Mock, :create_payment_intent, fn _order ->
       {:ok, %{id: "pi_test", client_secret: "pi_test_secret"}}

--- a/test/edenflowers_web/live/checkout_happy_path_test.exs
+++ b/test/edenflowers_web/live/checkout_happy_path_test.exs
@@ -7,7 +7,7 @@ defmodule EdenflowersWeb.CheckoutHappyPathTest do
   import Swoosh.TestAssertions
   import ExUnit.CaptureLog
 
-  alias Edenflowers.Store.{LineItem, Order}
+  alias Edenflowers.Store.Order
 
   setup :verify_on_exit!
 
@@ -28,11 +28,7 @@ defmodule EdenflowersWeb.CheckoutHappyPathTest do
 
     order = generate(order())
 
-    LineItem.add_item!(%{
-      order_id: order.id,
-      product_variant_id: variant.id,
-      quantity: 1
-    })
+    Order.add_line_item!(order, variant.id, 1, authorize?: false)
 
     payment_intent = %{
       id: "pi_test_#{:rand.uniform(1_000_000)}",

--- a/test/edenflowers_web/live/checkout_live_test.exs
+++ b/test/edenflowers_web/live/checkout_live_test.exs
@@ -18,7 +18,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
   import Mox
   import ExUnit.CaptureLog
 
-  alias Edenflowers.Store.{Order, LineItem}
+  alias Edenflowers.Store.Order
 
   setup :verify_on_exit!
 
@@ -29,12 +29,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
     order = generate(order())
 
-    {:ok, _line_item} =
-      LineItem.add_item(%{
-        order_id: order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+    {:ok, _order} = Order.add_line_item(order, variant.id, 1, authorize?: false)
 
     order = Order.get_for_checkout!(order.id, actor: nil)
 
@@ -98,11 +93,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant} do
       gift_order = generate(order(state: :gift_options, gift: true))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       conn
       |> Plug.Test.init_test_session(%{order_id: gift_order.id})
@@ -128,11 +119,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       step_3_order = generate(order(state: :delivery, customer_name: "Jane", customer_email: "jane@example.com"))
 
-      LineItem.add_item!(%{
-        order_id: step_3_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(step_3_order, variant.id, 1, authorize?: false)
 
       conn = Plug.Test.init_test_session(conn, %{order_id: step_3_order.id})
 
@@ -265,11 +252,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -284,11 +267,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_product: card_product, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       card =
         Order.add_card!(gift_order, card_variant.id, authorize?: false).line_items
@@ -312,11 +291,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_product: card_product, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       conn
       |> Plug.Test.init_test_session(%{order_id: gift_order.id})
@@ -331,11 +306,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -353,11 +324,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       # recipient_name is required when gift=true, so seed it on the order directly
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test Recipient"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -375,11 +342,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Original"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -395,11 +358,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -418,11 +377,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -445,11 +400,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -468,11 +419,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
          %{conn: conn, variant: variant, card_variant: card_variant} do
       gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -491,11 +438,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       gift_order =
         generate(order(state: :gift_options, gift: true, recipient_name: "Test", card_message: "Pre-existing"))
 
-      LineItem.add_item!(%{
-        order_id: gift_order.id,
-        product_variant_id: variant.id,
-        quantity: 1
-      })
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
 
       Order.add_card!(gift_order, card_variant.id, authorize?: false)
 
@@ -529,7 +472,9 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       # details filled in, then removed every product, leaving only a card.
       Order.add_card!(order, card_variant.id, authorize?: false)
       [non_card_line_item] = Enum.reject(order.line_items, & &1.is_card)
-      LineItem.remove_item!(non_card_line_item)
+      # Bypass Order.remove_line_item to fabricate the stale state this guard
+      # is meant to catch — a card-only cart with leftover checkout fields.
+      Ash.destroy!(non_card_line_item, action: :remove_item, authorize?: false)
 
       stale =
         order
@@ -562,7 +507,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       conn = Plug.Test.init_test_session(conn, %{order_id: order.id})
       {:ok, view, _html} = live(conn, "/checkout")
 
-      LineItem.remove_item!(non_card_line_item)
+      Order.remove_line_item!(order, non_card_line_item.id, authorize?: false)
       assert_redirect(view, "/")
 
       reloaded = Order.get_for_checkout!(order.id, actor: nil)

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -1108,6 +1108,94 @@ defmodule Edenflowers.Store.OrderTest do
     end
   end
 
+  describe "Order.remove_line_item action" do
+    test "removes a single line item without resetting checkout when others remain" do
+      tax_rate = generate(tax_rate())
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant_1 = generate(product_variant(product_id: product.id))
+      variant_2 = generate(product_variant(product_id: product.id))
+
+      order =
+        generate(
+          order(
+            state: :delivery,
+            customer_name: "Keep Me",
+            customer_email: "keep@example.com"
+          )
+        )
+
+      to_remove = generate(line_item(order_id: order.id, product_variant_id: variant_1.id, quantity: 1))
+      _keep = generate(line_item(order_id: order.id, product_variant_id: variant_2.id, quantity: 1))
+
+      assert {:ok, updated} = Order.remove_line_item(order, to_remove.id, authorize?: false)
+
+      assert updated.state == :delivery
+      assert updated.customer_name == "Keep Me"
+      assert length(updated.line_items) == 1
+    end
+
+    test "removing the last non-card line item resets checkout fields" do
+      tax_rate = generate(tax_rate())
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id))
+
+      order =
+        generate(
+          order(
+            state: :payment,
+            customer_name: "Stale Customer",
+            customer_email: "stale@example.com",
+            recipient_name: "Recipient",
+            payment_intent_id: "pi_stale"
+          )
+        )
+
+      line_item = generate(line_item(order_id: order.id, product_variant_id: variant.id, quantity: 1))
+
+      assert {:ok, updated} = Order.remove_line_item(order, line_item.id, authorize?: false)
+
+      assert updated.state == :contact_details
+      assert is_nil(updated.customer_name)
+      assert is_nil(updated.customer_email)
+      assert is_nil(updated.recipient_name)
+      assert is_nil(updated.payment_intent_id)
+      assert updated.line_items == []
+    end
+
+    test "broadcasts order:checkout_restarted when the cart empties" do
+      tax_rate = generate(tax_rate())
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id))
+
+      order = generate(order(state: :delivery, customer_name: "X", customer_email: "x@example.com"))
+      line_item = generate(line_item(order_id: order.id, product_variant_id: variant.id, quantity: 1))
+
+      Phoenix.PubSub.subscribe(Edenflowers.PubSub, "order:checkout_restarted:#{order.id}")
+
+      assert {:ok, _} = Order.remove_line_item(order, line_item.id, authorize?: false)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: topic}
+      assert topic == "order:checkout_restarted:#{order.id}"
+    end
+
+    test "does not broadcast order:checkout_restarted when other items remain" do
+      tax_rate = generate(tax_rate())
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant_1 = generate(product_variant(product_id: product.id))
+      variant_2 = generate(product_variant(product_id: product.id))
+
+      order = generate(order(state: :delivery))
+      to_remove = generate(line_item(order_id: order.id, product_variant_id: variant_1.id, quantity: 1))
+      _keep = generate(line_item(order_id: order.id, product_variant_id: variant_2.id, quantity: 1))
+
+      Phoenix.PubSub.subscribe(Edenflowers.PubSub, "order:checkout_restarted:#{order.id}")
+
+      assert {:ok, _} = Order.remove_line_item(order, to_remove.id, authorize?: false)
+
+      refute_receive %Phoenix.Socket.Broadcast{topic: _}, 100
+    end
+  end
+
   describe "cart_effectively_empty? calculation" do
     test "true when the order has no line items" do
       order = Order.create_for_checkout!(authorize?: false)


### PR DESCRIPTION
## Summary

- Fixes #159: removing the last non-card item from the cart drawer no longer leaves the checkout form holding stale data.
- Routes all cart mutations (`add_line_item`, `remove_line_item`, `increment_line_item`, `decrement_line_item`) through `Order` as the aggregate root, mirroring the existing `Order.add_card` / `Order.remove_card` pattern.
- `Order.remove_line_item` runs `restart_checkout` in the same transaction when the cart effectively empties, so the invariant is enforced regardless of which UI surface initiates the removal.
- `Order` publishes a new `order:checkout_restarted:<id>` topic on `:restart_checkout`. `CheckoutLive` subscribes and `push_navigate`s to `/`, replacing the previous `cart_effectively_empty?` branch.

## Architectural notes

The bug existed because the "cart-empty → reset checkout" rule lived in `CheckoutLive.handle_info`, while the cart drawer (a layout component) had no such subscription. Pulling the rule into the Order aggregate eliminates the class of bug — any future UI surface for cart mutation will get the right behaviour for free.

`LineItem`'s `code_interface` block is removed entirely. Actions remain (`:add_to_cart`, `:remove_item`, `:increment_quantity`, `:decrement_quantity`) and are still used internally by Order's `after_action` callbacks via `Ash.create` / `Ash.update` / `Ash.destroy`.

## Test plan

- [x] `mix test` — 238 passing, 0 failures (was 234 on `main`; +4 new resource-level tests)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] Manual: open the cart drawer on `/`, remove the last non-card item, verify redirect to `/` and that `customer_name` etc. are cleared on the next checkout
- [x] Manual: same flow on `/checkout` (the previously-working path) still resets and redirects
- [x] Manual: increment / decrement / add-to-cart still work end-to-end

Closes #159.