### PR TITLE
Reorder resource declarations for logical consistency

### DIFF
--- a/lib/edenflowers/accounts/user.ex
+++ b/lib/edenflowers/accounts/user.ex
@@ -66,9 +66,9 @@ defmodule Edenflowers.Accounts.User do
   code_interface do
     define :get_by_subject, action: :get_by_subject, args: [:subject]
     define :get_by_email, action: :get_by_email, args: [:email]
-    define :upsert, action: :upsert, args: [:email, :name]
     define :request_otp, action: :request_otp, args: [:email]
     define :sign_in_with_otp, action: :sign_in_with_otp, args: [:email, :otp]
+    define :upsert, action: :upsert, args: [:email, :name]
     define :subscribe_to_newsletter, action: :subscribe_to_newsletter, args: [:email]
     define :update_name, action: :update_name, args: [:name]
     define :update_newsletter_preference, action: :update_newsletter_preference, args: [:newsletter_opt_in]
@@ -100,28 +100,11 @@ defmodule Edenflowers.Accounts.User do
       upsert_identity :unique_email
     end
 
-    update :update do
-      accept [:name, :newsletter_opt_in]
-    end
-
     create :subscribe_to_newsletter do
       accept [:email]
       upsert? true
       upsert_identity :unique_email
       change set_attribute(:newsletter_opt_in, true)
-    end
-
-    update :update_name do
-      accept [:name]
-    end
-
-    update :update_newsletter_preference do
-      accept [:newsletter_opt_in]
-    end
-
-    update :set_newsletter_promo do
-      argument :newsletter_promo_id, :uuid, allow_nil?: false
-      change set_attribute(:newsletter_promo_id, arg(:newsletter_promo_id))
     end
 
     create :register_with_google do
@@ -140,6 +123,23 @@ defmodule Edenflowers.Accounts.User do
         |> Ash.Changeset.change_attribute(:email, user_info["email"])
         |> Ash.Changeset.change_attribute(:name, user_info["name"])
       end
+    end
+
+    update :update do
+      accept [:name, :newsletter_opt_in]
+    end
+
+    update :update_name do
+      accept [:name]
+    end
+
+    update :update_newsletter_preference do
+      accept [:newsletter_opt_in]
+    end
+
+    update :set_newsletter_promo do
+      argument :newsletter_promo_id, :uuid, allow_nil?: false
+      change set_attribute(:newsletter_promo_id, arg(:newsletter_promo_id))
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -13,6 +13,23 @@ defmodule Edenflowers.Store.FulfillmentOption do
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer]
 
+  @accepted_fields [
+    :name,
+    :minimum_cart_total,
+    :fulfillment_method,
+    :rate_type,
+    :base_price,
+    :price_per_km,
+    :free_dist_km,
+    :max_dist_km,
+    :same_day,
+    :order_deadline,
+    :available_days,
+    :enabled_dates,
+    :disabled_dates,
+    :tax_rate_id
+  ]
+
   postgres do
     table "fulfillment_options"
     repo Edenflowers.Repo
@@ -24,42 +41,7 @@ defmodule Edenflowers.Store.FulfillmentOption do
   end
 
   actions do
-    defaults [
-      :read,
-      :destroy,
-      create: [
-        :name,
-        :minimum_cart_total,
-        :fulfillment_method,
-        :rate_type,
-        :base_price,
-        :price_per_km,
-        :free_dist_km,
-        :max_dist_km,
-        :same_day,
-        :order_deadline,
-        :available_days,
-        :enabled_dates,
-        :disabled_dates,
-        :tax_rate_id
-      ],
-      update: [
-        :name,
-        :minimum_cart_total,
-        :fulfillment_method,
-        :rate_type,
-        :base_price,
-        :price_per_km,
-        :free_dist_km,
-        :max_dist_km,
-        :same_day,
-        :order_deadline,
-        :available_days,
-        :enabled_dates,
-        :disabled_dates,
-        :tax_rate_id
-      ]
-    ]
+    defaults [:read, :destroy, create: @accepted_fields, update: @accepted_fields]
 
     read :by_id do
       argument :id, :uuid, allow_nil?: false

--- a/lib/edenflowers/store/line_item.ex
+++ b/lib/edenflowers/store/line_item.ex
@@ -99,6 +99,16 @@ defmodule Edenflowers.Store.LineItem do
     # This is the base price for a specific item or service multiplied by the quantity, before any taxes or discounts are applied.
     calculate :subtotal, :decimal, expr(unit_price * quantity)
 
