### PR TITLE
Add responsive <.image> component and migrate all call sites

### DIFF
--- a/lib/edenflowers_web/components/core_components.ex
+++ b/lib/edenflowers_web/components/core_components.ex
@@ -656,6 +656,197 @@ defmodule EdenflowersWeb.CoreComponents do
   end
 
   @doc """
+  Renders an optimised responsive image through the configured Imgproxy server.
+
+  `width`/`height` are the **CSS pixel** dimensions the image will occupy on
+  screen — the component automatically emits a `srcset` covering 1×, 1.5×, and
+  2× so retina displays get a crisp source without callers having to remember
+  the rule.
+
+  Output is a `<picture>` with a WebP `<source>` and the original-format `<img>`
+  as fallback. When `priority` is set the image becomes a LCP candidate
+  (`loading="eager"`, `fetchpriority="high"`). Default for non-priority is
+  `loading="lazy"` + `decoding="async"`.
+
+  ## Art direction
+
+  Pass `sources` to swap crops per breakpoint — this replaces the legacy
+  pattern of two `<img>` tags toggled with `hidden`/`block` Tailwind classes:
+
+      <.image
+        src={@product.image_slug}
+        alt=""
+        width={600}
+        height={750}
+        sources={[%{media: "(min-width: 640px)", width: 600, height: 600}]}
+        sizes="(min-width: 640px) 25vw, 50vw"
+      />
+
+  ## Bypass cases
+
+  Three sources skip the `<picture>` + `srcset` machinery:
+
+    * SVGs (no point rasterising to WebP)
+    * External URLs (no `local:///` prefix — passes through unchanged so
+      placeholder images keep working)
+    * Tiny images (`width <= 64` with no `sources`) — emits a single 2× source
+
+  ## Examples
+
+      <.image src="local:///hero.jpg" alt="" width={1920} height={1080} priority />
+      <.image src={@product.image_slug} alt={@product.name} width={1000} height={1250} priority />
+      <.image src={@slug} alt={~t"Map"} width={1600} height={1880} sizes="(min-width: 768px) 50vw, 100vw" />
+  """
+  attr :src, :string, required: true
+  attr :alt, :string, required: true
+  attr :width, :integer, required: true
+  attr :height, :integer, required: true
+  attr :sizes, :string, default: "100vw"
+  attr :priority, :boolean, default: false
+  attr :crop_type, :string, default: "fill", values: ~w(fit fill auto)
+  attr :format, :atom, default: :webp, values: [:webp, :original]
+  attr :quality, :integer, default: 80
+  attr :sources, :list, default: []
+  attr :class, :any, default: nil
+  attr :rest, :global, include: ~w(id data-testid)
+
+  def image(assigns) do
+    cond do
+      svg_src?(assigns.src) ->
+        render_passthrough(assigns, Imgproxy.new(assigns.src) |> to_string())
+
+      external_src?(assigns.src) ->
+        render_passthrough(assigns, assigns.src)
+
+      assigns.width <= 64 and assigns.sources == [] ->
+        render_tiny(assigns)
+
+      true ->
+        render_picture(assigns)
+    end
+  end
+
+  defp svg_src?(src), do: Path.extname(src) |> String.downcase() == ".svg"
+
+  defp external_src?(src),
+    do: not String.starts_with?(src, "local:///")
+
+  defp render_passthrough(assigns, url) do
+    assigns = assign(assigns, :resolved_src, url)
+
+    ~H"""
+    <img
+      src={@resolved_src}
+      alt={@alt}
+      width={@width}
+      height={@height}
+      loading={if @priority, do: "eager", else: "lazy"}
+      decoding="async"
+      fetchpriority={if @priority, do: "high"}
+      class={@class}
+      {@rest}
+    />
+    """
+  end
+
+  defp render_tiny(assigns) do
+    url =
+      assigns.src
+      |> imgproxy_resize(assigns.width * 2, assigns.height * 2, assigns.crop_type, assigns.quality)
+      |> maybe_extension(assigns.format)
+      |> to_string()
+
+    render_passthrough(assigns, url)
+  end
+
+  defp render_picture(assigns) do
+    base_variants =
+      build_variants(assigns.src, assigns.width, assigns.height, assigns.crop_type, assigns.quality)
+
+    art_directed =
+      Enum.map(assigns.sources, fn source ->
+        crop = Map.get(source, :crop_type, assigns.crop_type)
+
+        %{
+          media: Map.fetch!(source, :media),
+          variants: build_variants(assigns.src, source.width, source.height, crop, assigns.quality)
+        }
+      end)
+
+    fallback_src = base_variants |> hd() |> Map.fetch!(:url)
+
+    assigns =
+      assign(assigns,
+        base_variants: base_variants,
+        art_directed: art_directed,
+        fallback_src: fallback_src
+      )
+
+    ~H"""
+    <picture>
+      <%= for ad <- @art_directed do %>
+        <%= if @format == :webp do %>
+          <source
+            type="image/webp"
+            media={ad.media}
+            srcset={srcset(ad.variants, :webp)}
+            sizes={@sizes}
+          />
+        <% end %>
+        <source media={ad.media} srcset={srcset(ad.variants, :original)} sizes={@sizes} />
+      <% end %>
+      <source :if={@format == :webp} type="image/webp" srcset={srcset(@base_variants, :webp)} sizes={@sizes} />
+      <img
+        src={@fallback_src}
+        srcset={srcset(@base_variants, :original)}
+        sizes={@sizes}
+        alt={@alt}
+        width={@width}
+        height={@height}
+        loading={if @priority, do: "eager", else: "lazy"}
+        decoding="async"
+        fetchpriority={if @priority, do: "high"}
+        class={@class}
+        {@rest}
+      />
+    </picture>
+    """
+  end
+
+  # Emits 1×, 1.5×, and 2× variants of the declared CSS-pixel size, capped at
+  # 3840w. Below 320w we skip 1.5× — the visible gain is marginal and the
+  # source asset may not be that large.
+  defp build_variants(src, width, height, crop_type, quality) do
+    multipliers = if width <= 320, do: [1.0, 2.0], else: [1.0, 1.5, 2.0]
+
+    multipliers
+    |> Enum.map(fn m ->
+      w = min(round(width * m), 3840)
+      h = min(round(height * m), 3840)
+      img = imgproxy_resize(src, w, h, crop_type, quality)
+      %{width: w, base_url: to_string(img), webp_url: img |> Imgproxy.set_extension("webp") |> to_string()}
+    end)
+    |> Enum.uniq_by(& &1.width)
+    |> Enum.map(&Map.put(&1, :url, &1.base_url))
+  end
+
+  defp imgproxy_resize(src, width, height, crop_type, quality) do
+    src
+    |> Imgproxy.new()
+    |> Imgproxy.resize(width, height, type: crop_type)
+    |> Imgproxy.add_option(:q, [quality])
+  end
+
+  defp maybe_extension(img, :webp), do: Imgproxy.set_extension(img, "webp")
+  defp maybe_extension(img, :original), do: img
+
+  defp srcset(variants, :webp),
+    do: variants |> Enum.map_join(", ", &"#{&1.webp_url} #{&1.width}w")
+
+  defp srcset(variants, :original),
+    do: variants |> Enum.map_join(", ", &"#{&1.base_url} #{&1.width}w")
+
+  @doc """
   Renders a product card used by both the Featured Blooms carousel (home)
   and the Store grid. One editorial treatment, no surface chrome — the
   photograph is the card; the only interactive accent is the brand
@@ -674,17 +865,14 @@ defmodule EdenflowersWeb.CoreComponents do
     ~H"""
     <.link navigate={@navigate} class={["group block focus:outline-none", @class]}>
       <figure class="bg-cream aspect-[4/5] relative mb-4 overflow-hidden sm:aspect-square">
