### PR TITLE
Move map fetch to Imgproxy local root, bump source for HiDPI

### DIFF
--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -108,14 +108,14 @@ defmodule EdenflowersWeb.HomeLive do
             src={
               "local:///home-vaasa-map.png"
               |> Imgproxy.new()
-              |> Imgproxy.resize(800, 940, type: "fill")
+              |> Imgproxy.resize(1600, 1880, type: "fill")
               |> Imgproxy.set_extension("webp")
               |> to_string()
             }
             alt={~t"Map of Vaasa, Finland showing Eden Flowers' location at Kauppapuistikko 21"}
             loading="lazy"
-            width="800"
-            height="940"
+            width="1600"
+            height="1880"
             class="aspect-[6/7] max-h-[520px] h-full w-full object-cover md:aspect-auto"
           />
         </div>

--- a/lib/mix/tasks/eden.fetch_map.ex
+++ b/lib/mix/tasks/eden.fetch_map.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Eden.FetchMap do
   @moduledoc """
   Fetches the Vaasa location map from Mapbox Static Images API and writes it to
-  `priv/static/images/home-vaasa-map.png`.
+  `images/home-vaasa-map.png`, the Imgproxy local-storage source.
 
   ## Why a Mix task
 
@@ -22,17 +22,19 @@ defmodule Mix.Tasks.Eden.FetchMap do
 
   @shortdoc "Fetch the Vaasa location map from Mapbox"
 
-  # Composition spec — keep in sync with the HEEx comment in home_live.ex.
+  # Composition spec. Dimensions are the Mapbox source; the render aspect is
+  # preserved (1097:1280 ≈ 800:940) so Imgproxy can pure-downscale to any DPR
+  # without re-cropping.
   @longitude 21.6165
   @latitude 63.0951
   @zoom 10
-  @width 800
-  @height 940
+  @width 1097
+  @height 1280
   @style "davemccrea/cmp1rbxej001201r0c0z808jo"
   # `pin-s` is Mapbox's small built-in pin. Color is hex without `#`.
   # Honey approximates --color-link-underline.
   @marker_color "E8B33C"
-  @output_path "priv/static/images/home-vaasa-map.png"
+  @output_path "images/home-vaasa-map.png"
 
   @impl Mix.Task
   def run(_args) do


### PR DESCRIPTION
## Summary
- Move `mix eden.fetch_map` output from `priv/static/images/home-vaasa-map.png` to `images/home-vaasa-map.png`, which is Imgproxy's actual local-storage root — the path `local:///home-vaasa-map.png` in `home_live.ex` resolves against.
- Bump source dimensions from 800x940 to **1097x1280** to give Imgproxy more pixels to downscale from. The 1097:1280 aspect ratio preserves the 800:940 render aspect so `resize(_, _, type: "fill")` does a clean downscale at any DPR — never re-crops.
- Bump the resize/width/height in `home_live.ex` to 1600x1880 so the rendered `<img>` is crisp at 2x DPR (browser packs 1600 device pixels into the rendered 800px box).

## Why ship these together
The source-image bump and the render bump are paired — landing one without the other puts the page in a transient inconsistent state (either oversized blurry upscaling or undersized waste). Shipping as one PR avoids that window.

## Test plan
- [ ] Run `mix eden.fetch_map` locally and confirm output lands at `images/home-vaasa-map.png`.
- [ ] Confirm Imgproxy serves the new map via `local:///home-vaasa-map.png` in dev.
- [ ] Inspect the home location map at 1x and 2x DPR (Chrome devtools) and confirm no blurring.
- [ ] Confirm the rendered aspect (max-h-[520px] aspect-[6/7]) still matches the source render, no letterboxing or stretching.
- [ ] Confirm no other code references the old `priv/static/images/home-vaasa-map.png` path.