+    calculate :discount,
+              :decimal,
+              expr(
+                if(
+                  promotion_applied?,
+                  do: subtotal * order.discount_rate,
+                  else: 0
+                )
+              )
+
     # This is the final amount for a specific line item, including the subtotal plus taxes and minus any line-specific discounts.
     calculate :total,
               :decimal,
@@ -107,16 +117,6 @@ defmodule Edenflowers.Store.LineItem do
                   promotion_applied?,
                   do: subtotal - discount,
                   else: subtotal
-                )
-              )
-
-    calculate :discount,
-              :decimal,
-              expr(
-                if(
-                  promotion_applied?,
-                  do: subtotal * order.discount_rate,
-                  else: 0
                 )
               )
 

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -405,14 +405,15 @@ defmodule Edenflowers.Store.Order do
   end
 
   calculations do
-    calculate :promotion_applied?, :boolean, expr(not is_nil(promotion_id))
-    calculate :grand_total, :decimal, expr(items_subtotal + (fulfillment_fee || 0))
-
     calculate :fulfillment_tax,
               :decimal,
               expr((fulfillment_fee || 0) * (fulfillment_tax_percentage || 0))
 
     calculate :tax, :decimal, expr(items_tax + fulfillment_tax)
+
+    calculate :grand_total, :decimal, expr(items_subtotal + (fulfillment_fee || 0))
+
+    calculate :promotion_applied?, :boolean, expr(not is_nil(promotion_id))
 
     # A cart with only a card line item is presented as empty in the UI
     # (card controls are hidden in the cart sidebar) and shouldn't keep

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -14,6 +14,7 @@ defmodule Edenflowers.Store.Order do
   alias Edenflowers.Store.FulfillmentOption
 
   @locales Edenflowers.Locales.all()
