### PR TITLE
Receipt integration plan and Typst schema update

### DIFF
--- a/docs/receipt-integration-plan.md
+++ b/docs/receipt-integration-plan.md
@@ -42,6 +42,28 @@ snapshots land.
 - `priv/receipts/fonts/` is gitignored — vendor the static weights or
   run `fetch_fonts.sh` during image build so they're present at runtime.
 
+## Persistence
+
+Render once at placement and write the PDF to disk; never regenerate.
+The deploy target is bare metal, so a local folder is the simplest
+durable option — no object storage needed.
+
+- **Path** — configurable, defaulting to e.g.
+  `/var/lib/edenflowers/receipts/`. Outside the release directory so
+  deploys don't wipe or shadow it.
+- **Layout** — shard by year/month: `2026/05/EF-2026-00428.pdf`.
+  Avoids one giant flat directory, easier to prune.
+- **Write-once** — never overwrite. The file is the canonical artifact
+  that was emailed; matches #158's immutability story.
+- **Serving** — through a Phoenix controller that re-authorises against
+  the order, not via static file serving. Otherwise anyone who guesses
+  an `EF-2026-…` reference downloads someone else's receipt.
+- **Backups** — the receipts folder must be in the backup scope
+  alongside Postgres. Call this out in the deploy runbook.
+
+Keeps the email attachment, the customer-support reprint, and the VAT
+audit trail all reading from the same on-disk file.
+
 ## Tests
 
 - `Edenflowers.ReceiptTest` — golden test: marshal a fixture order, diff

--- a/docs/receipt-integration-plan.md
+++ b/docs/receipt-integration-plan.md
@@ -1,0 +1,60 @@
+# Receipt PDF integration plan
+
+Wires the Typst template from #193 into the order confirmation email.
+
+**Blocked on #158** (immutable orders ADR). Receipts are the canonical
+snapshot of a placed order; the JSON payload should read from snapshot
+fields, not live joins through `:line_items` / `:promotion` / aggregates.
+Building against today's shape means rewriting the mapping when
+snapshots land.
+
+## Pieces to add
+
+1. **`Edenflowers.Receipt`** — single public `generate/1` taking a loaded
+   order. Marshals to the JSON shape in `priv/receipts/sample/order.*.json`
+   (all values pre-formatted strings; `lang` from `order.locale`). Shells
+   out:
+
+   ```
+   typst compile priv/receipts/main.typ - \
+     --input order=<json> \
+     --font-path priv/receipts/fonts
+   ```
+
+   Returns `{:ok, pdf_binary}` from stdout, `{:error, reason}` on non-zero
+   exit. No tempfiles.
+
+2. **Hook into `Email.order_confirmation/1`** (`lib/edenflowers/email.ex`).
+   After #198 lands this is a thin envelope builder; pipe the result
+   through `Swoosh.Email.attachment/2` with filename
+   `eden-flowers-#{order.reference}.pdf`. Single call site, no worker
+   changes — `SendOrderConfirmationEmail` already loads every aggregate
+   the payload needs.
+
+3. **Formatting helpers** — per-line `unit_price_ex_vat` derives from
+   `unit_price` and `tax_rate`; currency and dates use the existing CLDR
+   helpers. Keep formatting in one private module so the Typst side stays
+   locale-agnostic.
+
+## Deployment
+
+- Add `typst` to the runtime image (`Dockerfile`).
+- `priv/receipts/fonts/` is gitignored — vendor the static weights or
+  run `fetch_fonts.sh` during image build so they're present at runtime.
+
+## Tests
+
+- `Edenflowers.ReceiptTest` — golden test: marshal a fixture order, diff
+  the JSON against `priv/receipts/sample/order.en.json`. Skip the
+  `typst` shell-out in CI unless the binary is present.
+- Extend `checkout_happy_path_test.exs` to assert the delivered email
+  carries one PDF attachment with the expected filename.
+
+## Open questions for after #158
+
+- Which snapshot fields exist on the placed Order, and do they cover
+  every value the JSON payload needs (per-line VAT rate, promotion
+  amount, fulfillment tax)?
+- Does the snapshot store pre-formatted strings, or does the receipt
+  module format at render time? Affects whether currency/date helpers
+  live in `Receipt` or upstream.

--- a/docs/receipt-integration-plan.md
+++ b/docs/receipt-integration-plan.md
@@ -2,11 +2,11 @@
 
 Wires the Typst template from #193 into the order confirmation email.
 
-**Blocked on #158** (immutable orders ADR). Receipts are the canonical
-snapshot of a placed order; the JSON payload should read from snapshot
-fields, not live joins through `:line_items` / `:promotion` / aggregates.
-Building against today's shape means rewriting the mapping when
-snapshots land.
+Previously blocked on #158 (immutable-orders ADR); the implementation
+of that ADR landed in #201, and #198 collapsed `Email.order_confirmation/1`
+into a thin envelope builder. Both upstream dependencies are now in main.
+See the "Snapshot field map" section for the concrete fields the JSON
+payload should read.
 
 ## Pieces to add
 
