### PR TITLE
Implement ADR 0001 — immutable orders via snapshot + per-action lockdown

### DIFF
--- a/lib/edenflowers/email/templates/order_confirmation.text.eex
+++ b/lib/edenflowers/email/templates/order_confirmation.text.eex
@@ -10,7 +10,7 @@
 <%= gettext("Email") %>: <%= @order.customer_email %>
 
 <%= gettext("ITEMS") %>
-<%= for item <- @order.line_items do %>- <%= item.product_name %><%= if item.variant_size do %> (<%= String.capitalize(to_string(item.variant_size)) %>)<% end %> (<%= item.quantity %>) <%= @format_currency.(item.line_total) %>
+<%= for item <- @order.line_items do %>- <%= item.product_name %><%= if item.variant_size do %> (<%= String.capitalize(to_string(item.variant_size)) %>)<% end %> (<%= item.quantity %>) <%= @format_currency.(item.placed_line_total) %>
 <% end %>
 <%= if @order.fulfillment_method == :delivery do %><%= gettext("DELIVERY") %><% else %><%= gettext("PICKUP") %><% end %>
 <%= if @order.fulfillment_method == :delivery do %><%= if @order.gift do %><%= gettext("Recipient") %>: <%= @order.recipient_name %><% else %><%= gettext("Recipient") %>: <%= @order.customer_name %><% end %>
@@ -26,9 +26,9 @@
 <%= @order.card_message %><% end %>
 
 <%= gettext("Delivery fee") %>: <%= @format_currency.(@order.fulfillment_amount) %>
-<%= if @order.promotion_applied? do %><%= gettext("Discount") %>: -<%= @format_currency.(@order.discount_amount) %>
-<% end %><%= gettext("Tax") %>: <%= @format_currency.(@order.tax_amount) %>
-<%= gettext("Total") %>: <%= @format_currency.(@order.total) %>
+<%= if @order.placed_promotion_code do %><%= gettext("Discount") %>: -<%= @format_currency.(@order.placed_discount_amount) %>
+<% end %><%= gettext("Tax") %>: <%= @format_currency.(@order.placed_tax_amount) %>
+<%= gettext("Total") %>: <%= @format_currency.(@order.placed_total) %>
 
 <%= gettext("If you have any questions or wish to make changes to your order, please reply to this email.") %>
 

--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -39,28 +39,57 @@ defmodule Edenflowers.Store.LineItem do
     update :decrement_quantity do
       change atomic_update(:quantity, expr(if(quantity > 1, quantity - 1, quantity)))
     end
+
+    # Freezes the live aggregates into `placed_*` columns. Called from
+    # `Order.Changes.SnapshotTotals` during `:finalize_checkout`, before
+    # the parent order transitions to `:placed`. Guarded by policy so no
+    # other caller can write these columns.
+    update :snapshot_totals do
+      accept [:placed_line_total, :placed_discount_amount, :placed_line_tax_amount]
+    end
   end
 
   policies do
-    # Admin bypass - admins can do anything
+    # Admin/system can always read (admin views, background workers loading
+    # placed orders' line items for the confirmation email). Mutations to
+    # placed orders go through sibling resources per ADR 0001, so neither
+    # actor is bypassed for updates/destroys.
     bypass actor_attribute_equals(:admin, true) do
-      authorize_if always()
+      authorize_if action_type(:read)
     end
 
-    # Allow creating line items for any order (checkout flow). The card
+    bypass actor_attribute_equals(:system, true) do
+      authorize_if action_type(:read)
+    end
+
+    # Snapshot freezes placed_* columns; only the system actor (used by
+    # `Order.Changes.SnapshotTotals`) may invoke it, and only while the
+    # parent order is still in :payment. After that the row is immutable
+    # to every actor.
+    policy action(:snapshot_totals) do
+      forbid_if expr(order.state != :payment)
+      authorize_if actor_attribute_equals(:system, true)
+    end
+
+    # Add to cart only while the order is in checkout flow. The card
     # variant is gated at the order level via Order.add_card.
     policy action_type(:create) do
-      authorize_if always()
+      authorize_if expr(order.state != :placed)
     end
 