-        <img
-          src={@product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 750, type: "fill") |> to_string()}
+        <.image
+          src={@product.image_slug}
           alt=""
-          loading="lazy"
-          class="block h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.04] sm:hidden"
-        />
-        <img
-          src={@product.image_slug |> Imgproxy.new() |> Imgproxy.resize(600, 600, type: "fill") |> to_string()}
-          alt=""
-          loading="lazy"
-          class="hidden h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.04] sm:block"
+          width={600}
+          height={750}
+          sources={[%{media: "(min-width: 640px)", width: 600, height: 600}]}
+          sizes="(min-width: 640px) 25vw, 50vw"
+          class="h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.04]"
         />
       </figure>
 
@@ -717,10 +905,13 @@ defmodule EdenflowersWeb.CoreComponents do
   def category_tile(assigns) do
     ~H"""
     <.link navigate={@navigate} class="group relative overflow-hidden">
-      <img
+      <.image
         src={@image_src}
-        class="h-72 w-full object-cover transition duration-500 group-hover:scale-102 sm:h-80 md:h-96"
         alt={@label}
+        width={800}
+        height={400}
+        sizes="(min-width: 768px) 33vw, 100vw"
+        class="h-72 w-full object-cover transition duration-500 group-hover:scale-102 sm:h-80 md:h-96"
       />
       <div class="absolute inset-0 transition duration-500 group-hover:bg-black/10" />
       <div class="absolute inset-0 flex items-end p-6">
@@ -733,6 +924,10 @@ defmodule EdenflowersWeb.CoreComponents do
   attr :size, :integer, default: 5
 
   def social_media_links(assigns) do
+    # @size is a Tailwind scale step; multiply by 4 to get CSS pixels
+    # (h-5 = 20px, h-8 = 32px). Stays below the 64px tiny-icon threshold.
+    assigns = assign(assigns, :px, assigns.size * 4)
+
     ~H"""
     <div class="flex flex-row gap-4">
       <a