@@ -25,22 +25,74 @@ snapshots land.
    exit. No tempfiles.
 
 2. **Hook into `Email.order_confirmation/1`** (`lib/edenflowers/email.ex`).
-   After #198 lands this is a thin envelope builder; pipe the result
-   through `Swoosh.Email.attachment/2` with filename
-   `eden-flowers-#{order.reference}.pdf`. Single call site, no worker
+   Already a thin envelope builder after #198; pipe the result through
+   `Swoosh.Email.attachment/2` with filename
+   `eden-flowers-#{order.order_reference}.pdf`. Single call site, no worker
    changes — `SendOrderConfirmationEmail` already loads every aggregate
-   the payload needs.
+   the payload needs (and after #201 it can drop the `:promotion` and
+   `fulfillment_option: [:tax_rate]` loads in favour of the snapshot
+   columns).
 
 3. **Formatting helpers** — per-line `unit_price_ex_vat` derives from
    `unit_price` and `tax_rate`; currency and dates use the existing CLDR
-   helpers. Keep formatting in one private module so the Typst side stays
-   locale-agnostic.
+   helpers already living in `Edenflowers.Email` (`format_currency/2`,
+   `format_date/2`, `format_datetime/2`). Move them to a shared module
+   (e.g. `Edenflowers.Localize.Format`) so both `Email` and `Receipt`
+   call the same helpers and the Typst side stays locale-agnostic.
+
+## JSON payload shape (post-#201)
+
+The receipt JSON keys mirror the Ash attribute names 1:1 — flat
+structure, no editorial grouping. The Typst template reads each key
+directly. No live joins to `Promotion` or `FulfillmentOption` are
+needed; every value comes from the placed `Order` (snapshot columns,
+aggregates, and calculations) or its `LineItem`s.
+
+Order-level keys:
+
+| JSON key                  | Source on `Order`                            |
+| ------------------------- | -------------------------------------------- |
+| `lang`                    | `locale` (first two chars: `sv-FI` → `sv`)   |
+| `order_reference`         | `order_reference`                            |
+| `ordered_at`              | `ordered_at` (formatted via CLDR)            |
+| `customer_name`           | `customer_name`                              |
+| `customer_email`          | `customer_email`                             |
+| `fulfillment_method`      | `fulfillment_method` (snapshot)              |
+| `recipient_name`          | `recipient_name`                             |
+| `recipient_phone_number`  | `recipient_phone_number`                     |
+| `delivery_address`        | `geocoded_address \|\| delivery_address`     |
+| `delivery_instructions`   | `delivery_instructions`                      |
+| `fulfillment_date`        | `fulfillment_date` (formatted)               |
+| `card_message`            | `card_message`                               |
+| `fulfillment_amount`      | `fulfillment_amount` (formatted currency)    |
+| `discount_amount`         | `discount_amount` aggregate (formatted)      |
+| `tax_amount`              | `tax_amount` calc (formatted)                |
+| `line_total`              | `line_total` aggregate (formatted) — order's "subtotal" |
+| `total`                   | `total` calc (formatted) — grand total       |
+
+Per-line keys (under `line_items[]`), sourced from `LineItem`:
+
+| JSON key             | Source on `LineItem`                                  |
+| -------------------- | ----------------------------------------------------- |
+| `product_name`       | `product_name`                                        |
+| `variant_size`       | `variant_size`                                        |
+| `quantity`           | `quantity`                                            |
+| `unit_price`         | `unit_price` (formatted currency)                     |
+| `unit_price_ex_tax`  | derived: `unit_price / (1 + tax_rate)` (formatted)    |
+| `tax_rate`           | `tax_rate` (formatted percentage)                     |
+| `line_total`         | `line_total` calc (formatted)                         |
+
+Snapshots store **raw decimals**, not pre-formatted strings — `Receipt`
+formats at render time using the shared CLDR helpers. The Typst template
+treats every value as a string, so the order-level `line_total` and the
+per-line `line_total` never collide (they live at different nesting levels).
 
 ## Deployment
 
 - Add `typst` to the runtime image (`Dockerfile`).
-- `priv/receipts/fonts/` is gitignored — vendor the static weights or
-  run `fetch_fonts.sh` during image build so they're present at runtime.
+- Fonts are already committed under `priv/receipts/fonts/` (#194-era
+  vendoring) and shipped via the standard `COPY priv priv` step, so
+  no extra build action is needed.
 
 ## Persistence
 