+  @checkout_states [:contact_details, :gift_options, :delivery, :payment]
 
   @checkout_load [
     :total_items_in_cart,
@@ -35,14 +36,12 @@ defmodule Edenflowers.Store.Order do
     table "orders"
   end
 
-  @checkout_states [:contact_details, :gift_options, :delivery, :payment]
-
   code_interface do
-    define :create_for_checkout, action: :create_for_checkout
     define :get_by_id, action: :by_id, args: [:id]
     define :get_by_order_reference, action: :by_order_reference, args: [:order_reference]
     define :get_for_checkout, action: :for_checkout, args: [:id]
     define :get_all_completed, action: :completed
+    define :create_for_checkout, action: :create_for_checkout
     define :submit_contact_details, action: :submit_contact_details
     define :submit_gift_options, action: :submit_gift_options
     define :submit_delivery, action: :submit_delivery
@@ -52,6 +51,12 @@ defmodule Edenflowers.Store.Order do
     define :finalize_checkout, action: :finalize_checkout
     define :mark_payment_failed, action: :mark_payment_failed
     define :add_payment_intent_id, action: :add_payment_intent_id, args: [:payment_intent_id]
+    define :add_line_item, action: :add_line_item, args: [:product_variant_id, :quantity]
+    define :remove_line_item, action: :remove_line_item, args: [:line_item_id]
+    define :increment_line_item, action: :increment_line_item, args: [:line_item_id]
+    define :decrement_line_item, action: :decrement_line_item, args: [:line_item_id]
+    define :add_card, action: :add_card, args: [:product_variant_id]
+    define :remove_card, action: :remove_card
     define :add_promotion_with_id, action: :add_promotion_with_id, args: [:promotion_id]
     define :add_promotion_with_code, action: :add_promotion_with_code, args: [:code]
     define :clear_promotion, action: :clear_promotion
@@ -59,12 +64,6 @@ defmodule Edenflowers.Store.Order do
     define :set_gift, action: :set_gift, args: [:gift]
     define :update_locale, action: :update_locale, args: [:locale]
     define :restart_checkout, action: :restart_checkout
-    define :add_card, action: :add_card, args: [:product_variant_id]
-    define :remove_card, action: :remove_card
-    define :remove_line_item, action: :remove_line_item, args: [:line_item_id]
-    define :add_line_item, action: :add_line_item, args: [:product_variant_id, :quantity]
-    define :increment_line_item, action: :increment_line_item, args: [:line_item_id]
-    define :decrement_line_item, action: :decrement_line_item, args: [:line_item_id]
   end
 
   state_machine do
@@ -185,33 +184,56 @@ defmodule Edenflowers.Store.Order do
       require_atomic? false
     end
 
-    update :update_fulfillment_option do
-      accept [:fulfillment_option_id]
-      change {Changes.SnapshotFulfillmentMethod, []}
-      change set_attribute(:fulfillment_date, nil)
-      change {Changes.ClearDeliveryFields, []}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :set_gift do
-      accept [:gift]
-      change load(@checkout_load)
-    end
-
-    update :update_locale do
-      argument :locale, :string, allow_nil?: false
-      validate argument_in(:locale, @locales)
-      change atomic_update(:locale, expr(^arg(:locale)))
+    update :mark_payment_failed do
+      validate attribute_does_not_equal(:payment_status, :paid)
+      change set_attribute(:payment_status, :failed)
     end
 
     update :add_payment_intent_id do
       accept [:payment_intent_id]
     end
 
-    update :mark_payment_failed do
-      validate attribute_does_not_equal(:payment_status, :paid)
-      change set_attribute(:payment_status, :failed)
+    update :add_line_item do
+      argument :product_variant_id, :uuid, allow_nil?: false
+      argument :quantity, :integer, allow_nil?: false, constraints: [min: 1]
+      change {Changes.AddLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :remove_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.RemoveLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :increment_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.AdjustLineItemQuantity, direction: :increment}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :decrement_line_item do
+      argument :line_item_id, :uuid, allow_nil?: false
+      change {Changes.AdjustLineItemQuantity, direction: :decrement}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :add_card do
+      argument :product_variant_id, :uuid, allow_nil?: false
+      change {Changes.SwapCardLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :remove_card do
+      change set_attribute(:card_message, nil)
+      change {Changes.RemoveCardLineItem, []}
+      change load(@checkout_load)
+      require_atomic? false
     end
 
     update :add_promotion_with_id do
@@ -239,52 +261,29 @@ defmodule Edenflowers.Store.Order do
       require_atomic? false
     end
 
+    update :update_fulfillment_option do
+      accept [:fulfillment_option_id]
+      change {Changes.SnapshotFulfillmentMethod, []}
+      change set_attribute(:fulfillment_date, nil)
+      change {Changes.ClearDeliveryFields, []}
+      change load(@checkout_load)
+      require_atomic? false
+    end
+
+    update :set_gift do
+      accept [:gift]
+      change load(@checkout_load)
+    end
+
+    update :update_locale do
+      argument :locale, :string, allow_nil?: false
+      validate argument_in(:locale, @locales)
+      change atomic_update(:locale, expr(^arg(:locale)))
+    end
+
     update :restart_checkout do
       change {Changes.ResetCheckout, []}
       change transition_state(:contact_details)
-      require_atomic? false
-    end
-
-    update :add_card do
-      argument :product_variant_id, :uuid, allow_nil?: false
-      change {Changes.SwapCardLineItem, []}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :remove_card do
-      change set_attribute(:card_message, nil)
-      change {Changes.RemoveCardLineItem, []}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :remove_line_item do
-      argument :line_item_id, :uuid, allow_nil?: false
-      change {Changes.RemoveLineItem, []}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :add_line_item do
-      argument :product_variant_id, :uuid, allow_nil?: false
-      argument :quantity, :integer, allow_nil?: false, constraints: [min: 1]
-      change {Changes.AddLineItem, []}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :increment_line_item do
-      argument :line_item_id, :uuid, allow_nil?: false
-      change {Changes.AdjustLineItemQuantity, direction: :increment}
-      change load(@checkout_load)
-      require_atomic? false
-    end
-
-    update :decrement_line_item do
-      argument :line_item_id, :uuid, allow_nil?: false
-      change {Changes.AdjustLineItemQuantity, direction: :decrement}
-      change load(@checkout_load)
       require_atomic? false
     end
   end
@@ -359,6 +358,8 @@ defmodule Edenflowers.Store.Order do
         ]
       ]
 
+    attribute :locale, :string, default: "sv-FI"
+
     # Step 1 - Your Details
     attribute :customer_name, :string
     attribute :customer_email, :string
@@ -392,8 +393,6 @@ defmodule Edenflowers.Store.Order do
     attribute :discount_rate, :decimal
     attribute :promotion_name, :string
     attribute :promotion_code, :string
-
-    attribute :locale, :string, default: "sv-FI"
 
     timestamps()
   end

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -40,7 +40,7 @@ defmodule Edenflowers.Store.Order do
     define :get_by_id, action: :by_id, args: [:id]
     define :get_by_order_reference, action: :by_order_reference, args: [:order_reference]
     define :get_for_checkout, action: :for_checkout, args: [:id]
