### PR TITLE
Highlight key dates in checkout calendar

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,7 @@
 @source "../css";
 @source "../js";
 @source "../../lib/edenflowers_web";
+@source "../../lib/edenflowers";
 
 @custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -36,10 +36,19 @@ defmodule Edenflowers.Store.KeyDates do
 
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)
 
+  # Find the nth weekday of a month, e.g. the 2nd Sunday in May 2026 (Mother's Day).
   defp materialise({:nth_weekday, month, weekday, n}, year) do
+    # The weekday we want, as a number. Monday is 1, Sunday is 7.
     target = Map.fetch!(@weekdays, weekday)
+
+    # Start from the 1st of the month.
     first = Date.new!(year, month, 1)
+
+    # How many days to walk forward to reach the first matching weekday.
+    # mod 7 keeps this in 0..6, even if the subtraction goes negative.
     offset = Integer.mod(target - Date.day_of_week(first), 7)
+
+    # Jump to the first match, then add a week for each one after that.
     Date.add(first, offset + (n - 1) * 7)
   end
 end

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -1,0 +1,45 @@
+defmodule Edenflowers.Store.KeyDates do
+  @moduledoc """
+  Florist-relevant key dates rendered as decorations in the checkout calendar.
+
+  The list is intentionally code-defined rather than DB-backed: these holidays
+  are stable for years at a time, and version-controlling the list keeps every
+  change reviewable. Per-customer reminder dates (the wider auto-send feature)
+  will live in a separate, customer-scoped resource.
+  """
+
+  @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
+
+  @holidays [
+    %{name: "Valentine's Day", icon: "hero-heart-solid", rule: {:fixed, 2, 14}},
+    %{name: "Women's Day", icon: "hero-sparkles-solid", rule: {:fixed, 3, 8}},
+    %{name: "Mother's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 5, :sunday, 2}},
+    %{name: "Father's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 11, :sunday, 2}},
+    %{name: "Christmas Eve", icon: "hero-gift-solid", rule: {:fixed, 12, 24}}
+  ]
+
+  @spec for_year(integer()) :: [%{date: Date.t(), icon: String.t(), name: String.t()}]
+  def for_year(year) do
+    Enum.map(@holidays, fn %{rule: rule} = holiday ->
+      holiday
+      |> Map.delete(:rule)
+      |> Map.put(:date, materialise(rule, year))
+    end)
+  end
+
+  @spec icons_by_date(integer()) :: %{Date.t() => String.t()}
+  def icons_by_date(year) do
+    year
+    |> for_year()
+    |> Map.new(fn %{date: date, icon: icon} -> {date, icon} end)
+  end
+
+  defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)
+
+  defp materialise({:nth_weekday, month, weekday, n}, year) do
+    target = Map.fetch!(@weekdays, weekday)
+    first = Date.new!(year, month, 1)
+    offset = Integer.mod(target - Date.day_of_week(first), 7)
+    Date.add(first, offset + (n - 1) * 7)
+  end
+end

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -27,11 +27,11 @@ defmodule Edenflowers.Store.KeyDates do
     end)
   end
 
-  @spec icons_by_date(integer()) :: %{Date.t() => String.t()}
-  def icons_by_date(year) do
-    year
-    |> for_year()
-    |> Map.new(fn %{date: date, icon: icon} -> {date, icon} end)
+  @spec icon_for(Date.t()) :: String.t() | nil
+  def icon_for(%Date{} = date) do
+    Enum.find_value(@holidays, fn %{rule: rule, icon: icon} ->
+      if materialise(rule, date.year) == date, do: icon
+    end)
   end
 
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -5,7 +5,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   import EdenflowersWeb.CheckoutComponents, only: [steps: 1]
 