@@ -54,7 +106,7 @@ durable option — no object storage needed.
 - **Layout** — shard by year/month: `2026/05/EF-2026-00428.pdf`.
   Avoids one giant flat directory, easier to prune.
 - **Write-once** — never overwrite. The file is the canonical artifact
-  that was emailed; matches #158's immutability story.
+  that was emailed; matches the #158/#201 immutability story.
 - **Serving** — through a Phoenix controller that re-authorises against
   the order, not via static file serving. Otherwise anyone who guesses
   an `EF-2026-…` reference downloads someone else's receipt.
@@ -72,11 +124,31 @@ audit trail all reading from the same on-disk file.
 - Extend `checkout_happy_path_test.exs` to assert the delivered email
   carries one PDF attachment with the expected filename.
 
-## Open questions for after #158
+## Resolved open questions
 
-- Which snapshot fields exist on the placed Order, and do they cover
-  every value the JSON payload needs (per-line VAT rate, promotion
-  amount, fulfillment tax)?
-- Does the snapshot store pre-formatted strings, or does the receipt
-  module format at render time? Affects whether currency/date helpers
-  live in `Receipt` or upstream.
+- **Snapshot coverage** — see the field map above. Every value the
+  payload needs is on the placed `Order` or its `line_items`, with no
+  live joins required.
+- **Formatting** — snapshots are raw decimals; the receipt module
+  formats at render time. Share the CLDR helpers currently in
+  `Edenflowers.Email` between `Email` and `Receipt` rather than
+  duplicating them.
+
+## Still open
+
+- **Tax rate per line vs. order-level VAT breakdown.** The Typst
+  template renders one `vat_rate` per line and a single `tax` total;
+  this works as long as every line carries the same rate (today: yes —
+  one Finnish flower-product rate). If we ever sell mixed-rate items,
+  the JSON payload (and template) need a per-rate breakdown.
+- **Receipt locale vs. customer's current locale.** Today
+  `order.locale` is captured at checkout and persists through
+  `:placed`. The receipt uses it directly; no follow-up needed unless
+  we decide receipts should be re-rendered when a customer changes
+  language post-purchase (probably not — the emailed PDF is the
+  archival artifact).
+- **Where should the shop's identity (name, address, business ID,
+  IBAN) come from?** Tracked separately in #195 — `priv/receipts/shop.toml`
+  works for self-contained Typst previews but duplicates the address
+  hardcoded into the order-confirmation email template. Acceptable to
+  leave duplicated for now; revisit if the address changes.

--- a/priv/receipts/receipt.typ
+++ b/priv/receipts/receipt.typ
@@ -9,6 +9,39 @@
 // `shop` is loaded from shop.toml. All currency / date / VAT values
 // arrive pre-formatted as strings; labels are translated via order.lang.
 #let receipt(order) = {