-    define :get_all_completed, action: :completed
+    define :list_placed, action: :placed
     define :create_for_checkout, action: :create_for_checkout
     define :submit_contact_details, action: :submit_contact_details
     define :submit_gift_options, action: :submit_gift_options
@@ -107,7 +107,7 @@ defmodule Edenflowers.Store.Order do
       prepare build(load: @checkout_load)
     end
 
-    read :completed do
+    read :placed do
       filter expr(state == :placed)
     end
 

--- a/lib/edenflowers/store/product.ex
+++ b/lib/edenflowers/store/product.ex
@@ -11,17 +11,17 @@ defmodule Edenflowers.Store.Product do
   end
 
   code_interface do
-    define :get_all_for_store, action: :for_store
+    define :list_visible, action: :visible
     define :get_featured, action: :featured
     define :get_by_category, action: :by_category, args: [:category_id]
-    define :get_by_category_slug, action: :get_by_category_slug, args: [:slug]
+    define :get_by_category_slug, action: :by_category_slug, args: [:slug]
     define :get_by_id, action: :by_id, args: [:id]
   end
 
   actions do
     defaults [:read, :destroy]
 
-    read :for_store do
+    read :visible do
       prepare Edenflowers.Store.Product.Preparations.VisibleInStore
     end
 
@@ -37,7 +37,7 @@ defmodule Edenflowers.Store.Product do
       prepare Edenflowers.Store.Product.Preparations.VisibleInStore
     end
 
-    read :get_by_category_slug do
+    read :by_category_slug do
       argument :slug, :string, allow_nil?: false
 
       filter expr(product_category.slug == ^arg(:slug))

--- a/lib/edenflowers/store/product_category.ex
+++ b/lib/edenflowers/store/product_category.ex
@@ -17,18 +17,18 @@ defmodule Edenflowers.Store.ProductCategory do
   end
 
   code_interface do
-    define :get_all, action: :get_all
-    define :get_by_slug, action: :get_by_slug, args: [:slug]
+    define :get_all, action: :public
+    define :get_by_slug, action: :by_slug, args: [:slug]
   end
 
   actions do
     defaults [:read, :destroy]
 
-    read :get_all do
+    read :public do
       filter expr(visibility == :public)
     end
 
-    read :get_by_slug do
+    read :by_slug do
       argument :slug, :string, allow_nil?: false
       filter expr(slug == ^arg(:slug) and visibility == :public)
       get? true

--- a/lib/edenflowers/store/product_variant.ex
+++ b/lib/edenflowers/store/product_variant.ex
@@ -12,7 +12,7 @@ defmodule Edenflowers.Store.ProductVariant do
 
   code_interface do
     define :get_by_id, action: :by_id, args: [:id]
-    define :for_card_drawer, action: :for_card_drawer
+    define :purchasable_cards, action: :purchasable_cards
   end
 
   actions do
@@ -24,7 +24,7 @@ defmodule Edenflowers.Store.ProductVariant do
       get? true
     end
 
-    read :for_card_drawer do
+    read :purchasable_cards do
       # The Cards category is intentionally hidden from the storefront
       # (visibility: :hidden) — products are surfaced only at checkout via
       # this action. Excluding :draft keeps work-in-progress categories out.

--- a/lib/edenflowers_web/live/account_live.ex
+++ b/lib/edenflowers_web/live/account_live.ex
@@ -6,7 +6,7 @@ defmodule EdenflowersWeb.AccountLive do
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_required}
 
   def mount(_params, _session, socket) do
-    orders = Order.get_all_completed!(socket.assigns.current_user.id, actor: socket.assigns.current_user)
+    orders = Order.list_placed!(actor: socket.assigns.current_user)
 
     {:ok,
      socket

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -30,7 +30,7 @@ defmodule EdenflowersWeb.CheckoutLive do
          {:ok, fulfillment_options} <- FulfillmentOption.list() do
       fulfillment_options = sort_fulfillment_options(fulfillment_options)
       order = ensure_fulfillment_default(order, fulfillment_options, socket.assigns[:current_user])
-      card_variants = ProductVariant.for_card_drawer!()
+      card_variants = ProductVariant.purchasable_cards!()
 
       {:ok,
        socket

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -102,7 +102,7 @@ plants_category =
   })
   |> Ash.create!(authorize?: false)
 
