### PR TITLE
Dim body-wide during reconnect, keep #flash-group crisp

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -85,17 +85,30 @@ summary {
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  main {
-    transition: opacity 200ms ease-out;
+  /* Dim everything body-level (header, main, drawers) in lockstep, but keep
+     the flash group crisp so the "Disconnected" toast stays readable. */
+  body > *:not(#flash-group) {
+    transition: opacity 200ms ease-out 0ms;
   }
-  .phx-loading main,
-  .phx-click-loading main {
+  /* 400ms delay before dimming so sub-400ms socket flaps stay invisible;
+     un-dim is immediate (no delay) when the class is removed. */
+  .phx-loading body > *:not(#flash-group),
+  .phx-click-loading body > *:not(#flash-group) {
     opacity: 0.7;
+    transition-delay: 400ms;
   }
   .phx-submit-loading [type="submit"],
   .phx-submit-loading button[phx-click] {
     cursor: progress;
   }
+}
+
+/* Gate clicks during reconnect/loading so a tap on a CTA mid-flap doesn't
+   queue an ambiguous action. Keyboard focus and scrolling are unaffected;
+   the flash group stays interactive so toasts can be dismissed. */
+.phx-loading body > *:not(#flash-group),
+.phx-click-loading body > *:not(#flash-group) {
+  pointer-events: none;
 }
 
 /* FOUC fix: https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/ */


### PR DESCRIPTION
## Summary
- Widen the LiveView loading dim from `<main>` to `body > *:not(#flash-group)` so header, drawers, and floating UI dim in lockstep — but the "Disconnected" toast stays readable.
- Add a 400ms `transition-delay` before dimming so sub-400ms socket flaps stay invisible; un-dim is immediate.
- Gate clicks with `pointer-events: none` on the same scope so a tap on a CTA mid-flap can't queue an ambiguous action. Keyboard focus and scrolling are unaffected; #flash-group stays interactive so toasts can be dismissed.

## Test plan
- [ ] Throttle the LiveView socket and confirm header/drawers dim alongside main.
- [ ] Confirm the "Disconnected" toast remains crisp and dismissable while everything else is dimmed.
- [ ] Tap a CTA mid-reconnect and confirm the click does not register; release and confirm interactivity restored without flicker.
- [ ] Confirm short (<400ms) socket flaps do not visibly dim the UI.