+  // Schema contract. Typst has no struct types, so we assert keys
+  // exist up-front rather than discovering a missing field mid-render.
+  // Required: read unconditionally on every receipt. Optional: key must
+  // still be present in the dict; the value may be `none`.
+  let required = (
+    "lang", "order_reference", "ordered_at",
+    "customer_name", "customer_email",
+    "fulfillment_method", "fulfillment_date",
+    "line_items",
+    "items_subtotal", "fulfillment_fee", "tax", "grand_total",
+  )
+  let optional = (
+    "card_message",
+    "recipient_name", "recipient_phone_number",
+    "delivery_address", "delivery_instructions",
+    "discount",
+  )
+  for key in required {
+    assert(key in order, message: "receipt: missing required key `" + key + "`")
+  }
+  for key in optional {
+    assert(key in order, message: "receipt: missing optional key `" + key + "` (set to none if absent)")
+  }
+  let line_item_required = (
+    "product_name", "variant_size", "quantity",
+    "unit_price_ex_tax", "tax_rate", "total",
+  )
+  for item in order.line_items {
+    for key in line_item_required {
+      assert(key in item, message: "receipt: line item missing `" + key + "`")
+    }
+  }
+
   let t(key) = translate(key, order.lang)
   let fulfillment-label = if order.fulfillment_method == "delivery" {
     t("delivery")
@@ -176,7 +209,7 @@
       text(features: ("tnum",))[#item.unit_price_ex_tax],
       text(features: ("tnum",))[#item.quantity],
       text(features: ("tnum",))[#item.tax_rate],
-      text(features: ("tnum",))[#item.line_total],
+      text(features: ("tnum",))[#item.total],
     )).flatten()
   )
 
@@ -189,13 +222,13 @@
   // convention — "below the line") and a small size bump on the amount.
   let fee-label = t("fulfillment-fee").replace("{method}", fulfillment-label)
   let totals-rows = (
-    ([#t("subtotal")], [#order.line_total]),
-    ([#fee-label], [#order.fulfillment_amount]),
+    ([#t("subtotal")], [#order.items_subtotal]),
+    ([#fee-label], [#order.fulfillment_fee]),
   )
-  if order.discount_amount != none {
-    totals-rows.push(([#t("discount")], [−#order.discount_amount]))
+  if order.discount != none {
+    totals-rows.push(([#t("discount")], [−#order.discount]))
   }
-  totals-rows.push(([#t("vat")], [#order.tax_amount]))
+  totals-rows.push(([#t("vat")], [#order.tax]))
 
   // Three-column layout: label (auto), flexible gap (1fr), value (auto).
   // Auto-sizes labels to their widest content so locale variants like
@@ -221,7 +254,7 @@
         ],
         text(weight: "bold")[#t("total-paid")],
         [],
-        text(features: ("tnum",), weight: "bold")[#order.total],
+        text(features: ("tnum",), weight: "bold")[#order.grand_total],
       )
     ]
   ]

--- a/priv/receipts/receipt.typ
+++ b/priv/receipts/receipt.typ
@@ -4,12 +4,13 @@
 
 #let shop = toml("shop.toml")
 
-// Render a single receipt. `order` is a dict matching sample/order.*.json;
-// `shop` is loaded from shop.toml. All currency / date / VAT values arrive
-// pre-formatted as strings; labels are translated via order.lang.
+// Render a single receipt. `order` is a flat dict whose keys mirror the
+// Ash `Order` / `LineItem` attribute names; see sample/order.*.json.
+// `shop` is loaded from shop.toml. All currency / date / VAT values
+// arrive pre-formatted as strings; labels are translated via order.lang.
 #let receipt(order) = {
   let t(key) = translate(key, order.lang)
-  let fulfillment-label = if order.fulfillment.method == "delivery" {
+  let fulfillment-label = if order.fulfillment_method == "delivery" {
     t("delivery")
   } else {
     t("pickup")
@@ -45,7 +46,7 @@
   // QR encodes the customer-facing tracking URL. Reference is unguessable
   // (random hex, 48 bits of entropy) so the URL alone is hard to enumerate;
   // the tracking page should additionally email-gate on access.
-  let tracking-url = shop.tracking_base_url + "/" + order.reference
+  let tracking-url = shop.tracking_base_url + "/" + order.order_reference
 
   grid(
     columns: (auto, 1fr),
@@ -68,7 +69,7 @@
       #v(4pt)
       #text(features: ("tnum",))[
         #t("reference"):
-        #text(weight: "semibold")[#order.reference] \
+        #text(weight: "semibold")[#order.order_reference] \
         #t("order-date"): #text(weight: "semibold")[#order.ordered_at]
       ]
       #v(6pt)
@@ -84,7 +85,7 @@
   // The date is a property of the fulfillment (when to deliver / when to
   // collect), not a top-level field. Delivery and pickup share the same
   // shape: who/where, then a single inline date line at the bottom.
-  let date-label = if order.fulfillment.method == "delivery" {
+  let date-label = if order.fulfillment_method == "delivery" {
     t("delivery-date")
   } else {
     t("pickup-date")
@@ -96,21 +97,21 @@
     [
       #eyebrow(t("customer"))
       #v(5pt)
-      #text(weight: "semibold")[#order.customer.name] \
-      #order.customer.email
+      #text(weight: "semibold")[#order.customer_name] \
+      #order.customer_email
     ],
     [
       #eyebrow(fulfillment-label)
       #v(5pt)
-      #if order.fulfillment.method == "delivery" [
-        #text(weight: "semibold")[#order.fulfillment.recipient_name] \
-        #if order.fulfillment.recipient_phone != none [
-          #order.fulfillment.recipient_phone \
+      #if order.fulfillment_method == "delivery" [
+        #text(weight: "semibold")[#order.recipient_name] \
+        #if order.recipient_phone_number != none [
+          #order.recipient_phone_number \
         ]
-        #order.fulfillment.address \
-        #if order.fulfillment.instructions != none [
+        #order.delivery_address \
+        #if order.delivery_instructions != none [
           #text(font: fonts.serif, style: "italic")[
-            #order.fulfillment.instructions
+            #order.delivery_instructions
           ] \
         ]
       ] else [
@@ -118,7 +119,7 @@
         #shop.address
       ]
       #v(6pt)
-      #date-label: #text(weight: "semibold")[#order.fulfillment.date]
+      #date-label: #text(weight: "semibold")[#order.fulfillment_date]
     ],
   )
 
@@ -167,14 +168,14 @@
 
     ..order.line_items.map(item => (
       [
-        #item.name
+        #item.product_name
         #if item.variant_size != none [
           (#item.variant_size)
         ]
       ],
-      text(features: ("tnum",))[#item.unit_price_ex_vat],
+      text(features: ("tnum",))[#item.unit_price_ex_tax],
       text(features: ("tnum",))[#item.quantity],
-      text(features: ("tnum",))[#item.vat_rate],
+      text(features: ("tnum",))[#item.tax_rate],
       text(features: ("tnum",))[#item.line_total],
     )).flatten()
   )
@@ -188,13 +189,13 @@
   // convention — "below the line") and a small size bump on the amount.
   let fee-label = t("fulfillment-fee").replace("{method}", fulfillment-label)
   let totals-rows = (
-    ([#t("subtotal")], [#order.totals.subtotal]),
-    ([#fee-label], [#order.totals.fulfillment]),
+    ([#t("subtotal")], [#order.line_total]),
+    ([#fee-label], [#order.fulfillment_amount]),
   )
-  if order.totals.discount != none {
-    totals-rows.push(([#t("discount")], [−#order.totals.discount]))
+  if order.discount_amount != none {
+    totals-rows.push(([#t("discount")], [−#order.discount_amount]))
   }
-  totals-rows.push(([#t("vat")], [#order.totals.tax]))
+  totals-rows.push(([#t("vat")], [#order.tax_amount]))
 
   // Three-column layout: label (auto), flexible gap (1fr), value (auto).
   // Auto-sizes labels to their widest content so locale variants like
@@ -220,7 +221,7 @@
         ],
         text(weight: "bold")[#t("total-paid")],
         [],
-        text(features: ("tnum",), weight: "bold")[#order.totals.grand_total],
+        text(features: ("tnum",), weight: "bold")[#order.total],
       )
     ]
   ]

--- a/priv/receipts/sample/order.en.json
+++ b/priv/receipts/sample/order.en.json
@@ -1,54 +1,48 @@
 {
   "lang": "en",
-  "reference": "EF-2026-00428",
+  "order_reference": "EF-2026-00428",
   "ordered_at": "13 May 2026, 14:32",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "delivery",
-    "recipient_name": "Margareta Lindqvist",
-    "recipient_phone": "+358 40 555 0123",
-    "address": "Korsholmsesplanaden 12 A 4, 65100 Vaasa",
-    "instructions": "Doorbell to top-floor flat — please leave with the neighbour if no answer.",
-    "date": "Saturday, 16 May 2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "delivery",
+  "recipient_name": "Margareta Lindqvist",
+  "recipient_phone_number": "+358 40 555 0123",
+  "delivery_address": "Korsholmsesplanaden 12 A 4, 65100 Vaasa",
+  "delivery_instructions": "Doorbell to top-floor flat — please leave with the neighbour if no answer.",
+  "fulfillment_date": "Saturday, 16 May 2026",
   "card_message": "Grattis på födelsedagen, mamma! Med kärlek från oss alla.",
   "line_items": [
     {
-      "name": "Spring Posy",
+      "product_name": "Spring Posy",
       "variant_size": "Medium",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eucalyptus Bunch",
+      "product_name": "Eucalyptus Bunch",
       "variant_size": null,
       "quantity": 2,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "17,00 €"
     },
     {
-      "name": "Handwritten Card",
+      "product_name": "Handwritten Card",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "3,59 €",
+      "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "4,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "61,40 €",
-    "fulfillment": "9,00 €",
-    "discount": "6,14 €",
-    "tax": "13,38 €",
-    "grand_total": "64,26 €"
-  }
+  "line_total": "61,40 €",
+  "fulfillment_amount": "9,00 €",
+  "discount_amount": "6,14 €",
+  "tax_amount": "13,38 €",
+  "total": "64,26 €"
 }

--- a/priv/receipts/sample/order.en.json
+++ b/priv/receipts/sample/order.en.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eucalyptus Bunch",
@@ -28,7 +28,7 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "17,00 €"
+      "total": "17,00 €"
     },
     {
       "product_name": "Handwritten Card",
@@ -37,12 +37,12 @@
       "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "4,50 €"
+      "total": "4,50 €"
     }
   ],
-  "line_total": "61,40 €",
-  "fulfillment_amount": "9,00 €",
-  "discount_amount": "6,14 €",
-  "tax_amount": "13,38 €",
-  "total": "64,26 €"
+  "items_subtotal": "61,40 €",
+  "fulfillment_fee": "9,00 €",
+  "discount": "6,14 €",
+  "tax": "13,38 €",
+  "grand_total": "64,26 €"
 }

--- a/priv/receipts/sample/order.en.pickup.json
+++ b/priv/receipts/sample/order.en.pickup.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eucalyptus Bunch",
@@ -28,12 +28,12 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "8,50 €"
+      "total": "8,50 €"
     }
   ],
-  "line_total": "48,40 €",
-  "fulfillment_amount": "0,00 €",
-  "discount_amount": null,
-  "tax_amount": "9,84 €",
-  "total": "48,40 €"
+  "items_subtotal": "48,40 €",
+  "fulfillment_fee": "0,00 €",
+  "discount": null,
+  "tax": "9,84 €",
+  "grand_total": "48,40 €"
 }

--- a/priv/receipts/sample/order.en.pickup.json
+++ b/priv/receipts/sample/order.en.pickup.json
@@ -1,45 +1,39 @@
 {
   "lang": "en",
-  "reference": "EF-2026-00431",
+  "order_reference": "EF-2026-00431",
   "ordered_at": "13 May 2026, 16:08",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "pickup",
-    "recipient_name": null,
-    "recipient_phone": null,
-    "address": null,
-    "instructions": null,
-    "date": "Saturday, 16 May 2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "pickup",
+  "recipient_name": null,
+  "recipient_phone_number": null,
+  "delivery_address": null,
+  "delivery_instructions": null,
+  "fulfillment_date": "Saturday, 16 May 2026",
   "card_message": null,
   "line_items": [
     {
-      "name": "Spring Posy",
+      "product_name": "Spring Posy",
       "variant_size": "Medium",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eucalyptus Bunch",
+      "product_name": "Eucalyptus Bunch",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "8,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "48,40 €",
-    "fulfillment": "0,00 €",
-    "discount": null,
-    "tax": "9,84 €",
-    "grand_total": "48,40 €"
-  }
+  "line_total": "48,40 €",
+  "fulfillment_amount": "0,00 €",
+  "discount_amount": null,
+  "tax_amount": "9,84 €",
+  "total": "48,40 €"
 }

--- a/priv/receipts/sample/order.fi.json
+++ b/priv/receipts/sample/order.fi.json
@@ -1,54 +1,48 @@
 {
   "lang": "fi",
-  "reference": "EF-2026-00428",
+  "order_reference": "EF-2026-00428",
   "ordered_at": "13.5.2026 klo 14:32",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "delivery",
-    "recipient_name": "Margareta Lindqvist",
-    "recipient_phone": "+358 40 555 0123",
-    "address": "Korsholmsesplanaden 12 A 4, 65100 Vaasa",
-    "instructions": "Ovikello ylimpään kerrokseen — jos kukaan ei avaa, jätä naapurille.",
-    "date": "Lauantai 16.5.2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "delivery",
+  "recipient_name": "Margareta Lindqvist",
+  "recipient_phone_number": "+358 40 555 0123",
+  "delivery_address": "Korsholmsesplanaden 12 A 4, 65100 Vaasa",
+  "delivery_instructions": "Ovikello ylimpään kerrokseen — jos kukaan ei avaa, jätä naapurille.",
+  "fulfillment_date": "Lauantai 16.5.2026",
   "card_message": "Grattis på födelsedagen, mamma! Med kärlek från oss alla.",
   "line_items": [
     {
-      "name": "Kevätkimppu",
+      "product_name": "Kevätkimppu",
       "variant_size": "Keskikokoinen",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eukalyptuskimppu",
+      "product_name": "Eukalyptuskimppu",
       "variant_size": null,
       "quantity": 2,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "17,00 €"
     },
     {
-      "name": "Käsinkirjoitettu kortti",
+      "product_name": "Käsinkirjoitettu kortti",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "3,59 €",
+      "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "4,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "61,40 €",
-    "fulfillment": "9,00 €",
-    "discount": "6,14 €",
-    "tax": "13,38 €",
-    "grand_total": "64,26 €"
-  }
+  "line_total": "61,40 €",
+  "fulfillment_amount": "9,00 €",
+  "discount_amount": "6,14 €",
+  "tax_amount": "13,38 €",
+  "total": "64,26 €"
 }

--- a/priv/receipts/sample/order.fi.json
+++ b/priv/receipts/sample/order.fi.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eukalyptuskimppu",
@@ -28,7 +28,7 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "17,00 €"
+      "total": "17,00 €"
     },
     {
       "product_name": "Käsinkirjoitettu kortti",
@@ -37,12 +37,12 @@
       "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "4,50 €"
+      "total": "4,50 €"
     }
   ],
-  "line_total": "61,40 €",
-  "fulfillment_amount": "9,00 €",
-  "discount_amount": "6,14 €",
-  "tax_amount": "13,38 €",
-  "total": "64,26 €"
+  "items_subtotal": "61,40 €",
+  "fulfillment_fee": "9,00 €",
+  "discount": "6,14 €",
+  "tax": "13,38 €",
+  "grand_total": "64,26 €"
 }

--- a/priv/receipts/sample/order.fi.pickup.json
+++ b/priv/receipts/sample/order.fi.pickup.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eukalyptuskimppu",
@@ -28,12 +28,12 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "8,50 €"
+      "total": "8,50 €"
     }
   ],
-  "line_total": "48,40 €",
-  "fulfillment_amount": "0,00 €",
-  "discount_amount": null,
-  "tax_amount": "9,84 €",
-  "total": "48,40 €"
+  "items_subtotal": "48,40 €",
+  "fulfillment_fee": "0,00 €",
+  "discount": null,
+  "tax": "9,84 €",
+  "grand_total": "48,40 €"
 }

--- a/priv/receipts/sample/order.fi.pickup.json
+++ b/priv/receipts/sample/order.fi.pickup.json
@@ -1,45 +1,39 @@
 {
   "lang": "fi",
-  "reference": "EF-2026-00431",
+  "order_reference": "EF-2026-00431",
   "ordered_at": "13.5.2026 klo 16:08",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "pickup",
-    "recipient_name": null,
-    "recipient_phone": null,
-    "address": null,
-    "instructions": null,
-    "date": "Lauantai 16.5.2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "pickup",
+  "recipient_name": null,
+  "recipient_phone_number": null,
+  "delivery_address": null,
+  "delivery_instructions": null,
+  "fulfillment_date": "Lauantai 16.5.2026",
   "card_message": null,
   "line_items": [
     {
-      "name": "Kevätkimppu",
+      "product_name": "Kevätkimppu",
       "variant_size": "Keskikokoinen",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eukalyptuskimppu",
+      "product_name": "Eukalyptuskimppu",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "8,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "48,40 €",
-    "fulfillment": "0,00 €",
-    "discount": null,
-    "tax": "9,84 €",
-    "grand_total": "48,40 €"
-  }
+  "line_total": "48,40 €",
+  "fulfillment_amount": "0,00 €",
+  "discount_amount": null,
+  "tax_amount": "9,84 €",
+  "total": "48,40 €"
 }

--- a/priv/receipts/sample/order.sv.json
+++ b/priv/receipts/sample/order.sv.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eukalyptusbukett",
@@ -28,7 +28,7 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "17,00 €"
+      "total": "17,00 €"
     },
     {
       "product_name": "Handskrivet kort",
@@ -37,12 +37,12 @@
       "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "4,50 €"
+      "total": "4,50 €"
     }
   ],
-  "line_total": "61,40 €",
-  "fulfillment_amount": "9,00 €",
-  "discount_amount": "6,14 €",
-  "tax_amount": "13,38 €",
-  "total": "64,26 €"
+  "items_subtotal": "61,40 €",
+  "fulfillment_fee": "9,00 €",
+  "discount": "6,14 €",
+  "tax": "13,38 €",
+  "grand_total": "64,26 €"
 }

--- a/priv/receipts/sample/order.sv.json
+++ b/priv/receipts/sample/order.sv.json
@@ -1,54 +1,48 @@
 {
   "lang": "sv",
-  "reference": "EF-2026-00428",
+  "order_reference": "EF-2026-00428",
   "ordered_at": "13.5.2026 kl. 14:32",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "delivery",
-    "recipient_name": "Margareta Lindqvist",
-    "recipient_phone": "+358 40 555 0123",
-    "address": "Korsholmsesplanaden 12 A 4, 65100 Vasa",
-    "instructions": "Ringklocka till översta våningen — om ingen öppnar, lämna hos grannen.",
-    "date": "Lördag 16.5.2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "delivery",
+  "recipient_name": "Margareta Lindqvist",
+  "recipient_phone_number": "+358 40 555 0123",
+  "delivery_address": "Korsholmsesplanaden 12 A 4, 65100 Vasa",
+  "delivery_instructions": "Ringklocka till översta våningen — om ingen öppnar, lämna hos grannen.",
+  "fulfillment_date": "Lördag 16.5.2026",
   "card_message": "Grattis på födelsedagen, mamma! Med kärlek från oss alla.",
   "line_items": [
     {
-      "name": "Vårbukett",
+      "product_name": "Vårbukett",
       "variant_size": "Mellanstor",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eukalyptusbukett",
+      "product_name": "Eukalyptusbukett",
       "variant_size": null,
       "quantity": 2,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "17,00 €"
     },
     {
-      "name": "Handskrivet kort",
+      "product_name": "Handskrivet kort",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "3,59 €",
+      "unit_price_ex_tax": "3,59 €",
       "unit_price": "4,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "4,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "61,40 €",
-    "fulfillment": "9,00 €",
-    "discount": "6,14 €",
-    "tax": "13,38 €",
-    "grand_total": "64,26 €"
-  }
+  "line_total": "61,40 €",
+  "fulfillment_amount": "9,00 €",
+  "discount_amount": "6,14 €",
+  "tax_amount": "13,38 €",
+  "total": "64,26 €"
 }

--- a/priv/receipts/sample/order.sv.pickup.json
+++ b/priv/receipts/sample/order.sv.pickup.json
@@ -1,45 +1,39 @@
 {
   "lang": "sv",
-  "reference": "EF-2026-00431",
+  "order_reference": "EF-2026-00431",
   "ordered_at": "13.5.2026 kl. 16:08",
-  "customer": {
-    "name": "Anna Lindqvist",
-    "email": "anna.lindqvist@example.fi"
-  },
-  "fulfillment": {
-    "method": "pickup",
-    "recipient_name": null,
-    "recipient_phone": null,
-    "address": null,
-    "instructions": null,
-    "date": "Lördag 16.5.2026"
-  },
+  "customer_name": "Anna Lindqvist",
+  "customer_email": "anna.lindqvist@example.fi",
+  "fulfillment_method": "pickup",
+  "recipient_name": null,
+  "recipient_phone_number": null,
+  "delivery_address": null,
+  "delivery_instructions": null,
+  "fulfillment_date": "Lördag 16.5.2026",
   "card_message": null,
   "line_items": [
     {
-      "name": "Vårbukett",
+      "product_name": "Vårbukett",
       "variant_size": "Mellanstor",
       "quantity": 1,
-      "unit_price_ex_vat": "31,79 €",
+      "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "39,90 €"
     },
     {
-      "name": "Eukalyptusbukett",
+      "product_name": "Eukalyptusbukett",
       "variant_size": null,
       "quantity": 1,
-      "unit_price_ex_vat": "6,77 €",
+      "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
-      "vat_rate": "25,5 %",
+      "tax_rate": "25,5 %",
       "line_total": "8,50 €"
     }
   ],
-  "totals": {
-    "subtotal": "48,40 €",
-    "fulfillment": "0,00 €",
-    "discount": null,
-    "tax": "9,84 €",
-    "grand_total": "48,40 €"
-  }
+  "line_total": "48,40 €",
+  "fulfillment_amount": "0,00 €",
+  "discount_amount": null,
+  "tax_amount": "9,84 €",
+  "total": "48,40 €"
 }

--- a/priv/receipts/sample/order.sv.pickup.json
+++ b/priv/receipts/sample/order.sv.pickup.json
@@ -19,7 +19,7 @@
       "unit_price_ex_tax": "31,79 €",
       "unit_price": "39,90 €",
       "tax_rate": "25,5 %",
-      "line_total": "39,90 €"
+      "total": "39,90 €"
     },
     {
       "product_name": "Eukalyptusbukett",
@@ -28,12 +28,12 @@
       "unit_price_ex_tax": "6,77 €",
       "unit_price": "8,50 €",
       "tax_rate": "25,5 %",
-      "line_total": "8,50 €"
+      "total": "8,50 €"
     }
   ],
-  "line_total": "48,40 €",
-  "fulfillment_amount": "0,00 €",
-  "discount_amount": null,
-  "tax_amount": "9,84 €",
-  "total": "48,40 €"
+  "items_subtotal": "48,40 €",
+  "fulfillment_fee": "0,00 €",
+  "discount": null,
+  "tax": "9,84 €",
+  "grand_total": "48,40 €"
 }


### PR DESCRIPTION
## Summary

Plan-only PR outlining how the Typst receipt template from #193 gets
wired into the order confirmation email. No application code yet.

The receipt JSON payload mirrors the Ash attribute names 1:1 in a flat
structure (`order_reference`, `customer_name`, `fulfillment_method`,
`line_total`, `total`, etc.), so the future `Receipt.serialize/1`
mapping stays mechanical. All values come from the placed `Order`
snapshot columns and `LineItem`s — no live joins to `Promotion` or
`FulfillmentOption`.

## Files

- `docs/receipt-integration-plan.md` — the `Edenflowers.Receipt`
  module, the hook into `Email.order_confirmation/1` (one-liner
  `Swoosh.Email.attachment/2` call), the snapshot-field map
  (Order / LineItem attribute → JSON key), deployment (typst binary
  in the runtime image; fonts vendored under `priv/receipts/fonts/`),
  persistence (write-once to disk, sharded by year/month, served via
  authorised Phoenix controller), tests, and open questions
  (mixed-rate VAT, shop-identity centralisation per #195).
- `priv/receipts/receipt.typ` + 6 sample fixtures — rewritten to
  consume the flat JSON shape. All six variants compile via
  `typst compile main.typ ... --input fixture=<variant>`.

## Test plan

- [ ] Confirm the field map matches the placed-order shape
- [ ] Confirm the flat, Ash-aligned JSON keys are the preferred shape
      for `Receipt.serialize/1`
- [ ] Decide whether persistence ships with the email-attachment
      generator or as a follow-up