### PR TITLE
Add best-guess first_name calculation for User and Order

### DIFF
--- a/lib/edenflowers/accounts/calculations/first_name.ex
+++ b/lib/edenflowers/accounts/calculations/first_name.ex
@@ -1,0 +1,64 @@
+defmodule Edenflowers.Accounts.Calculations.FirstName do
+  @moduledoc """
+  Best-guess extraction of a first name from a freeform full-name string.
+
+  Customers type their name as a single field at checkout, so we never have a
+  reliable structural split. This calculation handles the common shapes:
+
+    * `"Jane Doe"`              -> `"Jane"`
+    * `"Smith, Jane"`           -> `"Jane"`  (comma-inverted form)
+    * `"  jane  "`              -> `"jane"`  (whitespace tolerated; no case mangling)
+    * `"Madonna"`               -> `"Madonna"` (mononym; the whole string is the first name)
+    * `nil` / `""` / whitespace -> `nil`
+
+  Multi-word given names ("Mary Anne") collapse to the first token. That's the
+  accepted trade-off for a heuristic — if a use case ever needs structured
+  given/family fields, capture them separately rather than extending this.
+
+  Used as a module calculation on resources that store a freeform name string.
+  Pass `source:` to point it at the right attribute:
+
+      calculate :customer_first_name, :string,
+        {Edenflowers.Accounts.Calculations.FirstName, source: :customer_name}
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def init(opts) do
+    case Keyword.fetch(opts, :source) do
+      {:ok, source} when is_atom(source) -> {:ok, opts}
+      _ -> {:error, "FirstName calculation requires a `:source` atom option"}
+    end
+  end
+
+  @impl true
+  def load(_query, opts, _context), do: [opts[:source]]
+
+  @impl true
+  def calculate(records, opts, _context) do
+    source = opts[:source]
+    Enum.map(records, fn record -> extract(Map.get(record, source)) end)
+  end
+
+  defp extract(nil), do: nil
+
+  defp extract(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed |> handle_comma_inversion() |> first_token()
+    end
+  end
+
+  defp handle_comma_inversion(name) do
+    case String.split(name, ",", parts: 2) do
+      [_last, given] -> String.trim(given)
+      [single] -> single
+    end
+  end
+
+  defp first_token(name) do
+    name
+    |> String.split(~r/\s+/, trim: true)
+    |> List.first()
+  end
+end

--- a/lib/edenflowers/accounts/user.ex
+++ b/lib/edenflowers/accounts/user.ex
@@ -187,6 +187,10 @@ defmodule Edenflowers.Accounts.User do
     belongs_to :newsletter_promo, Edenflowers.Store.Promotion
   end
 
+  calculations do
+    calculate :first_name, :string, {Edenflowers.Accounts.Calculations.FirstName, source: :name}
+  end
+
   identities do
     identity :unique_email, [:email]
   end

--- a/lib/edenflowers/store/order.ex
+++ b/lib/edenflowers/store/order.ex
@@ -427,6 +427,8 @@ defmodule Edenflowers.Store.Order do
   end
 
   calculations do
+    calculate :customer_first_name, :string, {Edenflowers.Accounts.Calculations.FirstName, source: :customer_name}
+
     calculate :promotion_applied?, :boolean, expr(not is_nil(promotion_id))
     calculate :grand_total, :decimal, expr(items_subtotal + (fulfillment_fee || 0))
 

--- a/test/edenflowers/accounts/calculations/first_name_test.exs
+++ b/test/edenflowers/accounts/calculations/first_name_test.exs
@@ -1,0 +1,164 @@
+defmodule Edenflowers.Accounts.Calculations.FirstNameTest do
+  use Edenflowers.DataCase, async: true
+  import Generator
+
+  alias Edenflowers.Accounts.Calculations.FirstName
+  alias Edenflowers.Accounts.User
+
+  describe "init/1" do
+    test "accepts a :source atom" do
+      assert {:ok, opts} = FirstName.init(source: :name)
+      assert opts[:source] == :name
+    end
+
+    test "rejects when :source is missing" do
+      assert {:error, _msg} = FirstName.init([])
+    end
+
+    test "rejects when :source is not an atom" do
+      assert {:error, _msg} = FirstName.init(source: "name")
+    end
+  end
+
+  describe "calculate/3 extraction" do
+    test "extracts the first token of a 'First Last' name" do
+      assert ["Jane"] = calc([%{name: "Jane Doe"}])
+    end
+
+    test "returns the given name from a 'Last, First' comma-inverted form" do
+      assert ["Jane"] = calc([%{name: "Smith, Jane"}])
+    end
+
+    test "trims whitespace around a comma-inverted given name" do
+      assert ["Jane"] = calc([%{name: "Smith,   Jane"}])
+    end
+
+    test "handles multi-word given name in comma-inverted form by taking the first token" do
+      assert ["Mary"] = calc([%{name: "Smith, Mary Anne"}])
+    end
+
+    test "collapses multi-word given names to the first token" do
+      assert ["Mary"] = calc([%{name: "Mary Anne Smith"}])
+    end
+
+    test "treats a mononym as the first name" do
+      assert ["Madonna"] = calc([%{name: "Madonna"}])
+    end
+
+    test "preserves casing — does not titlecase or downcase" do
+      assert ["jane"] = calc([%{name: "  jane  "}])
+      assert ["JANE"] = calc([%{name: "JANE DOE"}])
+    end
+
+    test "tolerates repeated internal whitespace" do
+      assert ["Jane"] = calc([%{name: "Jane     Doe"}])
+    end
+
+    test "tolerates tabs and mixed whitespace" do
+      assert ["Jane"] = calc([%{name: "\tJane\tDoe\t"}])
+    end
+
+    test "returns nil for nil input" do
+      assert [nil] = calc([%{name: nil}])
+    end
+
+    test "returns nil for an empty string" do
+      assert [nil] = calc([%{name: ""}])
+    end
+
+    test "returns nil for a whitespace-only string" do
+      assert [nil] = calc([%{name: "     "}])
+    end
+
+    test "operates on the field named by :source" do
+      records = [%{customer_name: "Jane Doe"}, %{customer_name: "Madonna"}]
+      assert ["Jane", "Madonna"] = FirstName.calculate(records, [source: :customer_name], %{})
+    end
+
+    test "preserves record ordering across a batch" do
+      records = [
+        %{name: "Alice Adams"},
+        %{name: nil},
+        %{name: "Smith, Bob"},
+        %{name: "Carol"}
+      ]
+
+      assert ["Alice", nil, "Bob", "Carol"] = FirstName.calculate(records, [source: :name], %{})
+    end
+  end
+
+  describe "load/3" do
+    test "declares the source attribute as a dependency" do
+      assert FirstName.load(nil, [source: :name], %{}) == [:name]
+      assert FirstName.load(nil, [source: :customer_name], %{}) == [:customer_name]
+    end
+  end
+
+  describe "User.first_name calculation" do
+    test "extracts first name from User.name" do
+      {:ok, user} = User.upsert("jane@example.com", "Jane Doe", authorize?: false)
+      user = Ash.load!(user, [:first_name], authorize?: false)
+
+      assert user.first_name == "Jane"
+    end
+
+    test "returns nil when User.name is nil" do
+      {:ok, user} = User.upsert("noname@example.com", nil, authorize?: false)
+      user = Ash.load!(user, [:first_name], authorize?: false)
+
+      assert is_nil(user.first_name)
+    end
+
+    test "handles comma-inverted names on User" do
+      {:ok, user} = User.upsert("smith@example.com", "Smith, Jane", authorize?: false)
+      user = Ash.load!(user, [:first_name], authorize?: false)
+
+      assert user.first_name == "Jane"
+    end
+
+    test "handles mononyms on User" do
+      {:ok, user} = User.upsert("madonna@example.com", "Madonna", authorize?: false)
+      user = Ash.load!(user, [:first_name], authorize?: false)
+
+      assert user.first_name == "Madonna"
+    end
+  end
+
+  describe "Order.customer_first_name calculation" do
+    test "extracts first name from Order.customer_name" do
+      order = generate(order(customer_name: "Jane Doe"))
+      order = Ash.load!(order, [:customer_first_name], authorize?: false)
+
+      assert order.customer_first_name == "Jane"
+    end
+
+    test "returns nil when Order.customer_name is nil" do
+      order = generate(order(customer_name: nil))
+      order = Ash.load!(order, [:customer_first_name], authorize?: false)
+
+      assert is_nil(order.customer_first_name)
+    end
+
+    test "handles comma-inverted customer_name" do
+      order = generate(order(customer_name: "Smith, Jane"))
+      order = Ash.load!(order, [:customer_first_name], authorize?: false)
+
+      assert order.customer_first_name == "Jane"
+    end
+
+    test "reads from customer_name independently of the linked User.name" do
+      # customer_name is a per-order snapshot, so even when a user is linked
+      # with a different name the calculation should reflect what the order
+      # stored at checkout time.
+      {:ok, user} = User.upsert("snap@example.com", "Different User Name", authorize?: false)
+      order = generate(order(user_id: user.id, customer_name: "Snapshot Name"))
+
+      order = Ash.load!(order, [:customer_first_name], authorize?: false)
+      assert order.customer_first_name == "Snapshot"
+    end
+  end
+
+  defp calc(records, opts \\ [source: :name]) do
+    FirstName.calculate(records, opts, %{})
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Edenflowers.Accounts.Calculations.FirstName`, a module calculation that does a best-guess extraction of a first name from a freeform full-name string. Handles mononyms, `"First Last"`, `"Last, First"` comma-inverted form, extra whitespace, and `nil`/blank.
- Exposes the calculation as `User.first_name` (reads from `User.name`) and `Order.customer_first_name` (reads from the snapshotted `Order.customer_name`).
- Accepts a `:source` option so the same module backs both resources without duplication.

## Why a calculation rather than a stored field?

Checkout captures the customer name as a single freeform string — there's no schema commitment to a first/last split. Keeping the first name as a derived view rather than a stored attribute means we can refine the heuristic without a migration, and we never have to worry about the split going stale relative to the source.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] Full test suite green (291 tests, 0 failures) via pre-push hook
- [ ] Manually verify in IEx: `Edenflowers.Store.Order |> Ash.Query.load(:customer_first_name) |> Ash.read!()` returns expected first names for representative orders
- [ ] Manually verify `"Smith, Jane"` → `"Jane"`, `"Madonna"` → `"Madonna"`, `nil` → `nil`