-# Cards are surfaced only at checkout via ProductVariant.for_card_drawer.
+# Cards are surfaced only at checkout via ProductVariant.purchasable_cards.
 # visibility: :hidden keeps the category out of the store ribbon while still
 # allowing its products to be read by that action.
 cards_category =

--- a/test/product_test.exs
+++ b/test/product_test.exs
@@ -136,7 +136,7 @@ defmodule Edenflowers.Store.ProductTest do
     end
   end
 
-  describe "Product.get_all_for_store filtering" do
+  describe "Product.list_visible filtering" do
     test "includes published products with variants and published category", %{tax_rate: tax_rate} do
       # Create published category
       published_category = generate(product_category(visibility: :public))
@@ -145,7 +145,7 @@ defmodule Edenflowers.Store.ProductTest do
       product = generate(product(tax_rate_id: tax_rate.id, product_category_id: published_category.id, draft: false))
       _variant = generate(product_variant(product_id: product.id))
 
-      products = Product.get_all_for_store!(authorize?: false)
+      products = Product.list_visible!(authorize?: false)
 
       assert Enum.any?(products, fn p -> p.id == product.id end)
     end
@@ -159,7 +159,7 @@ defmodule Edenflowers.Store.ProductTest do
 
       _variant = generate(product_variant(product_id: draft_product.id))
 
-      products = Product.get_all_for_store!(authorize?: false)
+      products = Product.list_visible!(authorize?: false)
 
       refute Enum.any?(products, fn p -> p.id == draft_product.id end)
     end
@@ -171,7 +171,7 @@ defmodule Edenflowers.Store.ProductTest do
       product_no_variants =
         generate(product(tax_rate_id: tax_rate.id, product_category_id: published_category.id, draft: false))
 
-      products = Product.get_all_for_store!(authorize?: false)
+      products = Product.list_visible!(authorize?: false)
 
       refute Enum.any?(products, fn p -> p.id == product_no_variants.id end)
     end
@@ -184,7 +184,7 @@ defmodule Edenflowers.Store.ProductTest do
       product = generate(product(tax_rate_id: tax_rate.id, product_category_id: draft_category.id, draft: false))
       _variant = generate(product_variant(product_id: product.id))
 
-      products = Product.get_all_for_store!(authorize?: false)
+      products = Product.list_visible!(authorize?: false)
 
       refute Enum.any?(products, fn p -> p.id == product.id end)
     end
@@ -194,7 +194,7 @@ defmodule Edenflowers.Store.ProductTest do
       product = generate(product(tax_rate_id: tax_rate.id, product_category_id: published_category.id, draft: false))
       _variant = generate(product_variant(product_id: product.id, price: "15.99"))
 
-      products = Product.get_all_for_store!(authorize?: false)
+      products = Product.list_visible!(authorize?: false)
       found_product = Enum.find(products, fn p -> p.id == product.id end)
 
       assert found_product != nil

--- a/test/product_variant_test.exs
+++ b/test/product_variant_test.exs
@@ -112,7 +112,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
     end
   end
 
-  describe "ProductVariant.for_card_drawer" do
+  describe "ProductVariant.purchasable_cards" do
     setup do
       tax_rate = generate(tax_rate())
       cards_category = generate(product_category(slug: "cards", visibility: :public))
@@ -135,7 +135,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
     test "returns variants from the cards category", %{card_product: card_product} do
       variant = generate(product_variant(product_id: card_product.id, draft: false))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
 
       assert Enum.any?(variants, fn v -> v.id == variant.id end)
     end
@@ -144,7 +144,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
       card_variant = generate(product_variant(product_id: card_product.id, draft: false))
       other_variant = generate(product_variant(product_id: other_product.id, draft: false))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
 
       assert Enum.any?(variants, fn v -> v.id == card_variant.id end)
       refute Enum.any?(variants, fn v -> v.id == other_variant.id end)
@@ -153,7 +153,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
     test "excludes draft variants", %{card_product: card_product} do
       draft_variant = generate(product_variant(product_id: card_product.id, draft: true))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
 
       refute Enum.any?(variants, fn v -> v.id == draft_variant.id end)
     end
@@ -162,7 +162,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
       draft_product = generate(product(tax_rate_id: tax_rate.id, product_category_id: cards_category.id, draft: true))
       variant = generate(product_variant(product_id: draft_product.id, draft: false))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
 
       refute Enum.any?(variants, fn v -> v.id == variant.id end)
     end
@@ -174,7 +174,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
       product = generate(product(tax_rate_id: tax_rate.id, product_category_id: draft_cards_category.id, draft: false))
       variant = generate(product_variant(product_id: product.id, draft: false))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
 
       refute Enum.any?(variants, fn v -> v.id == variant.id end)
     end