@@ -741,15 +936,12 @@ defmodule EdenflowersWeb.CoreComponents do
         rel="noopener noreferrer"
         aria-label="Eden Flowers on Facebook"
       >
-        <img
-          class={"h-#{@size} w-#{@size}"}
-          src={
-            "local:///facebook_logo_bw_128px.png"
-            |> Imgproxy.new()
-            |> Imgproxy.resize(128, 128, type: "fill")
-            |> to_string()
-          }
+        <.image
+          src="local:///facebook_logo_bw_128px.png"
           alt=""
+          width={@px}
+          height={@px}
+          class={"h-#{@size} w-#{@size}"}
         />
       </a>
       <a
@@ -758,15 +950,12 @@ defmodule EdenflowersWeb.CoreComponents do
         rel="noopener noreferrer"
         aria-label="Eden Flowers on Instagram"
       >
-        <img
-          class={"h-#{@size} w-#{@size}"}
-          src={
-            "local:///instagram_logo_bw_128px.png"
-            |> Imgproxy.new()
-            |> Imgproxy.resize(128, 128, type: "fill")
-            |> to_string()
-          }
+        <.image
+          src="local:///instagram_logo_bw_128px.png"
           alt=""
+          width={@px}
+          height={@px}
+          class={"h-#{@size} w-#{@size}"}
         />
       </a>
     </div>

--- a/lib/edenflowers_web/components/line_items_component.ex
+++ b/lib/edenflowers_web/components/line_items_component.ex
@@ -18,21 +18,23 @@ defmodule EdenflowersWeb.LineItemsComponent do
                 navigate={~p"/product/#{line_item.product_id}"}
                 class="shrink-0 transition-opacity hover:opacity-70"
               >
-                <img
-                  class="h-20 w-20 object-cover"
-                  src={
-                    line_item.product_image_slug |> Imgproxy.new() |> Imgproxy.resize(160, 160, type: "fill") |> to_string()
-                  }
+                <.image
+                  src={line_item.product_image_slug}
                   alt={"Image of #{line_item.product_name}"}
+                  width={80}
+                  height={80}
+                  sizes="80px"
+                  class="h-20 w-20 object-cover"
                 />
               </.link>
             <% else %>
-              <img
-                class="h-20 w-20 object-cover"
-                src={
-                  line_item.product_image_slug |> Imgproxy.new() |> Imgproxy.resize(160, 160, type: "fill") |> to_string()
-                }
+              <.image
+                src={line_item.product_image_slug}
                 alt={"Image of #{line_item.product_name}"}
