### PR TITLE
Extract email templates into Edenflowers.Email.Templates

### DIFF
--- a/lib/edenflowers/email.ex
+++ b/lib/edenflowers/email.ex
@@ -6,45 +6,9 @@ defmodule Edenflowers.Email do
   import Swoosh.Email
   use GettextSigils, backend: EdenflowersWeb.Gettext
 
-  require EEx
+  alias Edenflowers.Email.Templates
 
   @from_address Application.compile_env!(:edenflowers, :mailer_from_address)
-
-  # Compile the template at compile-time so gettext extraction works
-  EEx.function_from_file(
-    :defp,
-    :render_order_confirmation_template,
-    Path.join([__DIR__, "email", "templates", "order_confirmation.text.eex"]),
-    [:assigns]
-  )
-
-  EEx.function_from_file(
-    :defp,
-    :render_newsletter_promo_template,
-    Path.join([__DIR__, "email", "templates", "newsletter_promo.text.eex"]),
-    [:assigns]
-  )
-
-  EEx.function_from_file(
-    :defp,
-    :render_newsletter_already_subscribed_template,
-    Path.join([__DIR__, "email", "templates", "newsletter_already_subscribed.text.eex"]),
-    [:assigns]
-  )
-
-  EEx.function_from_file(
-    :defp,
-    :render_newsletter_resubscribed_template,
-    Path.join([__DIR__, "email", "templates", "newsletter_resubscribed.text.eex"]),
-    [:_assigns]
-  )
-
-  EEx.function_from_file(
-    :defp,
-    :render_otp_sign_in_template,
-    Path.join([__DIR__, "email", "templates", "otp_sign_in.text.eex"]),
-    [:assigns]
-  )
 
   @doc """
   Builds an order confirmation email
@@ -60,14 +24,12 @@ defmodule Edenflowers.Email do
   end
 
   defp render_order_confirmation(order, locale) do
-    assigns = %{
+    Templates.order_confirmation(%{
       order: order,
       format_currency: &format_currency(&1, locale),
       format_date: &format_date(&1, locale),
       format_datetime: &format_datetime(&1, locale)
-    }
-
-    render_order_confirmation_template(assigns)
+    })
   end
 
   def newsletter_promo(email_address, promo_code) do
@@ -75,7 +37,7 @@ defmodule Edenflowers.Email do
     |> from(@from_address)
     |> to(email_address)
     |> subject(~t"Welcome to Eden Flowers — your 15% off code inside")
-    |> text_body(render_newsletter_promo_template(%{promo_code: promo_code}))
+    |> text_body(Templates.newsletter_promo(%{promo_code: promo_code}))
   end
 
   def newsletter_already_subscribed(email_address, promo_code) do
@@ -83,7 +45,7 @@ defmodule Edenflowers.Email do
     |> from(@from_address)
     |> to(email_address)
     |> subject(~t"Your Eden Flowers promo code")
-    |> text_body(render_newsletter_already_subscribed_template(%{promo_code: promo_code}))
+    |> text_body(Templates.newsletter_already_subscribed(%{promo_code: promo_code}))
   end
 
   def newsletter_resubscribed(email_address) do
@@ -91,7 +53,7 @@ defmodule Edenflowers.Email do
     |> from(@from_address)
     |> to(email_address)
     |> subject(~t"Welcome back to the Eden Flowers newsletter")
-    |> text_body(render_newsletter_resubscribed_template(%{}))
+    |> text_body(Templates.newsletter_resubscribed(%{}))
   end
 
   def otp_sign_in(email_address, otp_code) do
@@ -99,7 +61,7 @@ defmodule Edenflowers.Email do
     |> from(@from_address)
     |> to(email_address)
     |> subject(~t"Your Eden Flowers sign-in code")
-    |> text_body(render_otp_sign_in_template(%{otp_code: otp_code}))
+    |> text_body(Templates.otp_sign_in(%{otp_code: otp_code}))
   end
 
   defp format_currency(amount, locale) do

--- a/lib/edenflowers/email/templates.ex
+++ b/lib/edenflowers/email/templates.ex
@@ -1,0 +1,27 @@
+defmodule Edenflowers.Email.Templates do
+  @moduledoc """
+  Plain-text email templates compiled at build time. Each entry in `@templates`
+  becomes a public render function named after the template, so
+  `Edenflowers.Email` can stay focused on building Swoosh envelopes.
+  """
+
+  require EEx
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  @templates [
+    {:order_confirmation, [:assigns]},
+    {:newsletter_promo, [:assigns]},
+    {:newsletter_already_subscribed, [:assigns]},
+    {:newsletter_resubscribed, [:_assigns]},
+    {:otp_sign_in, [:assigns]}
+  ]
+
+  for {name, args} <- @templates do
+    EEx.function_from_file(
+      :def,
+      name,
+      Path.join([__DIR__, "templates", "#{name}.text.eex"]),
+      args
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Stacked on #197. Pulls the five `EEx.function_from_file` calls out of `Edenflowers.Email` into a dedicated `Edenflowers.Email.Templates` module that compiles each `.text.eex` into a same-named public function via a single comprehension. `Edenflowers.Email` now just builds Swoosh envelopes and calls `Templates.<name>(assigns)`.

Behaviour is unchanged:
- Same templates, same plain-text output, same `gettext` extraction (the `.po` references already point at `.text.eex` line numbers, not the host module).
- `newsletter_resubscribed` still takes its placeholder `_assigns` arg name to avoid an unused-variable warning, since that template doesn't interpolate anything.

This is the "tidy-up" PR that was flagged during review of #197 as a candidate for separation. Merge order doesn't matter — once #197 merges, this one's base will rebase automatically.

## Test plan

- [ ] Compile: `mix compile` — confirms both modules wire up
- [ ] `mix test test/edenflowers/workers/send_otp_email_test.exs test/edenflowers/workers/send_newsletter_promo_email_test.exs test/edenflowers_web/live/checkout_happy_path_test.exs` — exercises every template path
- [ ] `mix gettext.extract --check-up-to-date` — confirms the .po references still resolve cleanly
- [ ] Touch one `.text.eex` file and confirm the host module recompiles (`function_from_file` registers `@external_resource`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyZYPUH5p5CR6CKJcUJGKX)_