@@ -182,7 +182,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
     test "loads product with tax_rate", %{card_product: card_product} do
       generate(product_variant(product_id: card_product.id, draft: false))
 
-      variants = ProductVariant.for_card_drawer!(authorize?: false)
+      variants = ProductVariant.purchasable_cards!(authorize?: false)
       found = Enum.find(variants, fn v -> v.product_id == card_product.id end)
 
       assert found != nil
@@ -196,7 +196,7 @@ defmodule Edenflowers.Store.ProductVariantTest do
       generate(product_variant(product_id: card_product.id, size: :medium, draft: false))
 
       variants =
-        ProductVariant.for_card_drawer!(authorize?: false)
+        ProductVariant.purchasable_cards!(authorize?: false)
         |> Enum.filter(fn v -> v.product_id == card_product.id end)
         |> Enum.map(& &1.size)
 


### PR DESCRIPTION
## Summary

Reorder + naming-consistency cleanup. Stacked on top of #202 (renames). Three commits, all behaviour-preserving.

### Tier A — main resource ordering

1. **\`Order\`: constants together.** \`@checkout_states\` moves up beside \`@locales\`.
2. **\`Order\`: \`attribute :locale\` lifts into the lifecycle group.**
3. **\`Order\`: regroup actions by cluster.** Reads → create → forward checkout transitions → backward \"edit\" transitions → lifecycle → cart edits → card cluster → promotion management → fulfillment/gift → locale → reset. Existing comment headers move with their groups; no new comments added.
4. **\`Order\`: \`code_interface\` mirrors actions** — scanning side-by-side is now lockstep.
5. **\`LineItem\`: calculations in derivation order** (\`promotion_applied?\`, \`subtotal\`, \`discount\`, \`total\`, \`tax\`). Pre-existing comments stay attached to their original calculations.
6. **\`User\`: actions and code_interface ordered reads → creates → updates.** OTP defines stay near reads.

### Tier B — modest cleanup

7. **\`FulfillmentOption\`: dedupe accept-list** into an \`@accepted_fields\` module attribute used by both \`create\` and \`update\`.
8. **\`Order\`: calculations grouped by kind** — money calcs in derivation order, predicates together.

### Group A — read action atom renames for idiomatic consistency

The codebase uses filter-style atoms for read actions (\`:by_id\`, \`:featured\`, \`:by_category\`). These renames bring stragglers into line:

| Resource | Action atom | Code-interface function |
|---|---|---|
| \`Order\` | \`:completed\` → \`:placed\` | \`get_all_completed\` → \`list_placed\` |
| \`Product\` | \`:for_store\` → \`:visible\` | \`get_all_for_store\` → \`list_visible\` |
| \`Product\` | \`:get_by_category_slug\` → \`:by_category_slug\` | unchanged |
| \`ProductCategory\` | \`:get_all\` → \`:public\` | unchanged |
| \`ProductCategory\` | \`:get_by_slug\` → \`:by_slug\` | unchanged |
| \`ProductVariant\` | \`:for_card_drawer\` → \`:purchasable_cards\` | \`for_card_drawer\` → \`purchasable_cards\` |

Code-interface function names only rename where the old name became misleading after the action rename. The conventional \`get_*\` function names (\`get_by_slug\`, \`get_by_category_slug\`) stay as caller-facing API.

**Not renamed:** \`User.get_by_subject\` / \`User.get_by_email\`. AshAuthentication's transformer auto-generates these read actions to match the framework's DSL options (default action names \`:get_by_subject\` / \`:get_by_email\`). Renaming creates duplicate orphan actions. The framework contract wins over the local naming convention.

### Incidental fix

\`account_live.ex\` was passing \`current_user.id\` as a positional arg to \`Order.get_all_completed!\`, which the action never declared. Dropped — the policy already filters by \`^actor(:id)\`.

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean (all three commits)
- [x] \`mix test\` — 279/279 passing (all three commits)
- [x] Pre-push hook reran the suite — also passes
- [x] Verified post-rename that \`Ash.Resource.Info.actions(User)\` contains no duplicate orphans

## Stacking note

Based on \`order-totals-rename\` so the diff is purely reorder/dedupe/rename. Once #202 merges, this can be retargeted at \`main\` (one click in the GitHub UI) or merged as-is.

---
_Generated by [Claude Code](https://claude.ai/code)_