### PR TITLE
Harmonise product cards across Store grid and Featured Blooms

### DIFF
--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -600,6 +600,54 @@ defmodule EdenflowersWeb.CoreComponents do
   end
 
   @doc """
+  Renders a product card used by both the Featured Blooms carousel (home)
+  and the Store grid. One editorial treatment, no surface chrome — the
+  photograph is the card; the only interactive accent is the brand
+  honey underline on hover. Mobile uses a 4:5 portrait crop for an
+  immersive feel; desktop uses a 1:1 square so cards line up cleanly.
+
+  `from_price?: true` prefixes the price with the "From" preposition,
+  appropriate when the value comes from `cheapest_price` across variants.
+  """
+  attr :product, :map, required: true, doc: "must respond to :name, :image_slug, :cheapest_price"
+  attr :navigate, :string, required: true
+  attr :from_price?, :boolean, default: true
+  attr :class, :any, default: nil
+
+  def product_card(assigns) do
+    ~H"""
+    <.link navigate={@navigate} class={["group block focus:outline-none", @class]}>
+      <figure class="bg-cream aspect-[4/5] relative mb-4 overflow-hidden sm:aspect-square">
+        <img
+          src={@product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 750, type: "fill") |> to_string()}
+          alt=""
+          loading="lazy"
+          class="block h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.04] sm:hidden"
+        />
+        <img
+          src={@product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 600, type: "fill") |> to_string()}
+          alt=""
+          loading="lazy"
+          class="hidden h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.04] sm:block"
+        />
+      </figure>
+
+      <div class="text-base-content flex flex-col gap-1.5">
+        <h3 class="card-title link-underline-group-hover-display">
+          {@product.name}
+        </h3>
+        <p class="font-serif text-base-content/65 text-base italic leading-none">
+          <span :if={@from_price?} class="font-sans tracking-[0.18em] mr-1 text-xs uppercase not-italic">
+            {~t"From"}
+          </span>
+          {Edenflowers.Utils.format_money(@product.cheapest_price)}
+        </p>
+      </div>
+    </.link>
+    """
+  end
+
+  @doc """
   Renders a category tile: a clickable image card with an overlaid label.
 
   ## Examples

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -94,35 +94,7 @@ defmodule EdenflowersWeb.HomeLive do
                   aria-roledescription="slide"
                   aria-label={"#{idx + 1} / #{length(@products)}: #{product.name}"}
                 >
-                  <.link navigate={~p"/product/#{product}"} class="group flex flex-col">
-                    <div class="mb-3 overflow-hidden rounded-lg">
-                      <picture>
-                        <%!-- Mobile: 4:5 portrait crop for an immersive feel.
-                             Desktop (sm+): 1:1 square so cards sit cleanly in a row. --%>
-                        <source
-                          media="(min-width: 640px)"
-                          srcset={
-                            product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 600, type: "fill") |> to_string()
-                          }
-                        />
-                        <img
-                          src={
-                            product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 750, type: "fill") |> to_string()
-                          }
-                          alt=""
-                          class="aspect-[4/5] w-full object-cover transition duration-500 ease-out group-hover:scale-[1.03] sm:aspect-square"
-                        />
-                      </picture>
-                    </div>
-                    <div class="text-base-content flex flex-col items-center gap-1">
-                      <h3 class="card-title link-underline-group-hover-display">
-                        {product.name}
-                      </h3>
-                      <p class="text-base-content/70 text-sm">
-                        {Edenflowers.Utils.format_money(product.cheapest_price)}
-                      </p>
-                    </div>
-                  </.link>
+                  <.product_card product={product} navigate={~p"/product/#{product}"} />
                 </li>
               </ul>
             </div>

--- a/lib/edenflowers_web/live/store_live.ex
+++ b/lib/edenflowers_web/live/store_live.ex
@@ -87,36 +87,12 @@ defmodule EdenflowersWeb.StoreLive do
             </.button>
           </div>
         <% else %>
-          <ul class="grid gap-6 sm:grid-cols-2 xl:grid-cols-3 xl:gap-8" role="list">
-            <li
-              :for={product <- @products}
-              class="group border-base-300/70 bg-base-100 relative flex flex-col overflow-hidden rounded-lg border focus-within:border-primary/60 focus-within:shadow-lg hover:border-primary/50 hover:shadow-lg"
-            >
-              <.link
-                class="flex h-full flex-col focus:outline-none"
-                navigate={~p"/product/#{product}"}
-              >
-                <figure class="aspect-square relative overflow-hidden">
-                  <img
-                    src={product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 600, type: "fill") |> to_string()}
-                    alt=""
-                    class="h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.03]"
-                    width="1"
-                    height="1"
-                    loading="lazy"
-                  />
-                </figure>
-
-                <div class="flex flex-1 flex-col gap-2 px-5 py-5 sm:px-6 sm:py-6">
-                  <h3 class="card-title text-base-content link-underline-group-hover-display">
-                    {product.name}
-                  </h3>
-
-                  <div class="text-base-content/70 text-sm">
-                    {Edenflowers.Utils.format_money(product.cheapest_price)}
-                  </div>
-                </div>
-              </.link>
+          <ul
+            class="grid gap-x-6 gap-y-12 sm:grid-cols-2 xl:grid-cols-3 xl:gap-x-8 xl:gap-y-14"
+            role="list"
+          >
+            <li :for={product <- @products}>
+              <.product_card product={product} navigate={~p"/product/#{product}"} />
             </li>
           </ul>
         <% end %>


### PR DESCRIPTION
## Summary
- The Store grid and the Featured Blooms carousel were running two different product-card designs (bordered/rounded tile vs. chrome-less editorial). They now share a single `product_card/1` component in `core_components.ex`.
- Direction taken: **kept the home page's chrome-less, photograph-led treatment** and applied it to the Store grid. The photo *is* the card; the brand honey underline on the title is the only hover accent.
- Mobile uses a 4:5 portrait crop, desktop a 1:1 square. Price reads as an italic serif caption with a small `FROM` eyebrow — sits beneath the title as a continuation of the same voice rather than a separate UI element.

## Test plan
- [x] `mix compile` — clean
- [x] Pre-push test hook — 234 tests, 0 failures
- [x] Visual: home Featured Blooms (`/?preview=secret`) at desktop 1280 and mobile 390
- [x] Visual: Store grid (`/store?preview=secret`) at desktop 1280 and mobile 390
- [x] Reviewer eyeball: confirm a card cropped from the home carousel and one cropped from the Store grid look identical