+                width={80}
+                height={80}
+                sizes="80px"
+                class="h-20 w-20 object-cover"
               />
             <% end %>
 

--- a/lib/edenflowers_web/live/about_live.ex
+++ b/lib/edenflowers_web/live/about_live.ex
@@ -12,15 +12,13 @@ defmodule EdenflowersWeb.AboutLive do
     <Layouts.app current_user={@current_user} order={@order} flash={@flash} current_path={@current_path}>
       <%!-- Hero --%>
       <section class="relative not-last:border-b">
-        <img
-          src={
-            "local:///image_4.jpg"
-            |> Imgproxy.new()
-            |> Imgproxy.resize(1920, 600, type: "fill")
-            |> to_string()
-          }
-          class="h-64 w-full object-cover sm:h-80 md:h-96"
+        <.image
+          src="local:///image_4.jpg"
           alt=""
+          width={1920}
+          height={600}
+          priority
+          class="h-64 w-full object-cover sm:h-80 md:h-96"
         />
         <div class="bg-black/30 absolute inset-0 flex items-end">
           <div class="container pb-10">
@@ -38,16 +36,13 @@ defmodule EdenflowersWeb.AboutLive do
             <%!-- Circular portrait --%>
             <div class="flex-shrink-0">
               <div class="h-56 w-56 overflow-hidden rounded-full sm:h-64 sm:w-64 md:h-72 md:w-72">
-                <img
-                  src={
-                    "local:///jennie_pregnant.jpg"
-                    |> Imgproxy.new()
-                    |> Imgproxy.resize(400, 400, type: "fill")
-                    |> Imgproxy.set_extension("webp")
-                    |> to_string()
-                  }
-                  class="h-full w-full object-cover"
+                <.image
+                  src="local:///jennie_pregnant.jpg"
                   alt="Jennie"
+                  width={288}
+                  height={288}
+                  sizes="288px"
+                  class="h-full w-full object-cover"
                 />
               </div>
             </div>
@@ -68,16 +63,12 @@ defmodule EdenflowersWeb.AboutLive do
 
       <%!-- Full-bleed image --%>
       <section class="not-last:border-b">
-        <img
-          src={
-            "local:///image_5.jpg"
-            |> Imgproxy.new()
-            |> Imgproxy.resize(1920, 800, type: "fill")
-            |> Imgproxy.set_extension("webp")
-            |> to_string()
-          }
-          class="h-72 w-full object-cover sm:h-96 md:h-[480px]"
+        <.image
+          src="local:///image_5.jpg"
           alt=""
+          width={1920}
+          height={800}
+          class="h-72 w-full object-cover sm:h-96 md:h-[480px]"
         />
       </section>
 

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -169,14 +169,12 @@ defmodule EdenflowersWeb.CheckoutLive do
                                     data-testid="card-image-button"
                                     title={gettext("Change card")}
                                   >
-                                    <img
-                                      src={
-                                        card_line_item.product_image_slug
-                                        |> Imgproxy.new()
-                                        |> Imgproxy.resize(160, 160, type: "fill")
-                                        |> to_string()
-                                      }
+                                    <.image
+                                      src={card_line_item.product_image_slug}
                                       alt={card_line_item.product_name}
+                                      width={80}
+                                      height={80}
+                                      sizes="80px"
                                       class="h-20 w-20 object-cover transition-opacity hover:opacity-70"
                                     />
                                   </button>
@@ -442,14 +440,12 @@ defmodule EdenflowersWeb.CheckoutLive do
                 class="border-base-300 flex flex-col items-center gap-1 border p-2 hover:bg-base-200"
                 data-testid={"card-option-#{variant.id}"}
               >
-                <img
-                  src={
-                    variant.image_slug
-                    |> Imgproxy.new()
-                    |> Imgproxy.resize(200, 200, type: "fill")
-                    |> to_string()
-                  }
+                <.image
+                  src={variant.image_slug}
                   alt={variant.product.name}
+                  width={96}
+                  height={96}
+                  sizes="96px"
                   class="h-24 w-24 object-cover"
                 />
                 <span class="text-sm">{variant.product.name}</span>