-    # Read/Update/Destroy access:
-    # Multiple authorize_if within one policy = OR (only one needs to pass)
-    policy action_type([:read, :update, :destroy]) do
-      # Guest checkout: Anyone can work with line items for orders still in
+    policy action_type(:read) do
+      # Guest checkout: anyone can work with line items for orders still in
       # the checkout flow (any sub-state before :placed).
       authorize_if expr(order.state != :placed)
-      # Placed orders: Only the owner can access their line items
+      # Placed orders: only the owner can read their line items.
       authorize_if expr(order.state == :placed and order.user_id == ^actor(:id))
+    end
+
+    # Placed orders are immutable to every actor; mutations during checkout
+    # flow are allowed via the existing cart actions.
+    policy action_type([:update, :destroy]) do
+      forbid_if expr(order.state == :placed)
+      authorize_if always()
     end
   end
 
@@ -85,6 +114,14 @@ defmodule Edenflowers.Store.LineItem do
     attribute :product_image_slug, :string, allow_nil?: false
     attribute :is_card, :boolean, default: false, allow_nil?: false
     attribute :variant_size, Edenflowers.Store.ProductVariantSize
+
+    # Snapshot of the live aggregates at finalize_checkout. Nullable so
+    # pre-snapshot rows aren't broken; new placed orders always populate
+    # them via `:snapshot_totals`.
+    attribute :placed_line_total, :decimal
+    attribute :placed_discount_amount, :decimal
+    attribute :placed_line_tax_amount, :decimal
+
     timestamps()
   end
 

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -178,6 +178,7 @@ defmodule Edenflowers.Store.Order do
     # Lifecycle transitions
     update :finalize_checkout do
       validate present(:payment_intent_id)
+      change {Changes.SnapshotTotals, []}
       change transition_state(:placed)
       change set_attribute(:payment_status, :paid)
       change set_attribute(:ordered_at, &DateTime.utc_now/0)
@@ -286,14 +287,15 @@ defmodule Edenflowers.Store.Order do
   end
 
   policies do
-    # System bypass - for webhooks and background jobs
-    bypass actor_attribute_equals(:system, true) do
-      authorize_if always()
+    # Admin/system can always read (admin views, background workers loading
+    # placed orders). Mutations on placed orders go via sibling resources
+    # per ADR 0001, so neither actor is bypassed for updates.
+    bypass actor_attribute_equals(:admin, true) do
+      authorize_if action_type(:read)
     end
 
-    # Admin bypass - admins can do anything
-    bypass actor_attribute_equals(:admin, true) do
-      authorize_if always()
+    bypass actor_attribute_equals(:system, true) do
+      authorize_if action_type(:read)
     end
 
     # Allow creating orders without authentication (for checkout flow)
@@ -306,7 +308,41 @@ defmodule Edenflowers.Store.Order do
       authorize_if expr(state == :placed and user_id == ^actor(:id))
     end
 
-    policy action_type(:update) do
+    # Presentational; allowed in any state, including :placed.
+    policy action(:update_locale) do
+      authorize_if always()
+    end
+
+    # State transition from :payment to :placed.
+    policy action(:finalize_checkout) do
+      authorize_if expr(state == :payment)
+    end
+
+    # All other mutating actions are cart-flow only. Per-action listing
+    # replaces the previous broad `action_type(:update)` policy so a placed
+    # order can't accidentally be edited via any of these actions.
+    policy action([
+             :submit_contact_details,
+             :submit_gift_options,
+             :submit_delivery,
+             :return_to_contact_details,
+             :return_to_gift_options,
+             :return_to_delivery,
+             :update_fulfillment_option,
+             :set_gift,
+             :add_payment_intent_id,
+             :mark_payment_failed,
+             :add_promotion_with_id,
+             :add_promotion_with_code,
+             :clear_promotion,
+             :restart_checkout,
+             :add_card,
+             :remove_card,
+             :remove_line_item,
+             :add_line_item,
+             :increment_line_item,
+             :decrement_line_item
+           ]) do
       authorize_if expr(state in ^@checkout_states)
     end
   end
@@ -371,6 +407,12 @@ defmodule Edenflowers.Store.Order do
     # so validations and templates can branch on a plain attribute instead of
     # traversing the relationship.
     attribute :fulfillment_method, FulfillmentOption.FulfillmentMethod
