### PR TITLE
Validate checkout email and use mobile-correct input types

### DIFF
--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -121,6 +121,8 @@ defmodule Edenflowers.Store.Order do
     update :submit_contact_details do
       accept [:customer_name, :customer_email]
       require_attributes [:customer_name, :customer_email]
+
+      validate {Validations.ValidateCustomerEmail, []}
       change {Changes.UpsertUserAndAssignToOrder, []}
       change transition_state(:gift_options)
       change load(@checkout_load)

--- a/lib/edenflowers/store/order/validations/validate_customer_email.ex
+++ b/lib/edenflowers/store/order/validations/validate_customer_email.ex
@@ -1,0 +1,24 @@
+defmodule Edenflowers.Store.Order.Validations.ValidateCustomerEmail do
+  @moduledoc """
+  Validates that `customer_email` looks like an email address.
+  """
+  use Ash.Resource.Validation
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  @email_regex ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    case Ash.Changeset.get_attribute(changeset, :customer_email) do
+      nil ->
+        :ok
+
+      email when is_binary(email) ->
+        if Regex.match?(@email_regex, email) do
+          :ok
+        else
+          {:error, field: :customer_email, message: ~t"Must be a valid email address"}
+        end
+    end
+  end
+end

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -95,7 +95,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                     <.input
                       label={~t"Email *"}
                       field={@form[:customer_email]}
-                      type="text"
+                      type="email"
                       data-testid="customer-email-input"
                     />
 
@@ -268,7 +268,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                         label={recipient_label(@order, "phone")}
                         placeholder={~t"045 1505141"}
                         field={@form[:recipient_phone_number]}
-                        type="text"
+                        type="tel"
                       />
 
                       <fieldset class="flex flex-col">

--- a/lib/edenflowers_web/magic_link_request_live.ex
+++ b/lib/edenflowers_web/magic_link_request_live.ex
@@ -34,7 +34,7 @@ defmodule EdenflowersWeb.MagicLinkRequestLive do
           </p>
         <% else %>
           <.form class="flex w-full flex-col space-y-4" for={@form} phx-change="change" phx-submit="submit" method="POST">
-            <.input autofocus field={@form[:email]} label={~t"Email"} placeholder={~t"info@edenflowers.fi"} />
+            <.input autofocus field={@form[:email]} type="email" label={~t"Email"} />
 
             <.button type="submit" variant="primary" size="lg">
               {~t"Get Magic Link"}

--- a/test/edenflowers_web/live/checkout_live_test.exs
+++ b/test/edenflowers_web/live/checkout_live_test.exs
@@ -63,6 +63,20 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
       |> click_button("Next")
       |> assert_has("h2", text: "Gift Options")
     end
+
+    test "rejects an invalid email and stays on step 1", %{conn: conn, order: order} do
+      conn
+      |> Plug.Test.init_test_session(%{order_id: order.id})
+      |> visit("/checkout")
+      |> fill_in("Your Name *", with: "John Doe")
+      |> fill_in("Email *", with: "notanemail")
+      |> click_button("Next")
+      |> assert_has("p", text: "Must be a valid email address")
+
+      reloaded = Order.get_for_checkout!(order.id, actor: nil)
+      assert reloaded.state == :contact_details
+      assert is_nil(reloaded.customer_email)
+    end
   end
 
   describe "Step 2: Gift Options" do


### PR DESCRIPTION
## Summary
- Reject obviously-invalid customer emails at the `:submit_contact_details` action so typos surface immediately, before the order progresses to gift options.
- Use `type="email"` for the customer-email and magic-link inputs, and `type="tel"` for the recipient phone input, so mobile users get the appropriate on-screen keyboard.

## Test plan
- [x] `mix test` (239 tests, 0 failures)
- [x] New test covers an invalid email staying on step 1 with an inline error and an unchanged order state
- [ ] On a real mobile device: confirm the email keyboard appears on the checkout email and magic-link email fields
- [ ] On a real mobile device: confirm the phone-pad keyboard appears on the recipient phone field