-  alias Edenflowers.Store.{Order, FulfillmentOption, ProductVariant, ProductVariantSize}
+  alias Edenflowers.Store.{Order, FulfillmentOption, KeyDates, ProductVariant, ProductVariantSize}
   alias Edenflowers.Fulfillments
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
@@ -30,6 +30,7 @@ defmodule EdenflowersWeb.CheckoutLive do
          {:ok, fulfillment_options} <- FulfillmentOption.list_for_checkout() do
       order = ensure_fulfillment_default(order, fulfillment_options, socket.assigns[:current_user])
       card_variants = ProductVariant.for_card_drawer!()
+      key_date_icons = load_key_date_icons()
 
       {:ok,
        socket
@@ -37,6 +38,7 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:page_title, ~t"Checkout")
        |> assign(:fulfillment_options, fulfillment_options)
        |> assign(:card_variants, card_variants)
+       |> assign(:key_date_icons, key_date_icons)
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
        |> assign(:client_secret, nil)
@@ -219,8 +221,8 @@ defmodule EdenflowersWeb.CheckoutLive do
                         >
                           <:day_decoration :let={day}>
                             <.icon
-                              :if={day == ~D[2025-05-07]}
-                              name="hero-heart-solid"
+                              :if={icon = Map.get(@key_date_icons, day)}
+                              name={icon}
                               class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
                             />
                           </:day_decoration>
@@ -774,6 +776,15 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp cart_has_items?(%{cart_effectively_empty?: true}), do: {:error, :empty_cart}
   defp cart_has_items?(_order), do: :ok
+
+  defp load_key_date_icons do
+    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
+
+    Map.merge(
+      KeyDates.icons_by_date(today.year),
+      KeyDates.icons_by_date(today.year + 1)
+    )
+  end
 
   # ===========
   # DOM helpers

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -30,7 +30,6 @@ defmodule EdenflowersWeb.CheckoutLive do
          {:ok, fulfillment_options} <- FulfillmentOption.list_for_checkout() do
       order = ensure_fulfillment_default(order, fulfillment_options, socket.assigns[:current_user])
       card_variants = ProductVariant.for_card_drawer!()
-      key_date_icons = load_key_date_icons()
 
       {:ok,
        socket
@@ -38,7 +37,6 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:page_title, ~t"Checkout")
        |> assign(:fulfillment_options, fulfillment_options)
        |> assign(:card_variants, card_variants)
-       |> assign(:key_date_icons, key_date_icons)
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
        |> assign(:client_secret, nil)
@@ -221,7 +219,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                         >
                           <:day_decoration :let={day}>
                             <.icon
-                              :if={icon = Map.get(@key_date_icons, day)}
+                              :if={icon = KeyDates.icon_for(day)}
                               name={icon}
                               class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
                             />
@@ -776,15 +774,6 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp cart_has_items?(%{cart_effectively_empty?: true}), do: {:error, :empty_cart}
   defp cart_has_items?(_order), do: :ok