+    # Captured at submit_delivery / update_fulfillment_option from
+    # `fulfillment_option.tax_rate.percentage`. Feeds the live
+    # `fulfillment_tax_amount` calculation so a tax-rate edit doesn't
+    # retroactively rewrite an in-flight cart's tax — and so the
+    # placed_fulfillment_tax_amount snapshot inherits the quoted rate.
+    attribute :fulfillment_tax_rate, :decimal
     attribute :geocoded_address, :string
     attribute :here_id, :string
     attribute :distance, :integer
@@ -380,6 +422,19 @@ defmodule Edenflowers.Store.Order do
     attribute :payment_intent_id, :string
 
     attribute :locale, :string, default: "sv-FI"
+
+    # Snapshot of the cart's aggregates and the promotion code at
+    # `:finalize_checkout`. Nullable so historical placed orders aren't
+    # broken; new placed orders always populate them via SnapshotTotals.
+    # Placed-order read paths consume these directly; cart-flow read paths
+    # continue to use the live aggregates/calculations.
+    attribute :placed_line_total, :decimal
+    attribute :placed_line_tax_amount, :decimal
+    attribute :placed_discount_amount, :decimal
+    attribute :placed_fulfillment_tax_amount, :decimal
+    attribute :placed_tax_amount, :decimal
+    attribute :placed_total, :decimal
+    attribute :placed_promotion_code, :string
 
     timestamps()
   end
@@ -398,10 +453,10 @@ defmodule Edenflowers.Store.Order do
     calculate :fulfillment_tax_amount,
               :decimal,
               expr(
-                if is_nil(fulfillment_option_id) do
+                if is_nil(fulfillment_tax_rate) do
                   0
                 else
-                  (fulfillment_amount || 0) * fulfillment_option.tax_rate.percentage
+                  (fulfillment_amount || 0) * fulfillment_tax_rate
                 end
               )
 

