### PR TITLE
Tighten flower API and dress location/footer/empty states

### DIFF
--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -600,8 +600,6 @@ defmodule EdenflowersWeb.CoreComponents do
   end
 
   @flower_paths Path.wildcard(Path.join(File.cwd!(), "priv/svg/flower-*.svg")) |> Enum.sort()
-  @flower_names Enum.map(@flower_paths, &Path.basename(&1, ".svg"))
-  @flower_count length(@flower_names)
 
   @flowers (for path <- @flower_paths, into: %{} do
               raw = File.read!(path)
@@ -628,22 +626,20 @@ defmodule EdenflowersWeb.CoreComponents do
   Renders a hand-drawn botanical illustration inline.
 
   Tailwind classes drive size (e.g. `h-10 w-10`) and color (e.g. `text-forest-content`),
-  since the SVG paths use `fill:currentColor`. Selection is deterministic from
-  `seed` — same seed always yields the same drawing — or pass an explicit `name`
-  like `"flower-09"` to pin one. The source SVGs ship in the repo at `priv/svg/`
-  and are inlined at compile time.
+  since the SVG paths use `fill:currentColor`. Pass `name` to pick a specific
+  drawing — the source SVGs ship in the repo at `priv/svg/` and are inlined at
+  compile time.
 
   ## Examples
 
-      <.flower seed="cart-empty" class="h-32 w-32 text-primary/80" />
+      <.flower name="flower-30" class="h-32 w-32 text-primary/80" />
       <.flower name="flower-09" class="h-10 w-10 text-forest-content/70" />
   """
-  attr :seed, :any, default: nil
-  attr :name, :string, default: nil, values: [nil | @flower_names]
+  attr :name, :string, required: true, values: Map.keys(@flowers)
   attr :class, :any, default: "h-6 w-6"
 
   def flower(assigns) do
-    %{viewbox: viewbox, body: body} = Map.fetch!(@flowers, assigns.name || flower_pick(assigns.seed))
+    %{viewbox: viewbox, body: body} = Map.fetch!(@flowers, assigns.name)
     assigns = assign(assigns, viewbox: viewbox, body: body)
 
     ~H"""
@@ -658,9 +654,6 @@ defmodule EdenflowersWeb.CoreComponents do
     </svg>
     """
   end
-
-  defp flower_pick(nil), do: "flower-01"
-  defp flower_pick(seed), do: Enum.at(@flower_names, :erlang.phash2(seed, @flower_count))
 
   @doc """
   Renders a product card used by both the Featured Blooms carousel (home)

--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -346,8 +346,12 @@ defmodule EdenflowersWeb.Layouts do
     </main>
 
     <footer>
-      <div class="bg-cream border-t border-b">
-        <div class="container py-20 md:py-36">
+      <div class="bg-cream relative overflow-hidden border-t border-b">
+        <.flower
+          name="flower-41"
+          class="text-base-content/15 pointer-events-none absolute top-6 right-6 h-20 w-20 md:top-10 md:right-10 md:h-28 md:w-28"
+        />
+        <div class="container relative py-20 md:py-36">
           <div class="footer-grid">
             <div class="footer-grid__newsletter space-y-4">
               <.live_component id="newsletter-signup-form" module={EdenflowersWeb.NewsletterSignupForm} />

--- a/lib/edenflowers_web/components/line_items_component.ex
+++ b/lib/edenflowers_web/components/line_items_component.ex
@@ -113,7 +113,7 @@ defmodule EdenflowersWeb.LineItemsComponent do
         </ul>
       <% else %>
         <div class="flex flex-col items-center gap-5 py-10 text-center">
-          <.flower seed="cart-empty" class="text-primary/70 h-20 w-20" />
+          <.flower name="flower-30" class="text-primary/70 h-20 w-20" />
           <p class="font-serif text-lg">{~t"Your cart is empty."}</p>
           <.button navigate={~p"/store"}>{~t"Browse the store"}</.button>
         </div>

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -92,7 +92,11 @@ defmodule EdenflowersWeb.HomeLive do
         </div>
       </section>
 
-      <section class="bg-cream not-last:border-b" aria-labelledby="location-heading">
+      <section class="bg-cream relative overflow-hidden not-last:border-b" aria-labelledby="location-heading">
+        <.flower
+          name="flower-41"
+          class="text-base-content/15 pointer-events-none absolute top-4 left-4 h-16 w-16 md:top-8 md:left-8 md:h-24 md:w-24"
+        />
         <div class="grid md:grid-cols-2">
           <div class="flex flex-col px-4 pt-16 pb-8 sm:px-8 md:justify-center md:px-12 md:py-20 lg:px-20">
             <p class="eyebrow text-base-content/60 mb-4">{~t"Where to find us"}</p>
@@ -124,7 +128,7 @@ defmodule EdenflowersWeb.HomeLive do
       <%!-- Pull quote --%>
       <section class="bg-forest not-last:border-b">
         <div class="container flex flex-col items-center gap-10 py-24 md:py-32">
-          <.flower seed="pull-quote" class="text-forest-content/70 h-12 w-12" />
+          <.flower name="flower-30" class="text-forest-content/70 h-12 w-12" />
           <blockquote class="pull-quote text-forest-content max-w-4xl text-center">
             {~t"Crafted for those with discerning taste — flowers that blend quality and style and arrive perfectly arranged at your door."}
           </blockquote>

--- a/lib/edenflowers_web/live/store_live.ex
+++ b/lib/edenflowers_web/live/store_live.ex
@@ -77,7 +77,7 @@ defmodule EdenflowersWeb.StoreLive do
 
         <%= if Enum.empty?(@products) do %>
           <div class="bg-cream flex flex-col items-center gap-5 rounded-lg px-8 py-20 text-center sm:py-24">
-            <.flower seed={@selected_category.slug} class="text-primary/80 h-20 w-20" />
+            <.flower name="flower-42" class="text-primary/80 h-20 w-20" />
             <h3 class="section-title text-primary">{~t"Fresh stems on the way"}</h3>
             <p class="text-base-content/75 max-w-md leading-relaxed">
               {~t"This collection is being refreshed. Check back shortly — or browse another category in the meantime."}


### PR DESCRIPTION
## Summary
- Drop `seed` from `<.flower>` and its `flower_pick/1` helpers. Make `name` required and validate against the compile-time `@flowers` map keys so typos surface at compile time, not as `Map.fetch!` crashes at render.
- Switch existing seed-based callsites to explicit names (cart empty → `flower-30`, pull-quote → `flower-30`, empty store → `flower-42`).
- Add botanical accents to the footer surface (top-right, `flower-41`) and the home location section (top-left, `flower-41`), absolute-positioned at 15% opacity with `pointer-events-none` on a `relative overflow-hidden` parent.

## Why drop `seed`?
In #173 the `seed` attribute produced a deterministic-but-arbitrary choice via `:erlang.phash2` over the SVG filename list. Every real caller actually wanted a *specific* drawing, and the indirection meant the chosen flower silently drifted whenever a new SVG was added to `priv/svg/` (the phash2 modulus changed). Explicit names are clearer and more stable.

## Test plan
- [ ] Confirm cart-empty state shows the expected `flower-30` illustration.
- [ ] Confirm pull-quote section on home shows `flower-30`.
- [ ] Confirm empty store category shows `flower-42` (no longer drifts when categories change).
- [ ] Confirm footer accent (`flower-41`) is visible top-right on cream surface, scales correctly at sm/md breakpoints, does not overflow.
- [ ] Confirm home location accent (`flower-41`) is visible top-left, does not interfere with the map image.
- [ ] Try a typo (`name="flower-99"`) locally and confirm compile fails (validates `values:` constraint).