### PR TITLE
Remove hero legibility wash overlays

### DIFF
--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -21,18 +21,6 @@ defmodule EdenflowersWeb.HomeLive do
           alt=""
         />
 
-        <%!-- Localised legibility wash: a soft radial darkens the area behind
-             the headline block (mobile bottom-left, desktop centre-left),
-             leaving the rest of the photo bright. --%>
-        <div
-          class="pointer-events-none absolute inset-0 md:hidden"
-          style="background: radial-gradient(closest-corner at 28% 78%, rgba(0,0,0,0.55), rgba(0,0,0,0) 65%);"
-        />
-        <div
-          class="pointer-events-none absolute inset-0 hidden md:block"
-          style="background: radial-gradient(closest-corner at 25% 55%, rgba(0,0,0,0.5), rgba(0,0,0,0) 55%);"
-        />
-
         <div class="container absolute inset-0 flex flex-col justify-end pb-20 sm:pb-28 md:justify-center md:pb-0">
           <h1 class="hero-display hero-reveal max-w-[16ch] text-white" style="--reveal-delay: 80ms;">
             {~t"Fresh flowers for everyday moments"}


### PR DESCRIPTION
## Summary
- Removes the two `radial-gradient` overlay divs that sat on top of the hero image to darken the area behind the headline.
- The wash was rendering as a visible gradient rather than the intended subtle legibility aid, so the hero photo now displays unmodified with the white headline directly on top.

## Trade-off to watch
The overlays existed to keep the white headline readable against bright spots in the photo. Without them, contrast depends entirely on the source image — if a future hero shot has light areas in the headline region, type may drop below WCAG AA. If that happens, options are a darker source image, a `text-shadow`, or reintroducing a more subtle wash.

## Test plan
- [x] `mix test` passes (238 tests, 0 failures — run by pre-commit hook)
- [ ] Visually confirm the hero on `/` renders without the dark patch behind the headline
- [ ] Confirm headline remains legible against the current hero image at mobile and desktop widths