-
-  defp load_key_date_icons do
-    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
-
-    Map.merge(
-      KeyDates.icons_by_date(today.year),
-      KeyDates.icons_by_date(today.year + 1)
-    )
-  end
 
   # ===========
   # DOM helpers

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -1,0 +1,53 @@
+defmodule Edenflowers.Store.KeyDatesTest do
+  use ExUnit.Case, async: true
+
+  alias Edenflowers.Store.KeyDates
+
+  describe "for_year/1" do
+    test "materialises the five known holidays for 2026" do
+      by_name = KeyDates.for_year(2026) |> Map.new(fn %{name: n, date: d} -> {n, d} end)
+
+      assert by_name["Valentine's Day"] == ~D[2026-02-14]
+      assert by_name["Women's Day"] == ~D[2026-03-08]
+      assert by_name["Mother's Day"] == ~D[2026-05-10]
+      assert by_name["Father's Day"] == ~D[2026-11-08]
+      assert by_name["Christmas Eve"] == ~D[2026-12-24]
+    end
+
+    test "nth-weekday rule shifts year-over-year" do
+      mothers_day = fn year ->
+        KeyDates.for_year(year)
+        |> Enum.find(&(&1.name == "Mother's Day"))
+        |> Map.fetch!(:date)
+      end
+
+      assert mothers_day.(2026) == ~D[2026-05-10]
+      assert mothers_day.(2027) == ~D[2027-05-09]
+      assert mothers_day.(2028) == ~D[2028-05-14]
+    end
+
+    test "every entry has a heroicon name and a human-readable name" do
+      for %{name: name, icon: icon} <- KeyDates.for_year(2026) do
+        assert is_binary(name) and name != ""
+        assert String.starts_with?(icon, "hero-")
+      end
+    end
+  end
+
+  describe "icons_by_date/1" do
+    test "maps each holiday's date to its icon" do
+      icons = KeyDates.icons_by_date(2026)
+
+      assert icons[~D[2026-02-14]] == "hero-heart-solid"
+      assert icons[~D[2026-03-08]] == "hero-sparkles-solid"
+      assert icons[~D[2026-05-10]] == "hero-heart-solid"
+      assert icons[~D[2026-11-08]] == "hero-heart-solid"
+      assert icons[~D[2026-12-24]] == "hero-gift-solid"
+    end
+
+    test "returns nil for non-holiday dates" do
+      icons = KeyDates.icons_by_date(2026)
+      assert icons[~D[2026-06-15]] == nil
+    end
+  end
+end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -34,20 +34,23 @@ defmodule Edenflowers.Store.KeyDatesTest do
     end
   end
 
-  describe "icons_by_date/1" do
-    test "maps each holiday's date to its icon" do
-      icons = KeyDates.icons_by_date(2026)
+  describe "icon_for/1" do
+    test "returns the icon for each holiday in 2026" do
+      assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-03-08]) == "hero-sparkles-solid"
+      assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-11-08]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-12-24]) == "hero-gift-solid"
+    end
 
-      assert icons[~D[2026-02-14]] == "hero-heart-solid"
-      assert icons[~D[2026-03-08]] == "hero-sparkles-solid"
-      assert icons[~D[2026-05-10]] == "hero-heart-solid"
-      assert icons[~D[2026-11-08]] == "hero-heart-solid"
-      assert icons[~D[2026-12-24]] == "hero-gift-solid"
+    test "tracks the right year — Mother's Day shifts across years" do
+      assert KeyDates.icon_for(~D[2027-05-09]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2028-05-14]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2027-05-10]) == nil
     end
 
     test "returns nil for non-holiday dates" do
-      icons = KeyDates.icons_by_date(2026)
-      assert icons[~D[2026-06-15]] == nil
+      assert KeyDates.icon_for(~D[2026-06-15]) == nil
     end
   end
 end


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `~D[2025-05-07]` placeholder in `CheckoutLive`'s day-decoration slot with a code-defined list of florist-relevant holidays: Valentine's Day, Women's Day, Mother's Day, Father's Day, Christmas Eve.
- New `Edenflowers.Store.KeyDates` module materialises each year's concrete dates from a small recurrence DSL (`:fixed` and `:nth_weekday`). The slot consults `KeyDates.icon_for/1` directly — no LV assign, no mount-time caching.
- Extends Tailwind's `@source` allowlist to `lib/edenflowers` so the `hero-*` icon class literals in `KeyDates` are detected by the JIT scanner and CSS gets emitted.

Two commits for clarity: the first ships the feature with a mount-time icon map; the second simplifies to on-demand computation. Squash if you prefer a single landing point.

Closes #208.

## Test plan
- [x] `mix test test/key_dates_test.exs` — 6 tests covering each holiday's date across 2026, 2027, 2028 (Mother's Day rule shift), icon mapping, and the negative case.
- [x] `mix test` — full suite, 296 tests passing locally.
- [ ] Smoke-check in the browser: load the checkout calendar, navigate to a month containing one of the seeded holidays, confirm the correct Heroicon renders in the right cell.