--- a/lib/edenflowers_web/live/home_live.ex
+++ b/lib/edenflowers_web/live/home_live.ex
@@ -15,10 +15,13 @@ defmodule EdenflowersWeb.HomeLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash} current_path={@current_path}>
       <section class="relative overflow-hidden not-last:border-b">
-        <img
-          src={"local:///image_1.jpg" |> Imgproxy.new() |> Imgproxy.resize(1920, 1080, type: "fill") |> to_string()}
-          class="h-[100vh] w-full object-cover"
+        <.image
+          src="local:///image_1.jpg"
           alt=""
+          width={1920}
+          height={1080}
+          priority
+          class="h-[100vh] w-full object-cover"
         />
 
         <div class="container absolute inset-0 flex flex-col justify-end pb-20 sm:pb-28 md:justify-center md:pb-0">
@@ -108,18 +111,12 @@ defmodule EdenflowersWeb.HomeLive do
             </p>
           </div>
 
-          <img
-            src={
-              "local:///home-vaasa-map.png"
-              |> Imgproxy.new()
-              |> Imgproxy.resize(1600, 1880, type: "fill")
-              |> Imgproxy.set_extension("webp")
-              |> to_string()
-            }
+          <.image
+            src="local:///home-vaasa-map.png"
             alt={~t"Map of Vaasa, Finland showing Eden Flowers' location at Kauppapuistikko 21"}
-            loading="lazy"
-            width="1600"
-            height="1880"
+            width={1600}
+            height={1880}
+            sizes="(min-width: 768px) 50vw, 100vw"
             class="aspect-[6/7] max-h-[520px] h-full w-full object-cover md:aspect-auto"
           />
         </div>