--- a/lib/edenflowers/store/order/changes/copy_fulfillment_method.ex
+++ b/lib/edenflowers/store/order/changes/copy_fulfillment_method.ex
@@ -1,8 +1,10 @@
 defmodule Edenflowers.Store.Order.Changes.CopyFulfillmentMethod do
   @moduledoc """
-  Denormalizes `fulfillment_method` onto the order whenever
-  `fulfillment_option_id` changes, so validations and the UI can read the
-  method as a direct attribute instead of traversing the relationship.
+  Denormalizes `fulfillment_method` and `fulfillment_tax_rate` onto the
+  order whenever `fulfillment_option_id` changes. The method makes
+  validations and templates branch on a plain attribute; the tax rate
+  snapshot lets the live `fulfillment_tax_amount` calculation — and the
+  placed snapshot — survive a later edit to the upstream tax rate.
 
   Applied synchronously during the `change` phase (not `before_action`) so
   validations running in the same action see the updated method.
@@ -14,21 +16,27 @@ defmodule Edenflowers.Store.Order.Changes.CopyFulfillmentMethod do
   @impl true
   def change(changeset, _opts, _context) do
     if Ash.Changeset.changing_attribute?(changeset, :fulfillment_option_id) do
-      set_method(changeset)
+      set_from_option(changeset)
     else
       changeset
     end
   end
 
-  defp set_method(changeset) do
+  defp set_from_option(changeset) do
     case Ash.Changeset.get_attribute(changeset, :fulfillment_option_id) do
       nil ->
-        Ash.Changeset.force_change_attribute(changeset, :fulfillment_method, nil)
+        Ash.Changeset.force_change_attributes(changeset,
+          fulfillment_method: nil,
+          fulfillment_tax_rate: nil
+        )
 
       id ->
-        case Ash.get(FulfillmentOption, id, authorize?: false) do
-          {:ok, %{fulfillment_method: method}} ->
-            Ash.Changeset.force_change_attribute(changeset, :fulfillment_method, method)
+        case Ash.get(FulfillmentOption, id, load: [:tax_rate], authorize?: false) do
+          {:ok, %{fulfillment_method: method, tax_rate: %{percentage: percentage}}} ->
+            Ash.Changeset.force_change_attributes(changeset,
+              fulfillment_method: method,
+              fulfillment_tax_rate: percentage
+            )
 
           {:error, _} ->
             Ash.Changeset.add_error(changeset,

--- a/lib/edenflowers/store/order/changes/reset_checkout.ex
+++ b/lib/edenflowers/store/order/changes/reset_checkout.ex
@@ -22,6 +22,8 @@ defmodule Edenflowers.Store.Order.Changes.ResetCheckout do
     delivery_instructions: nil,
     fulfillment_date: nil,
     fulfillment_amount: nil,
+    fulfillment_method: nil,
+    fulfillment_tax_rate: nil,
     geocoded_address: nil,
     here_id: nil,
     distance: nil,

--- a/lib/edenflowers/store/order/changes/snapshot_totals.ex
+++ b/lib/edenflowers/store/order/changes/snapshot_totals.ex
@@ -1,0 +1,67 @@
+defmodule Edenflowers.Store.Order.Changes.SnapshotTotals do
+  @moduledoc """
+  Runs in `before_action` on `:finalize_checkout`, while the order is still
+  in `:payment`, and freezes the cart's live aggregates and the promotion
+  code into the order's and line items' `placed_*` columns.
+
+  After this runs, a placed order's numbers no longer depend on upstream
+  rows (promotion percentage, tax rate, fulfillment option) so an admin
+  edit to any of those rows can't rewrite history. See ADR 0001.
+  """
+  use Ash.Resource.Change
+
+  import Edenflowers.Actors
+
+  alias Edenflowers.Store.LineItem
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.before_action(changeset, &snapshot/1)
+  end
+
+  defp snapshot(changeset) do
+    order =
+      changeset.data
+      |> Ash.load!(
+        [
+          :line_total,
+          :line_tax_amount,
+          :discount_amount,
+          :fulfillment_tax_amount,
+          :tax_amount,
+          :total,
+          :promotion,
+          line_items: [:line_total, :discount_amount, :line_tax_amount]
+        ],
+        authorize?: false
+      )
+
+    snapshot_line_items(order.line_items)
+
+    Ash.Changeset.force_change_attributes(changeset,
+      placed_line_total: order.line_total,
+      placed_line_tax_amount: order.line_tax_amount,
+      placed_discount_amount: order.discount_amount,
+      placed_fulfillment_tax_amount: order.fulfillment_tax_amount,
+      placed_tax_amount: order.tax_amount,
+      placed_total: order.total,
+      placed_promotion_code: order.promotion && order.promotion.code
+    )
+  end
+
+  defp snapshot_line_items(line_items) do
+    Enum.each(line_items, fn item ->
+      item
+      |> Ash.Changeset.for_update(
+        :snapshot_totals,
+        %{
+          placed_line_total: item.line_total,
+          placed_discount_amount: item.discount_amount,
+          placed_line_tax_amount: item.line_tax_amount
+        },
+        actor: system_actor()
+      )
+      |> Ash.update!()
+    end)
+  end
+end

--- a/lib/edenflowers/workers/send_order_confirmation_email.ex
+++ b/lib/edenflowers/workers/send_order_confirmation_email.ex
@@ -20,30 +20,13 @@ defmodule Edenflowers.Workers.SendOrderConfirmationEmail do
   end
 
   def perform(%Oban.Job{args: %{"order_id" => order_id}}) do
+    # Placed orders are immutable per ADR 0001: the live aggregates the
+    # template used to read have all been frozen into `placed_*` columns by
+    # SnapshotTotals at finalize_checkout. The worker only needs the order
+    # row plus its line items.
     order_id
-    # TODO: use system_actor here or authorize?: false ?
-    |> Order.get_by_id!(actor: system_actor(), authorize?: false)
-    |> Ash.load!(
-      [
-        # Aggregates
-        :line_total,
-        :line_tax_amount,
-        :discount_amount,
-
-        # Calculations
-        :promotion_applied?,
-        :total,
-        :tax_amount,
-        :fulfillment_tax_amount,
-
-        # Relationships
-        :promotion,
-        fulfillment_option: [:tax_rate],
-        line_items: [:line_subtotal, :line_total]
-      ],
-      actor: system_actor(),
-      authorize?: false
-    )
+    |> Order.get_by_id!(actor: system_actor())
+    |> Ash.load!([:line_items], actor: system_actor())
     |> Email.order_confirmation()
     |> Mailer.deliver()
   end

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -160,7 +160,13 @@ defmodule Edenflowers.Store.OrderTest do
     {:ok, fulfillment_amount} = Edenflowers.Fulfillments.calculate_price(fulfillment_option)
 
     order =
-      generate(order(fulfillment_option_id: fulfillment_option.id, fulfillment_amount: fulfillment_amount))
+      generate(
+        order(
+          fulfillment_option_id: fulfillment_option.id,
+          fulfillment_amount: fulfillment_amount,
+          fulfillment_tax_rate: tax_rate_1.percentage
+        )
+      )
 
     _line_item =
       generate(
@@ -1066,6 +1072,8 @@ defmodule Edenflowers.Store.OrderTest do
       assert is_nil(reset_order.delivery_instructions)
       assert is_nil(reset_order.fulfillment_date)
       assert is_nil(reset_order.fulfillment_amount)
+      assert is_nil(reset_order.fulfillment_method)
+      assert is_nil(reset_order.fulfillment_tax_rate)
       assert is_nil(reset_order.geocoded_address)
       assert is_nil(reset_order.here_id)
       assert is_nil(reset_order.distance)
@@ -1361,6 +1369,400 @@ defmodule Edenflowers.Store.OrderTest do
       order = generate(order(state: :placed, payment_status: :paid, payment_intent_id: "pi_old"))
 
       assert {:error, error} = Order.add_payment_intent_id(order, "pi_new", actor: nil)
+      assert %Ash.Error.Forbidden{} = error
+    end
+  end
+
+  describe "fulfillment_tax_rate snapshot (ADR 0001)" do
+    setup do
+      tax_rate = generate(tax_rate(percentage: "0.255"))
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id, price: "50.00"))
+
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate.id,
+            name: "Pickup",
+            fulfillment_method: :pickup,
+            rate_type: :fixed,
+            base_price: "10.00",
+            order_deadline: ~T[12:00:00]
+          )
+        )
+
+      order = generate(order(state: :delivery))
+      generate(line_item(order_id: order.id, product_variant_id: variant.id, quantity: 1))
+
+      %{
+        order: order,
+        tax_rate: tax_rate,
+        fulfillment_option: fulfillment_option
+      }
+    end
+
+    test "submit_delivery captures fulfillment_tax_rate from the chosen option", %{
+      order: order,
+      fulfillment_option: option,
+      tax_rate: tax_rate
+    } do
+      assert {:ok, updated} =
+               order
+               |> Ash.Changeset.for_update(:submit_delivery, %{
+                 fulfillment_option_id: option.id,
+                 fulfillment_date: Date.add(Date.utc_today(), 1)
+               })
+               |> Ash.update(authorize?: false)
+
+      assert Decimal.equal?(updated.fulfillment_tax_rate, tax_rate.percentage)
+    end
+
+    test "in-flight cart's fulfillment_tax_amount uses snapshot, not the live rate", %{
+      order: order,
+      fulfillment_option: option,
+      tax_rate: tax_rate
+    } do
+      {:ok, updated} =
+        order
+        |> Ash.Changeset.for_update(:submit_delivery, %{
+          fulfillment_option_id: option.id,
+          fulfillment_date: Date.add(Date.utc_today(), 1)
+        })
+        |> Ash.update(authorize?: false)
+
+      original_amount = Ash.load!(updated, :fulfillment_tax_amount, authorize?: false).fulfillment_tax_amount
+
+      # Admin edits the underlying tax rate row.
+      tax_rate
+      |> Ecto.Changeset.change(%{percentage: Decimal.new("0.10")})
+      |> Edenflowers.Repo.update!()
+
+      after_edit = Ash.load!(updated, :fulfillment_tax_amount, authorize?: false).fulfillment_tax_amount
+      assert Decimal.equal?(after_edit, original_amount)
+    end
+
+    test "update_fulfillment_option re-captures fulfillment_tax_rate for the new option", %{
+      order: order,
+      fulfillment_option: option,
+      tax_rate: original_rate
+    } do
+      {:ok, with_option} =
+        order
+        |> Ash.Changeset.for_update(:submit_delivery, %{
+          fulfillment_option_id: option.id,
+          fulfillment_date: Date.add(Date.utc_today(), 1)
+        })
+        |> Ash.update(authorize?: false)
+
+      new_tax = generate(tax_rate(percentage: "0.14"))
+
+      new_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: new_tax.id,
+            name: "Delivery alt",
+            fulfillment_method: :delivery,
+            rate_type: :fixed,
+            base_price: "12.00",
+            order_deadline: ~T[12:00:00]
+          )
+        )
+
+      assert {:ok, swapped} =
+               Order.update_fulfillment_option(with_option, new_option.id, authorize?: false)
+
+      assert Decimal.equal?(swapped.fulfillment_tax_rate, new_tax.percentage)
+      refute Decimal.equal?(swapped.fulfillment_tax_rate, original_rate.percentage)
+    end
+  end
+
+  describe "finalize_checkout snapshot (ADR 0001)" do
+    setup do
+      tax_rate = generate(tax_rate(percentage: "0.255"))
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id, price: "30.00"))
+
+      promotion =
+        generate(promotion(code: "SAVE10", discount_percentage: "0.10", minimum_cart_total: "0"))
+
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate.id,
+            name: "Pickup",
+            fulfillment_method: :pickup,
+            rate_type: :fixed,
+            base_price: "10.00",
+            order_deadline: ~T[12:00:00]
+          )
+        )
+
+      order =
+        generate(
+          order(
+            state: :payment,
+            payment_intent_id: "pi_test",
+            fulfillment_option_id: fulfillment_option.id,
+            fulfillment_amount: "10.00",
+            fulfillment_method: :pickup,
+            fulfillment_tax_rate: tax_rate.percentage,
+            promotion_id: promotion.id
+          )
+        )
+
+      line_item =
+        generate(line_item(order_id: order.id, product_variant_id: variant.id, quantity: 2))
+
+      %{
+        order: order,
+        line_item: line_item,
+        tax_rate: tax_rate,
+        promotion: promotion
+      }
+    end
+
+    test "finalize_checkout writes placed_* totals on Order", %{order: order, tax_rate: tax_rate} do
+      assert {:ok, placed} = Order.finalize_checkout(order.id, authorize?: false)
+
+      # subtotal = 2 * 30 = 60; discount 10% = 6; line_total = 54
+      assert Decimal.equal?(placed.placed_line_total, "54.00")
+      # line_tax_amount = 54 * 0.255 = 13.77
+      assert placed.placed_line_tax_amount
+             |> Decimal.round(2)
+             |> Decimal.equal?("13.77")
+
+      assert Decimal.equal?(placed.placed_discount_amount, "6.00")
+
+      # fulfillment_tax_amount = 10 * 0.255 = 2.55
+      assert placed.placed_fulfillment_tax_amount
+             |> Decimal.round(2)
+             |> Decimal.equal?("2.55")
+
+      # tax_amount = line_tax + fulfillment_tax
+      assert placed.placed_tax_amount
+             |> Decimal.round(2)
+             |> Decimal.equal?(Decimal.add(placed.placed_line_tax_amount, placed.placed_fulfillment_tax_amount) |> Decimal.round(2))
+
+      # total = line_total + fulfillment_amount = 54 + 10 = 64
+      assert Decimal.equal?(placed.placed_total, "64.00")
+
+      # Ignore tax_rate to silence unused; included in pattern for clarity
+      _ = tax_rate
+    end
+
+    test "finalize_checkout captures placed_promotion_code", %{order: order, promotion: promotion} do
+      assert {:ok, placed} = Order.finalize_checkout(order.id, authorize?: false)
+      assert placed.placed_promotion_code == promotion.code
+    end
+
+    test "finalize_checkout writes placed_* totals on each LineItem", %{
+      order: order,
+      line_item: line_item
+    } do
+      assert {:ok, _placed} = Order.finalize_checkout(order.id, authorize?: false)
+
+      reloaded = Ash.get!(Edenflowers.Store.LineItem, line_item.id, authorize?: false)
+
+      # subtotal 60, 10% discount = 6, line_total = 54
+      assert Decimal.equal?(reloaded.placed_line_total, "54.00")
+      assert Decimal.equal?(reloaded.placed_discount_amount, "6.00")
+      # line_tax_amount = 54 * 0.255
+      assert reloaded.placed_line_tax_amount
+             |> Decimal.round(2)
+             |> Decimal.equal?("13.77")
+    end
+
+    test "snapshot is immune to later promotion percentage edits", %{
+      order: order,
+      promotion: promotion
+    } do
+      {:ok, placed} = Order.finalize_checkout(order.id, authorize?: false)
+      original_total = placed.placed_total
+
+      promotion
+      |> Ecto.Changeset.change(%{discount_percentage: Decimal.new("0.90")})
+      |> Edenflowers.Repo.update!()
+
+      reloaded = Order.get_by_id!(placed.id, actor: %{system: true})
+      assert Decimal.equal?(reloaded.placed_total, original_total)
+    end
+
+    test "snapshot is immune to later tax rate edits", %{order: order, tax_rate: tax_rate} do
+      {:ok, placed} = Order.finalize_checkout(order.id, authorize?: false)
+      original_tax = placed.placed_tax_amount
+
+      tax_rate
+      |> Ecto.Changeset.change(%{percentage: Decimal.new("0.05")})
+      |> Edenflowers.Repo.update!()
+
+      reloaded = Order.get_by_id!(placed.id, actor: %{system: true})
+      assert Decimal.equal?(reloaded.placed_tax_amount, original_tax)
+    end
+
+    test "placed_promotion_code is nil when no promotion was applied" do
+      tax_rate = generate(tax_rate(percentage: "0.10"))
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id, price: "20.00"))
+
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate.id,
+            name: "Pickup-x",
+            fulfillment_method: :pickup,
+            rate_type: :fixed,
+            base_price: "5.00",
+            order_deadline: ~T[12:00:00]
+          )
+        )
+
+      order =
+        generate(
+          order(
+            state: :payment,
+            payment_intent_id: "pi_no_promo",
+            fulfillment_option_id: fulfillment_option.id,
+            fulfillment_amount: "5.00",
+            fulfillment_method: :pickup,
+            fulfillment_tax_rate: tax_rate.percentage
+          )
+        )
+
+      generate(line_item(order_id: order.id, product_variant_id: variant.id, quantity: 1))
+
+      {:ok, placed} = Order.finalize_checkout(order.id, authorize?: false)
+      assert is_nil(placed.placed_promotion_code)
+      assert is_nil(placed.placed_discount_amount) or Decimal.equal?(placed.placed_discount_amount, "0")
+    end
+  end
+
+  describe "Placed order lockdown (ADR 0001)" do
+    setup do
+      tax_rate = generate(tax_rate(percentage: "0.255"))
+      product = generate(product(tax_rate_id: tax_rate.id))
+      variant = generate(product_variant(product_id: product.id, price: "30.00"))
+
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate.id,
+            name: "Pickup",
+            fulfillment_method: :pickup,
+            rate_type: :fixed,
+            base_price: "5.00",
+            order_deadline: ~T[12:00:00]
+          )
+        )
+
+      {:ok, user} =
+        Edenflowers.Accounts.User.upsert("owner@example.com", "Owner", authorize?: false)
+
+      order =
+        generate(
+          order(
+            state: :placed,
+            payment_status: :paid,
+            payment_intent_id: "pi_locked",
+            user_id: user.id,
+            fulfillment_option_id: fulfillment_option.id,
+            fulfillment_amount: "5.00",
+            fulfillment_method: :pickup,
+            fulfillment_tax_rate: tax_rate.percentage,
+            placed_total: "65.00"
+          )
+        )
+
+      %{order: order, user: user, variant: variant}
+    end
+
+    test "owner cannot return placed order to an earlier checkout step", %{
+      order: order,
+      user: user
+    } do
+      assert {:error, error} = Order.return_to_contact_details(order, actor: user)
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "owner cannot restart checkout on a placed order", %{order: order, user: user} do
+      assert {:error, error} = Order.restart_checkout(order, actor: user)
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "admin cannot edit cart-flow fields on a placed order via cart actions", %{order: order} do
+      assert {:error, error} =
+               Order.add_payment_intent_id(order, "pi_admin_attempt", actor: %{admin: true})
+
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "system actor cannot edit cart-flow fields on a placed order via cart actions", %{
+      order: order
+    } do
+      assert {:error, error} =
+               Order.add_payment_intent_id(order, "pi_system_attempt", actor: %{system: true})
+
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "finalize_checkout is rejected once the order is placed", %{order: order} do
+      assert {:error, error} = Order.finalize_checkout(order.id, actor: %{system: true})
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "update_locale stays allowed even on placed orders", %{order: order, user: user} do
+      assert {:ok, updated} = Order.update_locale(order, "en-GB", actor: user)
+      assert updated.locale == "en-GB"
+    end
+
+    test "line items on a placed order cannot be created", %{order: order, variant: variant} do
+      assert {:error, error} =
+               Edenflowers.Store.LineItem
+               |> Ash.Changeset.for_create(:add_to_cart, %{
+                 order_id: order.id,
+                 product_variant_id: variant.id,
+                 quantity: 1
+               })
+               |> Ash.create(actor: nil)
+
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "line items on a placed order cannot be destroyed by the owner", %{
+      order: order,
+      user: user,
+      variant: variant
+    } do
+      # Manually attach a line item to the placed order (seed_generator bypass)
+      line_item =
+        Edenflowers.Store.LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: variant.id,
+          quantity: 1
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert {:error, error} =
+               Ash.destroy(line_item, action: :remove_item, actor: user)
+
+      assert %Ash.Error.Forbidden{} = error
+    end
+
+    test "snapshot_totals refuses non-system actors", %{order: order, variant: variant} do
+      line_item =
+        Edenflowers.Store.LineItem
+        |> Ash.Changeset.for_create(:add_to_cart, %{
+          order_id: order.id,
+          product_variant_id: variant.id,
+          quantity: 1
+        })
+        |> Ash.create!(authorize?: false)
+
+      assert {:error, error} =
+               line_item
+               |> Ash.Changeset.for_update(:snapshot_totals, %{placed_line_total: "1.00"})
+               |> Ash.update(actor: %{admin: true})
+
       assert %Ash.Error.Forbidden{} = error
     end
   end


### PR DESCRIPTION
Implements the architectural decision recorded in PR #158 (ADR 0001).

## Summary

- **Snapshot** at `:finalize_checkout` freezes the cart's live totals and promotion code into new `placed_*` columns on `Order` and `LineItem` via a new `Order.Changes.SnapshotTotals` change (`before_action`, while the order is still `:payment`).
- **Per-action policies** replace the broad `policy action_type(:update)` block on `Order`. Each cart-flow action is enumerated and gated on `state in @checkout_states`; `:finalize_checkout` is gated on `state == :payment`; `:update_locale` stays allowed in any state. The admin / system bypasses are tightened to authorize reads only, so neither actor can mutate a placed order through cart actions — refunds, returns, etc. go via sibling resources per the ADR.
- **LineItem mirrors**: `:create`, `:update`, `:destroy` forbid when the parent order is `:placed`; the new `:snapshot_totals` action is the only way to write `placed_*` line-item columns, and it requires both the system actor and the parent order in `:payment`.
- **`Order.fulfillment_tax_rate`** is captured by `CopyFulfillmentMethod` whenever the option changes, and the live `fulfillment_tax_amount` calculation reads the snapshot column instead of traversing `fulfillment_option.tax_rate.percentage`. An in-flight cart keeps the rate it was quoted at when an admin edits the upstream `tax_rate` row.
- **Confirmation email worker + template** read `placed_*` directly; the worker no longer loads aggregates, calculations, or upstream relationships.

## Migration

Not in this branch — please run `mix ash_postgres.generate_migrations` locally and commit the generated migration on top. (Mix is not available in the Claude Code environment.)

## Test plan

- [ ] `mix ash_postgres.generate_migrations` produces the expected schema diff
- [ ] `mix test` — new describes cover snapshot capture, immunity to upstream edits, and policy lockdown on placed orders
- [ ] Smoke-test a checkout end-to-end and verify the confirmation email shows the snapshot values

Closes the implementation portion of ADR 0001 (PR #158).

https://claude.ai/code/session_01YCQ82N8rw1C9LjY51o1Bmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCQ82N8rw1C9LjY51o1Bmv)_