### PR TITLE
Close cart drawer when empty-cart CTA navigates away

### DIFF
--- a/lib/edenflowers_web/components/line_items_component.ex
+++ b/lib/edenflowers_web/components/line_items_component.ex
@@ -115,7 +115,9 @@ defmodule EdenflowersWeb.LineItemsComponent do
         <div class="flex flex-col items-center gap-5 py-10 text-center">
           <.flower seed="cart-empty" class="text-primary/70 h-20 w-20" />
           <p class="font-serif text-lg">{~t"Your cart is empty."}</p>
-          <.button navigate={~p"/store"}>{~t"Browse the store"}</.button>
+          <.button navigate={~p"/store"} phx-click={JS.exec("phx-hide", to: "#cart-drawer")}>
+            {~t"Browse the store"}
+          </.button>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary
The empty-state "Browse the store" button was missing the `phx-click={JS.exec("phx-hide", to: "#cart-drawer")}` pattern used elsewhere in the drawer, so the drawer's `overflow-hidden` lock on `<html>` was never cleared and the destination page (e.g. `/store`) was stuck unscrollable until a manual interaction unlocked it.

Same class of bug as #174, in a code path added later by #173.

## Test plan
- [ ] Open cart drawer with no items.
- [ ] Click "Browse the store" — confirm the drawer closes during the navigation, not after.
- [ ] Confirm the destination page (/store) is scrollable immediately.
- [ ] Repeat with keyboard activation (Enter on the button) to confirm the JS.exec fires on keyboard too.