### PR TITLE
Clear card_message form param when removing card

### DIFF
--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -611,7 +611,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   def handle_event("remove_card", _, socket) do
     order = Order.remove_card!(socket.assigns.order, actor: actor(socket))
-    {:noreply, assign_forms(socket, order)}
+    {:noreply, assign_forms(socket, order, drop: ["card_message"])}
   end
 
   # Stripe events
@@ -709,8 +709,19 @@ defmodule EdenflowersWeb.CheckoutLive do
   # some validations read off the order's loaded relationships (e.g. line_items);
   # the params side has to be preserved so selecting a card doesn't wipe values
   # the customer is still editing.
-  defp assign_forms(socket, order) do
-    form_params = if form = socket.assigns[:form], do: form.params, else: %{}
+  #
+  # Pass `drop: ["field_name", ...]` to discard specific params that the
+  # action just invalidated (e.g. clearing `card_message` when the card is
+  # removed) — otherwise the stale typed value would shadow the now-nil
+  # attribute on the rebuilt form.
+  defp assign_forms(socket, order, opts \\ []) do
+    drop = Keyword.get(opts, :drop, [])
+
+    form_params =
+      case socket.assigns[:form] do
+        nil -> %{}
+        form -> Map.drop(form.params, drop)
+      end
 
     socket
     |> assign(order: order)

--- a/test/edenflowers_web/live/checkout_live_test.exs
+++ b/test/edenflowers_web/live/checkout_live_test.exs
@@ -7,6 +7,7 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
     only: [
       live: 2,
       render_click: 3,
+      render_change: 2,
       element: 2,
       render_blur: 2,
       render_submit: 2,
@@ -461,6 +462,29 @@ defmodule EdenflowersWeb.CheckoutLiveTest do
 
       reloaded = Order.get_for_checkout!(gift_order.id, actor: nil)
       assert is_nil(reloaded.card_message)
+    end
+
+    test "re-adding a card after removal renders an empty card_message field",
+         %{conn: conn, variant: variant, card_variant: card_variant} do
+      gift_order = generate(order(state: :gift_options, gift: true, recipient_name: "Test"))
+
+      Order.add_line_item!(gift_order, variant.id, 1, authorize?: false)
+
+      Order.add_card!(gift_order, card_variant.id, authorize?: false)
+
+      {:ok, view, _html} =
+        conn
+        |> Plug.Test.init_test_session(%{order_id: gift_order.id})
+        |> live("/checkout")
+
+      view
+      |> element("[data-testid='checkout-form-2']")
+      |> render_change(%{"form" => %{"card_message" => "Stale message"}})
+
+      render_click(view, "remove_card", %{})
+      html = render_click(view, "select_card", %{"variant-id" => card_variant.id})
+
+      assert html =~ ~r{<textarea[^>]*data-testid="card-message-textarea"[^>]*>\s*</textarea>}
     end
   end
 


### PR DESCRIPTION
## Summary
- `assign_forms` preserves typed form params across rebuilds so selecting a different card doesn't wipe input the customer is still editing. On `remove_card` this preservation worked against us: the Ash action nulled `card_message` on the order, but the typed value remained in `form.params` and shadowed the attribute when the customer re-added a card — surfacing as a stale message in the textarea.
- Extended `assign_forms` with an optional `drop:` keyword and used it from the `remove_card` handler to discard the stale param.
- Added a LiveView regression test that seeds a typed `card_message`, fires `remove_card` then `select_card`, and asserts the rendered textarea is empty.

## Test plan
- [x] `mix test test/edenflowers_web/live/checkout_live_test.exs` — 31 tests pass, including the new regression test.
- [x] Verified the new test fails when the `drop: ["card_message"]` argument is removed (catches the regression).
- [x] Full `mix test` suite — 291 tests, 0 failures (ran via pre-push hook).
- [ ] Manual smoke: in checkout, add card → type a message → remove card → add card again → confirm the textarea is empty.