--- a/lib/edenflowers_web/live/maternity_live.ex
+++ b/lib/edenflowers_web/live/maternity_live.ex
@@ -9,23 +9,19 @@ defmodule EdenflowersWeb.MaternityLive do
     ~H"""
     <div class="bg-base-200 flex min-h-screen flex-col">
       <header class="flex justify-center py-8">
-        <img
-          src={
-            "local:///Eden_flowers-logo1_green_web.svg"
-            |> Imgproxy.new()
-            |> to_string()
-          }
+        <.image
+          src="local:///Eden_flowers-logo1_green_web.svg"
+          alt="Eden Flowers"
+          width={160}
+          height={80}
           class="w-40 md:hidden"
-          alt="Eden Flowers"
         />
-        <img
-          src={
-            "local:///Eden_flowers-logo2_green_web.svg"
-            |> Imgproxy.new()
-            |> to_string()
-          }
-          class="hidden w-64 md:block"
+        <.image
+          src="local:///Eden_flowers-logo2_green_web.svg"
           alt="Eden Flowers"
+          width={256}
+          height={80}
+          class="hidden w-64 md:block"
         />
       </header>
 
@@ -36,16 +32,13 @@ defmodule EdenflowersWeb.MaternityLive do
       >
         <div class="flex w-full max-w-4xl flex-col items-center gap-8 md:flex-row md:items-center md:gap-12">
           <div class="order-2 w-full max-w-sm flex-shrink-0 md:order-1 md:w-96">
-            <img
-              src={
-                "local:///jennie_pregnant.jpg"
-                |> Imgproxy.new()
-                |> Imgproxy.resize(800, 1000, type: "fill")
-                |> Imgproxy.set_extension("webp")
-                |> to_string()
-              }
-              class="w-full rounded-md object-cover shadow-md"
+            <.image
+              src="local:///jennie_pregnant.jpg"
               alt="Jennie"
+              width={400}
+              height={500}
+              sizes="(min-width: 768px) 384px, 100vw"
+              class="w-full rounded-md object-cover shadow-md"
             />
           </div>
 

--- a/lib/edenflowers_web/live/product_live.ex
+++ b/lib/edenflowers_web/live/product_live.ex
@@ -48,14 +48,15 @@ defmodule EdenflowersWeb.ProductLive do
           <%!-- Photograph: capped at 480px wide on desktop so it sits at
                a calmer scale; aspect 4:5 matches the mobile grid card. --%>
           <figure class="bg-cream aspect-[4/5] relative overflow-hidden">
-            <img
+            <.image
               data-testid="product-image"
-              src={
-                @selected_variant.image_slug |> Imgproxy.new() |> Imgproxy.resize(1000, 1250, type: "fill") |> to_string()
-              }
+              src={@selected_variant.image_slug}
               alt={"#{@product.name} #{String.capitalize(to_string(@selected_variant.size))}"}
+              width={1000}
+              height={1250}
+              sizes="(min-width: 768px) 480px, 100vw"
+              priority
               class="h-full w-full object-cover"
-              loading="eager"
             />
             <figcaption :if={@product.featured} class="product-mark">
               <span class="product-mark__eyebrow">{~t"Favourite"}</span>


### PR DESCRIPTION
## Summary

- New `<.image>` function component in `core_components.ex` encapsulating Imgproxy URL generation, `srcset` retina variants (1×/1.5×/2×, capped at 3840w), a WebP `<picture>` `<source>` with original-format fallback, art direction via a `sources` attr, and an LCP `priority` flag (`loading="eager"` + `fetchpriority="high"`).
- All 18 existing `<img>` call sites migrated. The product card's dual-`<img>` mobile/desktop crop swap collapses into one art-directed `<picture>`. The homepage hero, About hero, and product detail image are now correctly flagged as LCP priority.
- Three bypass paths keep the component flexible: SVG sources (logos), external URLs (placeholder `https://placehold.co/...` in seeds), and icons ≤64px CSS pixels all emit a single `<img>` without `<picture>`/`srcset` overhead.

### Why now

The existing pattern (`Imgproxy.new() |> Imgproxy.resize(W, H, type: "fill") |> to_string()`) was repeated at every call site, and the codebase had a recurring "remember to 2× the CSS width for retina" rule that's now structurally enforced by the component. The largest single perf win is `fetchpriority="high"` on the homepage hero, which was previously a plain `<img>` with no priority hint.

### Behaviour changes per page

| Page | Before | After |
|---|---|---|
| Home hero | Single 1920×1080 JPG, no priority | `<picture>` with WebP source, 3-variant srcset, `fetchpriority="high"` |
| Featured Blooms card | Two `<img>` tags toggled with `hidden`/`block` (both downloaded by some browsers) | One `<picture>` with `<source media="(min-width: 640px)">` — browser fetches only the matching crop |
| Product detail hero | `loading="eager"` JPG | Full `<picture>` + `priority` |
| Vaasa map, About banners, Jennie portraits | Single fixed-size source | `<picture>` + responsive srcset + WebP fallback |
| Cart/checkout thumbnails | 160×160 PNG at 80 CSS px | WebP `<picture>` with 80w/120w/160w srcset |
| Maternity SVG logos | Two `<img>` toggled with hidden/block | Same toggling, but now via `<.image>` SVG bypass |
| Social icons (Facebook/Instagram) | 128×128 PNG at 20 CSS px | Tiny-icon bypass: single WebP `<img>` at 40px (2× CSS size) |

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test`: 239 tests, 0 failures
- [x] All routes return 200: `/`, `/about`, `/maternity`, `/store/bouquets`, `/contact`, `/product/:id`
- [x] Rendered HTML inspected: `fetchpriority="high"` set exactly once per priority page; WebP `<source>` present in every `<picture>`; external URLs bypass correctly; SVGs bypass correctly
- [ ] Visual smoke-test in browser at 1440px and 360px viewports (reviewer pls verify)
- [ ] DevTools Network: confirm Chrome picks the correct srcset variant per DPR/viewport, and that the hero `image_1.jpg` shows `Priority: High`
- [ ] Lighthouse run on `/` and `/product/:id` — expect ≥200ms LCP improvement

## Follow-ups (not in this PR)

- The dynamic Tailwind class interpolation in `social_media_links` (`h-#{@size} w-#{@size}`) is a pre-existing JIT risk; untouched here.
- If Imgproxy server supports AVIF, adding an AVIF `<source>` before the WebP `<source>` is a one-line change in `image/1`.