### PR TITLE
Admin fulfillment calendar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Project
+
+- Call `source .env` before running mix.
+
 ## Coding Standards
 
 - Do not add comments that reiterate what the code does.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -706,3 +706,67 @@ body.ready {
   background-color: #fafaf9;
   background-image: url("data:image/svg+xml,%3Csvg width='52' height='26' viewBox='0 0 52 26' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23294735' fill-opacity='0.04'%3E%3Cpath d='M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
+
+/* Admin fulfillment calendar — decorations
+   Two visual primitives layered onto cells / legend swatches:
+   - strike: a short diagonal line through the centre, marking a closed cell.
+   - corner: a top-right triangle, marking an override that contradicts the weekday rule.
+   Each is offered on both pseudo-elements so cells can use one slot for the
+   strike and the other for the corner without colliding. */
+@utility calendar-strike-after {
+  &::after {
+    content: "";
+    position: absolute;
+    left: 22%;
+    right: 22%;
+    top: 50%;
+    height: 2px;
+    border-radius: 9999px;
+    transform: translateY(-50%) rotate(-22deg);
+    @apply bg-error/75;
+  }
+
+  &:hover::after {
+    @apply bg-error;
+  }
+}
+
+@utility calendar-strike-before {
+  &::before {
+    content: "";
+    position: absolute;
+    left: 22%;
+    right: 22%;
+    top: 50%;
+    height: 2px;
+    border-radius: 9999px;
+    transform: translateY(-50%) rotate(-22deg);
+    @apply bg-error/75;
+  }
+}
+
+@utility calendar-corner-before {
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0.5rem;
+    height: 0.5rem;
+    clip-path: polygon(100% 0, 0 0, 100% 100%);
+    @apply bg-primary/75;
+  }
+}
+
+@utility calendar-corner-after {
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0.5rem;
+    height: 0.5rem;
+    clip-path: polygon(100% 0, 0 0, 100% 100%);
+    @apply bg-primary/75;
+  }
+}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -722,7 +722,28 @@ body.ready {
     top: 50%;
     height: 2px;
     border-radius: 9999px;
-    transform: translateY(-50%) rotate(-22deg);
+    transform: translateY(-50%) rotate(45deg);
+    @apply bg-error/75;
+  }
+
+  &:hover::after {
+    @apply bg-error;
+  }
+}
+
+/* Tighter strike for smaller elements (weekday header buttons). Same angle
+   and colour as calendar-strike-after — just a shorter visible span so the
+   slash doesn't overshoot a 3-letter label. */
+@utility calendar-strike-after-tight {
+  &::after {
+    content: "";
+    position: absolute;
+    left: 32%;
+    right: 32%;
+    top: 50%;
+    height: 2px;
+    border-radius: 9999px;
+    transform: translateY(-50%) rotate(45deg);
     @apply bg-error/75;
   }
 
@@ -740,7 +761,7 @@ body.ready {
     top: 50%;
     height: 2px;
     border-radius: 9999px;
-    transform: translateY(-50%) rotate(-22deg);
+    transform: translateY(-50%) rotate(45deg);
     @apply bg-error/75;
   }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,7 @@
 @source "../css";
 @source "../js";
 @source "../../lib/edenflowers_web";
+@source "../../lib/edenflowers";
 
 @custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -770,3 +770,16 @@ body.ready {
     @apply bg-primary/75;
   }
 }
+
+/* Mixed state — options disagree at the current scope. 45° stripes are the
+   universal "indeterminate / pending" pattern; distinct from closed (strike),
+   open (plain), and past (faded), and pure background so the digit reads on top. */
+@utility calendar-mixed {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0,
+    transparent 4px,
+    color-mix(in oklab, var(--color-base-content) 22%, transparent) 4px,
+    color-mix(in oklab, var(--color-base-content) 22%, transparent) 5.5px
+  );
+}

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -295,7 +295,7 @@ Hooks.CalendarHook = {
     // Read targets from the currently-focused cell, not the root: each cell's
     // targets are relative to its own date (ArrowDown from May 1 -> May 8,
     // ArrowDown from May 8 -> May 15, etc).
-    const viewDateEl = this.getElement(`calendar-day-${this.viewDate}`);
+    const viewDateEl = this.getElement(`${this.id}-day-${this.viewDate}`);
     if (!viewDateEl) return;
 
     const targets = this.parseKeyTargets(viewDateEl);
@@ -359,7 +359,7 @@ Hooks.CalendarHook = {
       return;
     }
 
-    const dateEl = this.getElement(`calendar-day-${date}`);
+    const dateEl = this.getElement(`${this.id}-day-${date}`);
     if (dateEl) {
       /** @type {HTMLElement} */ (dateEl).focus();
     }
@@ -389,14 +389,14 @@ Hooks.CalendarHook = {
    */
   setTabIndex(nextDate = null) {
     // Remove focus from view date
-    const viewDateEl = this.getElement(`calendar-day-${this.viewDate}`);
+    const viewDateEl = this.getElement(`${this.id}-day-${this.viewDate}`);
     if (viewDateEl) {
       viewDateEl.setAttribute("tabindex", "-1");
     }
 
     // Set focus on next date
     if (nextDate) {
-      const nextDateEl = this.getElement(`calendar-day-${nextDate}`);
+      const nextDateEl = this.getElement(`${this.id}-day-${nextDate}`);
       if (nextDateEl) {
         nextDateEl.setAttribute("tabindex", "0");
       }

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -1,5 +1,6 @@
 defmodule Edenflowers.Fulfillments do
   alias Edenflowers.Store.FulfillmentOption
+  alias Edenflowers.Weekday
   import Decimal, only: [is_decimal: 1]
 
   defp here_api, do: Application.get_env(:edenflowers, :here_api, Edenflowers.HereAPI)
@@ -94,6 +95,8 @@ defmodule Edenflowers.Fulfillments do
     - The day of week is disabled and the date is not in the enabled dates
     - The date is today but the deadline for same day delivery has passed
     - The date is today but same day delivery is disabled
+
+  `now` must be a DateTime — same-day deadline checks need the time of day.
   """
   @spec fulfill_on_date(FulfillmentOption.t(), Date.t(), DateTime.t()) :: {boolean(), atom()}
   def fulfill_on_date(fulfillment_option = %FulfillmentOption{}, date, now \\ now()) do
@@ -112,21 +115,47 @@ defmodule Edenflowers.Fulfillments do
   @type cell_state :: :open | :past | :weekday_off | :override_off
 
   @doc """
-  Map `fulfill_on_date/3` into a coarse-grained cell state for the calendar UI.
+  Coarse-grained cell state for the calendar UI. Used by both the customer
+  checkout calendar and the admin date-toggle editor so styling can't drift
+  from the actual selectability rules.
 
-  Both the customer-facing checkout calendar and the admin date-toggle editor
-  consume this so the styling stays in sync with the actual selectability rules.
+  Two audiences:
 
-  Same-day reasons collapse to `:past` — from the user's perspective, "today is
-  unavailable" reads exactly like "the past": a date you can't pick.
+  - `:customer` (default) — `now` must be a `DateTime`. Same-day deadline rules
+    apply: today collapses to `:past` once the order deadline has passed or
+    when `same_day: false`. From the customer's perspective, "can't pick today"
+    looks identical to "the past".
+
+  - `:admin` — `now` is a `Date`. Same-day rules are skipped because the admin
+    is editing rules, not booking against them. Today reflects whatever the
+    weekday/override rules say so it can be toggled like any other date.
   """
-  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t()) :: cell_state()
-  def cell_state(fulfillment_option, date, now \\ now()) do
+  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t() | Date.t(), keyword()) :: cell_state()
+  def cell_state(fulfillment_option, date, now \\ now(), opts \\ [])
+
+  def cell_state(fulfillment_option, date, now, opts) when is_list(opts) do
+    case Keyword.get(opts, :audience, :customer) do
+      :admin -> admin_cell_state(fulfillment_option, date, now)
+      :customer -> customer_cell_state(fulfillment_option, date, now)
+    end
+  end
+
+  defp customer_cell_state(fulfillment_option, date, now) do
     case fulfill_on_date(fulfillment_option, date, now) do
       {true, _} -> :open
       {false, :date_disabled} -> :override_off
       {false, :day_of_week_disabled} -> :weekday_off
       {false, _past_or_same_day} -> :past
+    end
+  end
+
+  defp admin_cell_state(option, date, today) do
+    cond do
+      Date.compare(date, today) == :lt -> :past
+      date in option.disabled_dates -> :override_off
+      date in option.enabled_dates -> :open
+      weekday_enabled?({option, date, nil}) -> :open
+      true -> :weekday_off
     end
   end
 
@@ -143,8 +172,7 @@ defmodule Edenflowers.Fulfillments do
   end
 
   defp weekday_enabled?({%{available_days: available_days}, date, _now}) do
-    day = date |> Date.day_of_week() |> day_of_week_to_atom()
-    day in available_days
+    Weekday.from_date(date) in available_days
   end
 
   defp fulfill_today?({%{same_day: false, order_deadline: _order_deadline}, date, now}) do
@@ -160,14 +188,6 @@ defmodule Edenflowers.Fulfillments do
   end
 
   defp date_today?(date, now), do: Date.compare(date, now) == :eq
-
-  defp day_of_week_to_atom(1), do: :monday
-  defp day_of_week_to_atom(2), do: :tuesday
-  defp day_of_week_to_atom(3), do: :wednesday
-  defp day_of_week_to_atom(4), do: :thursday
-  defp day_of_week_to_atom(5), do: :friday
-  defp day_of_week_to_atom(6), do: :saturday
-  defp day_of_week_to_atom(7), do: :sunday
 
   defp now(), do: DateTime.now!("Europe/Helsinki")
 end

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -109,6 +109,27 @@ defmodule Edenflowers.Fulfillments do
     end
   end
 
+  @type cell_state :: :open | :past | :weekday_off | :override_off
+
+  @doc """
+  Map `fulfill_on_date/3` into a coarse-grained cell state for the calendar UI.
+
+  Both the customer-facing checkout calendar and the admin date-toggle editor
+  consume this so the styling stays in sync with the actual selectability rules.
+
+  Same-day reasons collapse to `:past` — from the user's perspective, "today is
+  unavailable" reads exactly like "the past": a date you can't pick.
+  """
+  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t()) :: cell_state()
+  def cell_state(fulfillment_option, date, now \\ now()) do
+    case fulfill_on_date(fulfillment_option, date, now) do
+      {true, _} -> :open
+      {false, :date_disabled} -> :override_off
+      {false, :day_of_week_disabled} -> :weekday_off
+      {false, _past_or_same_day} -> :past
+    end
+  end
+
   defp date_past?({_, date, now}) do
     Date.compare(date, now) == :lt
   end

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -138,12 +138,8 @@ defmodule Edenflowers.Fulfillments do
     Enum.member?(disabled_dates, date)
   end
 
-  # Treats florist key dates as if they were always in `enabled_dates`, so the
-  # weekday rule cannot close them as collateral. An explicit `disabled_dates`
-  # entry still wins, and same-day operational rules still apply — the admin
-  # can deliberately close a key date, but cannot do so by accident.
   defp date_enabled?({%{enabled_dates: enabled_dates}, date, _}) do
-    Enum.member?(enabled_dates, date) or not is_nil(Edenflowers.Store.KeyDates.icon_for(date))
+    Enum.member?(enabled_dates, date)
   end
 
   defp weekday_enabled?({%{available_days: available_days}, date, _now}) do

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -92,7 +92,7 @@ defmodule Edenflowers.Fulfillments do
 
     - The date is in the past
     - The date is disabled
-    - The day of week is disabled and the date is not in the enabled dates
+    - The weekday is disabled and the date is not in the enabled dates
     - The date is today but the deadline for same day delivery has passed
     - The date is today but same day delivery is disabled
   """
@@ -104,63 +104,57 @@ defmodule Edenflowers.Fulfillments do
           fulfill_today?(params)} do
       {true, _, _, _, _} -> {false, :past}
       {_, true, _, _, _} -> {false, :date_disabled}
-      {_, _, false, false, _} -> {false, :day_of_week_disabled}
+      {_, _, false, false, _} -> {false, :weekday_disabled}
       {_, _, _, _, {false, reason}} -> {false, reason}
       _ -> {true, :ok}
     end
   end
 
   @typedoc """
-  Coarse-grained selectability of a calendar cell. Drives both styling and
-  whether the cell propagates a click; the customer and admin calendars share
-  this vocabulary so they can't drift apart.
+  Customer-facing calendar cell state. The customer can't act on the why-not,
+  so every unavailable date — whether the weekday is off or the date is
+  explicitly in `disabled_dates` — reads as `:closed`.
   """
-  @type cell_state :: :open | :past | :weekday_off | :override_off
+  @type customer_cell_state :: :open | :closed | :past
 
-  @type audience :: :customer | :admin
+  @typedoc """
+  Admin-facing calendar cell state. The admin is editing the rules, so the
+  distinction between `:weekday_disabled` (the weekday rule closes the date)
+  and `:date_disabled` (an explicit override closes the date) matters —
+  clicking each produces a different update.
+  """
+  @type admin_cell_state :: :open | :past | :weekday_disabled | :date_disabled
 
   @doc """
-  Coarse-grained cell state for the calendar UI. Used by both the customer
-  checkout calendar and the admin date-toggle editor so styling can't drift
-  from the actual selectability rules.
-
-  Two audiences:
-
-  - `:customer` (default) — `now` must be a `DateTime`. Same-day deadline rules
-    apply: today collapses to `:past` once the order deadline has passed or
-    when `same_day: false`. From the customer's perspective, "can't pick today"
-    looks identical to "the past".
-
-  - `:admin` — `now` is a `Date`. Same-day rules are skipped because the admin
-    is editing rules, not booking against them. Today reflects whatever the
-    weekday/override rules say so it can be toggled like any other date.
+  Customer-facing cell state for the checkout calendar. `now` must be a
+  `DateTime` because same-day deadline rules apply: today collapses to `:past`
+  once the order deadline has passed or when `same_day: false`. From the
+  customer's perspective, "can't pick today" looks identical to "the past".
   """
-  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t() | Date.t(), audience: audience()) :: cell_state()
-  def cell_state(fulfillment_option, date, now \\ now(), opts \\ [])
-
-  def cell_state(fulfillment_option, date, now, opts) when is_list(opts) do
-    case Keyword.get(opts, :audience, :customer) do
-      :admin -> admin_cell_state(fulfillment_option, date, now)
-      :customer -> customer_cell_state(fulfillment_option, date, now)
-    end
-  end
-
-  defp customer_cell_state(fulfillment_option, date, now) do
+  @spec customer_cell_state(FulfillmentOption.t(), Date.t(), DateTime.t()) :: customer_cell_state()
+  def customer_cell_state(fulfillment_option, date, now \\ now()) do
     case fulfill_on_date(fulfillment_option, date, now) do
       {true, _} -> :open
-      {false, :date_disabled} -> :override_off
-      {false, :day_of_week_disabled} -> :weekday_off
+      {false, :date_disabled} -> :closed
+      {false, :weekday_disabled} -> :closed
       {false, _past_or_same_day} -> :past
     end
   end
 
-  defp admin_cell_state(option, date, today) do
+  @doc """
+  Admin-facing cell state for the date-toggle editor. `today` is a `Date`;
+  same-day deadline rules are skipped because the admin is editing rules, not
+  booking against them. Today reflects whatever the weekday rule and any
+  per-date override say, so it can be toggled like any other date.
+  """
+  @spec admin_cell_state(FulfillmentOption.t(), Date.t(), Date.t()) :: admin_cell_state()
+  def admin_cell_state(option, date, today) do
     cond do
       Date.compare(date, today) == :lt -> :past
-      date in option.disabled_dates -> :override_off
+      date in option.disabled_dates -> :date_disabled
       date in option.enabled_dates -> :open
       weekday_enabled?({option, date, nil}) -> :open
-      true -> :weekday_off
+      true -> :weekday_disabled
     end
   end
 

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -88,7 +88,7 @@ defmodule Edenflowers.Fulfillments do
   @doc """
   Check if the order can be fulfilled on the given date.
 
-  A date can be fufilled except when:
+  A date can be fulfilled except when:
 
     - The date is in the past
     - The date is disabled
@@ -96,17 +96,14 @@ defmodule Edenflowers.Fulfillments do
     - The date is today but the deadline for same day delivery has passed
     - The date is today but same day delivery is disabled
   """
-  @spec fulfill_on_date(FulfillmentOption.t(), Date.t(), DateTime.t()) :: {boolean(), atom()}
-  def fulfill_on_date(fulfillment_option = %FulfillmentOption{}, date, now \\ now()) do
-    params = {fulfillment_option, date, now}
-
-    case {date_past?(params), date_disabled?(params), date_enabled?(params), weekday_enabled?(params),
-          fulfill_today?(params)} do
-      {true, _, _, _, _} -> {false, :past}
-      {_, true, _, _, _} -> {false, :date_disabled}
-      {_, _, false, false, _} -> {false, :weekday_disabled}
-      {_, _, _, _, {false, reason}} -> {false, reason}
-      _ -> {true, :ok}
+  @spec fulfill_on_date(FulfillmentOption.t(), Date.t(), DateTime.t()) :: :ok | {:error, atom()}
+  def fulfill_on_date(%FulfillmentOption{} = option, date, now \\ now()) do
+    cond do
+      date_past?(date, now) -> {:error, :past}
+      date_disabled?(option, date) -> {:error, :date_disabled}
+      not date_enabled?(option, date) and not weekday_enabled?(option, date) -> {:error, :weekday_disabled}
+      (reason = today_blocked_reason(option, date, now)) != nil -> {:error, reason}
+      true -> :ok
     end
   end
 
@@ -134,10 +131,10 @@ defmodule Edenflowers.Fulfillments do
   @spec customer_cell_state(FulfillmentOption.t(), Date.t(), DateTime.t()) :: customer_cell_state()
   def customer_cell_state(fulfillment_option, date, now \\ now()) do
     case fulfill_on_date(fulfillment_option, date, now) do
-      {true, _} -> :open
-      {false, :date_disabled} -> :closed
-      {false, :weekday_disabled} -> :closed
-      {false, _past_or_same_day} -> :past
+      :ok -> :open
+      {:error, :date_disabled} -> :closed
+      {:error, :weekday_disabled} -> :closed
+      {:error, _past_or_same_day} -> :past
     end
   end
 
@@ -153,36 +150,26 @@ defmodule Edenflowers.Fulfillments do
       Date.compare(date, today) == :lt -> :past
       date in option.disabled_dates -> :date_disabled
       date in option.enabled_dates -> :open
-      weekday_enabled?({option, date, nil}) -> :open
+      weekday_enabled?(option, date) -> :open
       true -> :weekday_disabled
     end
   end
 
-  defp date_past?({_, date, now}) do
-    Date.compare(date, now) == :lt
+  defp date_past?(date, now), do: Date.compare(date, now) == :lt
+
+  defp date_disabled?(option, date), do: date in option.disabled_dates
+
+  defp date_enabled?(option, date), do: date in option.enabled_dates
+
+  defp weekday_enabled?(option, date), do: Weekday.from_date(date) in option.available_days
+
+  defp today_blocked_reason(%{same_day: false}, date, now) do
+    if date_today?(date, now), do: :same_day_delivery_disabled
   end
 
-  defp date_disabled?({%{disabled_dates: disabled_dates}, date, _}) do
-    Enum.member?(disabled_dates, date)
-  end
-
-  defp date_enabled?({%{enabled_dates: enabled_dates}, date, _}) do
-    Enum.member?(enabled_dates, date)
-  end
-
-  defp weekday_enabled?({%{available_days: available_days}, date, _now}) do
-    Weekday.from_date(date) in available_days
-  end
-
-  defp fulfill_today?({%{same_day: false, order_deadline: _order_deadline}, date, now}) do
-    if date_today?(date, now) do
-      {false, :same_day_delivery_disabled}
-    end
-  end
-
-  defp fulfill_today?({%{same_day: true, order_deadline: order_deadline}, date, now}) do
+  defp today_blocked_reason(%{same_day: true, order_deadline: order_deadline}, date, now) do
     if date_today?(date, now) and Time.compare(now, order_deadline) == :gt do
-      {false, :order_deadline_passed}
+      :order_deadline_passed
     end
   end
 

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -95,8 +95,6 @@ defmodule Edenflowers.Fulfillments do
     - The day of week is disabled and the date is not in the enabled dates
     - The date is today but the deadline for same day delivery has passed
     - The date is today but same day delivery is disabled
-
-  `now` must be a DateTime — same-day deadline checks need the time of day.
   """
   @spec fulfill_on_date(FulfillmentOption.t(), Date.t(), DateTime.t()) :: {boolean(), atom()}
   def fulfill_on_date(fulfillment_option = %FulfillmentOption{}, date, now \\ now()) do
@@ -112,7 +110,14 @@ defmodule Edenflowers.Fulfillments do
     end
   end
 
+  @typedoc """
+  Coarse-grained selectability of a calendar cell. Drives both styling and
+  whether the cell propagates a click; the customer and admin calendars share
+  this vocabulary so they can't drift apart.
+  """
   @type cell_state :: :open | :past | :weekday_off | :override_off
+
+  @type audience :: :customer | :admin
 
   @doc """
   Coarse-grained cell state for the calendar UI. Used by both the customer
@@ -130,7 +135,7 @@ defmodule Edenflowers.Fulfillments do
     is editing rules, not booking against them. Today reflects whatever the
     weekday/override rules say so it can be toggled like any other date.
   """
-  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t() | Date.t(), keyword()) :: cell_state()
+  @spec cell_state(FulfillmentOption.t(), Date.t(), DateTime.t() | Date.t(), audience: audience()) :: cell_state()
   def cell_state(fulfillment_option, date, now \\ now(), opts \\ [])
 
   def cell_state(fulfillment_option, date, now, opts) when is_list(opts) do

--- a/lib/edenflowers/fulfillments.ex
+++ b/lib/edenflowers/fulfillments.ex
@@ -138,8 +138,12 @@ defmodule Edenflowers.Fulfillments do
     Enum.member?(disabled_dates, date)
   end
 
+  # Treats florist key dates as if they were always in `enabled_dates`, so the
+  # weekday rule cannot close them as collateral. An explicit `disabled_dates`
+  # entry still wins, and same-day operational rules still apply — the admin
+  # can deliberately close a key date, but cannot do so by accident.
   defp date_enabled?({%{enabled_dates: enabled_dates}, date, _}) do
-    Enum.member?(enabled_dates, date)
+    Enum.member?(enabled_dates, date) or not is_nil(Edenflowers.Store.KeyDates.icon_for(date))
   end
 
   defp weekday_enabled?({%{available_days: available_days}, date, _now}) do

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -24,18 +24,43 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   """
 
   alias Edenflowers.Fulfillments
-  alias Edenflowers.Store.FulfillmentOption
+  alias Edenflowers.Store.{FulfillmentOption, KeyDates}
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
   @type cell_state :: Fulfillments.cell_state() | :mixed
 
   @doc """
-  Cell state for a single option (delegates to `Fulfillments.cell_state/3`).
+  Cell state for a single option, from the admin's point of view.
+
+  Differs from `Fulfillments.cell_state/2` (the customer's view) in one way:
+  same-day operational rules (deadlines, `same_day: false`) do not collapse
+  today into `:past`. Today reflects whatever the availability rules say,
+  so the admin can toggle it like any other date.
   """
   @spec cell_state(FulfillmentOption.t(), Date.t()) :: cell_state()
-  def cell_state(%FulfillmentOption{} = option, date) do
-    Fulfillments.cell_state(option, date)
+  def cell_state(%FulfillmentOption{} = option, %Date{} = date) do
+    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
+
+    cond do
+      Date.compare(date, today) == :lt -> :past
+      date in option.disabled_dates -> :override_off
+      date in option.enabled_dates -> :open
+      key_date?(date) -> :open
+      weekday_available?(option, date) -> :open
+      true -> :weekday_off
+    end
+  end
+
+  @doc """
+  Whether the date's state is set by an explicit override rather than its
+  weekday rule — i.e. the date appears in `enabled_dates` or `disabled_dates`.
+  Used to mark cells that contradict the weekday default so admins can spot
+  deliberate exceptions at a glance.
+  """
+  @spec override?(FulfillmentOption.t(), Date.t()) :: boolean()
+  def override?(%FulfillmentOption{} = option, %Date{} = date) do
+    date in option.enabled_dates or date in option.disabled_dates
   end
 
   @doc """
@@ -92,13 +117,20 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
 
   @doc """
   Toggle a weekday for a single fulfillment option, returning the updated
-  `%{available_days: [...]}` map.
+  `%{available_days: [...], enabled_dates: [...], disabled_dates: [...]}` map.
 
-  When toggling a weekday off, any explicit `enabled_dates` whose weekday
-  matches are preserved (they remain explicit on-overrides). Similarly for
-  the inverse direction — overrides survive weekday-level flips.
+  Prunes any now-redundant overrides whose direction matches the new weekday
+  rule: an `enabled_dates` entry on a now-available weekday is dropped (the
+  rule already opens that date), and a `disabled_dates` entry on a now-closed
+  weekday is dropped (the rule already closes it). This keeps the invariant
+  "every override genuinely contradicts the weekday rule" so the override
+  mark in the UI never lies.
   """
-  @spec toggle_weekday(FulfillmentOption.t(), atom()) :: %{available_days: [atom()]}
+  @spec toggle_weekday(FulfillmentOption.t(), atom()) :: %{
+          available_days: [atom()],
+          enabled_dates: [Date.t()],
+          disabled_dates: [Date.t()]
+        }
   def toggle_weekday(%FulfillmentOption{} = option, weekday) when weekday in @weekdays do
     available =
       if weekday in option.available_days do
@@ -107,12 +139,28 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
         [weekday | option.available_days]
       end
 
-    %{available_days: available}
+    # An override is stale when its presence and absence yield the same
+    # cell_state. For enabled_dates: open by rule, or a key date (which is
+    # protected regardless). For disabled_dates: closed by rule AND not a key
+    # date (key dates need the explicit disable to stay closed).
+    enabled =
+      Enum.reject(option.enabled_dates, fn date ->
+        weekday_atom(date) in available or key_date?(date)
+      end)
+
+    disabled =
+      Enum.reject(option.disabled_dates, fn date ->
+        weekday_atom(date) not in available and not key_date?(date)
+      end)
+
+    %{available_days: available, enabled_dates: enabled, disabled_dates: disabled}
   end
 
   defp weekday_available?(option, date) do
     weekday_atom(date) in option.available_days
   end
+
+  defp key_date?(date), do: not is_nil(KeyDates.icon_for(date))
 
   defp weekday_atom(date) do
     case Date.day_of_week(date) do

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -28,6 +28,13 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
+  @typedoc "What the admin calendar is currently editing: every option, or one option by id."
+  @type scope :: :all | String.t()
+
+  @typedoc """
+  `Fulfillments.cell_state/4` outputs plus `:mixed`, which only happens in the
+  admin "All options" view when options disagree on a date.
+  """
   @type cell_state :: Fulfillments.cell_state() | :mixed
 
   @doc """
@@ -70,7 +77,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   Returns `:on` when the scoped option can't be found so the header keeps a
   sensible default rather than disappearing.
   """
-  @spec weekday_state(:all | String.t(), [FulfillmentOption.t()], atom()) :: :on | :off | :mixed
+  @spec weekday_state(scope(), [FulfillmentOption.t()], Weekday.t()) :: :on | :off | :mixed
   def weekday_state(:all, options, weekday) do
     options
     |> Enum.map(&(weekday in &1.available_days))
@@ -130,8 +137,8 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   "every override genuinely contradicts the weekday rule" so the override
   mark in the UI never lies.
   """
-  @spec toggle_weekday(FulfillmentOption.t(), atom()) :: %{
-          available_days: [atom()],
+  @spec toggle_weekday(FulfillmentOption.t(), Weekday.t()) :: %{
+          available_days: [Weekday.t()],
           enabled_dates: [Date.t()],
           disabled_dates: [Date.t()]
         }

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -9,7 +9,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   ## Click semantics
 
   - Clicking a **weekday header** toggles that weekday in `available_days`.
-    This is the default rule for that day of the week.
+    This is the default rule for that weekday.
 
   - Clicking a **date cell** toggles an *override*:
     - If the date's weekday is currently available, the click adds the date
@@ -32,10 +32,10 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   @type scope :: :all | String.t()
 
   @typedoc """
-  `Fulfillments.cell_state/4` outputs plus `:mixed`, which only happens in the
-  admin "All options" view when options disagree on a date.
+  `Fulfillments.admin_cell_state/3` outputs plus `:mixed`, which only happens
+  in the admin "All options" view when options disagree on a date.
   """
-  @type cell_state :: Fulfillments.cell_state() | :mixed
+  @type cell_state :: Fulfillments.admin_cell_state() | :mixed
 
   @doc """
   Whether the date's state is set by an explicit override rather than its
@@ -58,7 +58,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
 
   def cell_state_for_options(options, date, today) when is_list(options) do
     options
-    |> Enum.map(&Fulfillments.cell_state(&1, date, today, audience: :admin))
+    |> Enum.map(&Fulfillments.admin_cell_state(&1, date, today))
     |> Enum.uniq()
     |> case do
       [single] -> single

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -23,8 +23,9 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   no override is stored once a date matches its weekday default.
   """
 
-  alias Edenflowers.{Fulfillments, Weekday}
+  alias Edenflowers.Fulfillments
   alias Edenflowers.Store.{FulfillmentOption, KeyDates}
+  alias Edenflowers.Weekday
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
@@ -46,6 +47,32 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   @spec override?(FulfillmentOption.t(), Date.t()) :: boolean()
   def override?(%FulfillmentOption{} = option, %Date{} = date) do
     date in option.enabled_dates or date in option.disabled_dates
+  end
+
+  @doc """
+  Narrow `options` to the current scope. `:all` returns everything; a UUID
+  string returns the single option (or `[]` when not found).
+  """
+  @spec scoped_options(scope(), [FulfillmentOption.t()]) :: [FulfillmentOption.t()]
+  def scoped_options(:all, options), do: options
+  def scoped_options(option_id, options), do: Enum.filter(options, &(&1.id == option_id))
+
+  @doc """
+  Cell state for the current scope. `:all` aggregates across every option
+  (collapsing disagreement to `:mixed`); a single-option scope returns that
+  option's admin cell state. Returns `:open` when the scoped id is unknown
+  so the cell renders sensibly rather than blowing up.
+  """
+  @spec cell_state_for_scope(scope(), [FulfillmentOption.t()], Date.t(), Date.t()) :: cell_state()
+  def cell_state_for_scope(:all, options, %Date{} = date, %Date{} = today) do
+    cell_state_for_options(options, date, today)
+  end
+
+  def cell_state_for_scope(option_id, options, %Date{} = date, %Date{} = today) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> :open
+      option -> Fulfillments.admin_cell_state(option, date, today)
+    end
   end
 
   @doc """
@@ -78,6 +105,8 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   sensible default rather than disappearing.
   """
   @spec weekday_state(scope(), [FulfillmentOption.t()], Weekday.t()) :: :on | :off | :mixed
+  def weekday_state(:all, [], _weekday), do: :on
+
   def weekday_state(:all, options, weekday) do
     options
     |> Enum.map(&(weekday in &1.available_days))
@@ -169,24 +198,13 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
     virtual_option = struct(original_option, new_attrs)
 
     weekday
-    |> key_dates_on_weekday()
+    |> KeyDates.dates_for_weekday()
     |> Enum.reduce(new_attrs, fn date, attrs ->
       old_open? = open?(original_option, date)
       new_open? = open?(virtual_option, date)
 
       if old_open? == new_open?, do: attrs, else: restore(attrs, date, old_open?)
     end)
-  end
-
-  # Key dates on `weekday` within the relevant lookahead. KeyDates lookups
-  # are per-year, so we cover this year and next.
-  defp key_dates_on_weekday(weekday) do
-    year = Date.utc_today().year
-
-    [year, year + 1]
-    |> Enum.flat_map(&KeyDates.for_year/1)
-    |> Enum.map(& &1.date)
-    |> Enum.filter(&(Weekday.from_date(&1) == weekday))
   end
 
   # Past-agnostic openness — would the rule + overrides leave this date open?
@@ -249,7 +267,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
     actionable =
       week
       |> Enum.reject(&(Date.compare(&1, today) == :lt))
-      |> Enum.reject(&KeyDates.icon_for/1)
+      |> Enum.reject(&KeyDates.key_date?/1)
 
     case actionable do
       [] ->
@@ -282,12 +300,12 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
         }
   def set_week(%FulfillmentOption{} = option, week, %Date{} = today, direction)
       when is_list(week) and direction in [:open, :closed] do
+    initial = %{enabled_dates: option.enabled_dates, disabled_dates: option.disabled_dates}
+
     week
     |> Enum.reject(&(Date.compare(&1, today) == :lt))
-    |> Enum.reject(&KeyDates.icon_for/1)
-    |> Enum.reduce(%{enabled_dates: option.enabled_dates, disabled_dates: option.disabled_dates}, fn date, acc ->
-      set_date(option, acc, date, direction)
-    end)
+    |> Enum.reject(&KeyDates.key_date?/1)
+    |> Enum.reduce(initial, fn date, acc -> set_date(option, acc, date, direction) end)
   end
 
   @doc """

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -1,0 +1,128 @@
+defmodule Edenflowers.Store.FulfillmentCalendar do
+  @moduledoc """
+  Pure functions for the admin date-toggle editor.
+
+  Translates calendar clicks into updated attribute maps that the LiveView
+  hands to `Ash.update/2`. Keeps click semantics out of the LiveView so they
+  can be unit-tested without a socket or database.
+
+  ## Click semantics
+
+  - Clicking a **weekday header** toggles that weekday in `available_days`.
+    This is the default rule for that day of the week.
+
+  - Clicking a **date cell** toggles an *override*:
+    - If the date's weekday is currently available, the click adds the date
+      to `disabled_dates` (closes that specific date).
+    - If the date's weekday is currently unavailable, the click adds it to
+      `enabled_dates` (opens that specific date).
+    - Clicking an already-overridden date removes the override, returning
+      the date to its weekday default.
+
+  This means every click is reversible and the data shape stays minimal:
+  no override is stored once a date matches its weekday default.
+  """
+
+  alias Edenflowers.Fulfillments
+  alias Edenflowers.Store.FulfillmentOption
+
+  @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
+
+  @type cell_state :: Fulfillments.cell_state() | :mixed
+
+  @doc """
+  Cell state for a single option (delegates to `Fulfillments.cell_state/3`).
+  """
+  @spec cell_state(FulfillmentOption.t(), Date.t()) :: cell_state()
+  def cell_state(%FulfillmentOption{} = option, date) do
+    Fulfillments.cell_state(option, date)
+  end
+
+  @doc """
+  Cell state across multiple options. Returns `:mixed` when options disagree
+  on whether the date is open — used by the "All options" admin view to
+  signal that the florist must pick a specific option to disambiguate.
+  """
+  @spec cell_state_for_options([FulfillmentOption.t()], Date.t()) :: cell_state()
+  def cell_state_for_options([], _date), do: :open
+
+  def cell_state_for_options(options, date) when is_list(options) do
+    options
+    |> Enum.map(&cell_state(&1, date))
+    |> Enum.uniq()
+    |> case do
+      [single] -> single
+      _multiple -> :mixed
+    end
+  end
+
+  @doc """
+  Toggle a date for a single fulfillment option, returning the updated
+  `%{enabled_dates: [...], disabled_dates: [...]}` map. Pass these to
+  `Ash.update/2` to persist.
+
+  See module doc for the click semantics.
+  """
+  @spec toggle_date(FulfillmentOption.t(), Date.t()) :: %{
+          enabled_dates: [Date.t()],
+          disabled_dates: [Date.t()]
+        }
+  def toggle_date(%FulfillmentOption{} = option, %Date{} = date) do
+    enabled = option.enabled_dates
+    disabled = option.disabled_dates
+
+    cond do
+      date in enabled ->
+        # Remove the explicit on-override. Date returns to its weekday default.
+        %{enabled_dates: List.delete(enabled, date), disabled_dates: disabled}
+
+      date in disabled ->
+        # Remove the explicit off-override.
+        %{enabled_dates: enabled, disabled_dates: List.delete(disabled, date)}
+
+      weekday_available?(option, date) ->
+        # Currently open by weekday default → add an off-override.
+        %{enabled_dates: enabled, disabled_dates: [date | disabled]}
+
+      true ->
+        # Currently closed by weekday default → add an on-override.
+        %{enabled_dates: [date | enabled], disabled_dates: disabled}
+    end
+  end
+
+  @doc """
+  Toggle a weekday for a single fulfillment option, returning the updated
+  `%{available_days: [...]}` map.
+
+  When toggling a weekday off, any explicit `enabled_dates` whose weekday
+  matches are preserved (they remain explicit on-overrides). Similarly for
+  the inverse direction — overrides survive weekday-level flips.
+  """
+  @spec toggle_weekday(FulfillmentOption.t(), atom()) :: %{available_days: [atom()]}
+  def toggle_weekday(%FulfillmentOption{} = option, weekday) when weekday in @weekdays do
+    available =
+      if weekday in option.available_days do
+        List.delete(option.available_days, weekday)
+      else
+        [weekday | option.available_days]
+      end
+
+    %{available_days: available}
+  end
+
+  defp weekday_available?(option, date) do
+    weekday_atom(date) in option.available_days
+  end
+
+  defp weekday_atom(date) do
+    case Date.day_of_week(date) do
+      1 -> :monday
+      2 -> :tuesday
+      3 -> :wednesday
+      4 -> :thursday
+      5 -> :friday
+      6 -> :saturday
+      7 -> :sunday
+    end
+  end
+end

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -37,11 +37,12 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   same-day operational rules (deadlines, `same_day: false`) do not collapse
   today into `:past`. Today reflects whatever the availability rules say,
   so the admin can toggle it like any other date.
-  """
-  @spec cell_state(FulfillmentOption.t(), Date.t()) :: cell_state()
-  def cell_state(%FulfillmentOption{} = option, %Date{} = date) do
-    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
 
+  `today` is passed in so this function stays pure — easy to test, and the
+  view-model can compute it once per render rather than per cell.
+  """
+  @spec cell_state(FulfillmentOption.t(), Date.t(), Date.t()) :: cell_state()
+  def cell_state(%FulfillmentOption{} = option, %Date{} = date, %Date{} = today) do
     cond do
       Date.compare(date, today) == :lt -> :past
       date in option.disabled_dates -> :override_off
@@ -68,16 +69,79 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   on whether the date is open — used by the "All options" admin view to
   signal that the florist must pick a specific option to disambiguate.
   """
-  @spec cell_state_for_options([FulfillmentOption.t()], Date.t()) :: cell_state()
-  def cell_state_for_options([], _date), do: :open
+  @spec cell_state_for_options([FulfillmentOption.t()], Date.t(), Date.t()) :: cell_state()
+  def cell_state_for_options([], _date, _today), do: :open
 
-  def cell_state_for_options(options, date) when is_list(options) do
+  def cell_state_for_options(options, date, today) when is_list(options) do
     options
-    |> Enum.map(&cell_state(&1, date))
+    |> Enum.map(&cell_state(&1, date, today))
     |> Enum.uniq()
     |> case do
       [single] -> single
       _multiple -> :mixed
+    end
+  end
+
+  @doc """
+  Weekday state across the current scope.
+
+  - `:on` — every option in scope has the weekday available.
+  - `:off` — no option in scope has the weekday available.
+  - `:mixed` — options disagree.
+
+  Scope is either `:all` (every option) or a single option id (UUID string).
+  Returns `:on` when the scoped option can't be found so the header keeps a
+  sensible default rather than disappearing.
+  """
+  @spec weekday_state(:all | String.t(), [FulfillmentOption.t()], atom()) :: :on | :off | :mixed
+  def weekday_state(:all, options, weekday) do
+    options
+    |> Enum.map(&(weekday in &1.available_days))
+    |> Enum.uniq()
+    |> case do
+      [true] -> :on
+      [false] -> :off
+      _mixed -> :mixed
+    end
+  end
+
+  def weekday_state(option_id, options, weekday) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> :on
+      option -> if weekday in option.available_days, do: :on, else: :off
+    end
+  end
+
+  @doc """
+  Single-date admin view: cell state, override flag, and the optional key-date
+  name (used for the confirm prompt when an admin closes a holiday).
+
+  Returns the three pieces together so the render function makes one call per
+  cell instead of three. `override?` is intentionally `false` when scope is
+  `:all` — across options, "some override, some don't" can't be summarized
+  by one dot.
+  """
+  @type cell_view :: %{state: cell_state(), override?: boolean(), key_date_name: String.t() | nil}
+  @spec view_model(:all | String.t(), [FulfillmentOption.t()], Date.t(), Date.t()) :: cell_view()
+  def view_model(:all, options, date, today) do
+    %{
+      state: cell_state_for_options(options, date, today),
+      override?: false,
+      key_date_name: KeyDates.name_for(date)
+    }
+  end
+
+  def view_model(option_id, options, date, today) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil ->
+        %{state: :open, override?: false, key_date_name: KeyDates.name_for(date)}
+
+      option ->
+        %{
+          state: cell_state(option, date, today),
+          override?: override?(option, date),
+          key_date_name: KeyDates.name_for(date)
+        }
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -23,34 +23,12 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   no override is stored once a date matches its weekday default.
   """
 
-  alias Edenflowers.Fulfillments
+  alias Edenflowers.{Fulfillments, Weekday}
   alias Edenflowers.Store.FulfillmentOption
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
   @type cell_state :: Fulfillments.cell_state() | :mixed
-
-  @doc """
-  Cell state for a single option, from the admin's point of view.
-
-  Differs from `Fulfillments.cell_state/2` (the customer's view) in one way:
-  same-day operational rules (deadlines, `same_day: false`) do not collapse
-  today into `:past`. Today reflects whatever the availability rules say,
-  so the admin can toggle it like any other date.
-
-  `today` is passed in so this function stays pure — easy to test, and the
-  view-model can compute it once per render rather than per cell.
-  """
-  @spec cell_state(FulfillmentOption.t(), Date.t(), Date.t()) :: cell_state()
-  def cell_state(%FulfillmentOption{} = option, %Date{} = date, %Date{} = today) do
-    cond do
-      Date.compare(date, today) == :lt -> :past
-      date in option.disabled_dates -> :override_off
-      date in option.enabled_dates -> :open
-      weekday_available?(option, date) -> :open
-      true -> :weekday_off
-    end
-  end
 
   @doc """
   Whether the date's state is set by an explicit override rather than its
@@ -73,7 +51,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
 
   def cell_state_for_options(options, date, today) when is_list(options) do
     options
-    |> Enum.map(&cell_state(&1, date, today))
+    |> Enum.map(&Fulfillments.cell_state(&1, date, today, audience: :admin))
     |> Enum.uniq()
     |> case do
       [single] -> single
@@ -108,29 +86,6 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
     case Enum.find(options, &(&1.id == option_id)) do
       nil -> :on
       option -> if weekday in option.available_days, do: :on, else: :off
-    end
-  end
-
-  @doc """
-  Single-date admin view: cell state and override flag together so the render
-  function makes one call per cell instead of two.
-
-  `override?` is intentionally `false` when scope is `:all` — across options,
-  "some override, some don't" can't be summarized by one dot.
-  """
-  @type cell_view :: %{state: cell_state(), override?: boolean()}
-  @spec view_model(:all | String.t(), [FulfillmentOption.t()], Date.t(), Date.t()) :: cell_view()
-  def view_model(:all, options, date, today) do
-    %{state: cell_state_for_options(options, date, today), override?: false}
-  end
-
-  def view_model(option_id, options, date, today) do
-    case Enum.find(options, &(&1.id == option_id)) do
-      nil ->
-        %{state: :open, override?: false}
-
-      option ->
-        %{state: cell_state(option, date, today), override?: override?(option, date)}
     end
   end
 
@@ -188,25 +143,13 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
         [weekday | option.available_days]
       end
 
-    enabled = Enum.reject(option.enabled_dates, &(weekday_atom(&1) in available))
-    disabled = Enum.reject(option.disabled_dates, &(weekday_atom(&1) not in available))
+    enabled = Enum.reject(option.enabled_dates, &(Weekday.from_date(&1) in available))
+    disabled = Enum.reject(option.disabled_dates, &(Weekday.from_date(&1) not in available))
 
     %{available_days: available, enabled_dates: enabled, disabled_dates: disabled}
   end
 
   defp weekday_available?(option, date) do
-    weekday_atom(date) in option.available_days
-  end
-
-  defp weekday_atom(date) do
-    case Date.day_of_week(date) do
-      1 -> :monday
-      2 -> :tuesday
-      3 -> :wednesday
-      4 -> :thursday
-      5 -> :friday
-      6 -> :saturday
-      7 -> :sunday
-    end
+    Weekday.from_date(date) in option.available_days
   end
 end

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -24,7 +24,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   """
 
   alias Edenflowers.{Fulfillments, Weekday}
-  alias Edenflowers.Store.FulfillmentOption
+  alias Edenflowers.Store.{FulfillmentOption, KeyDates}
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
@@ -127,8 +127,9 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   end
 
   @doc """
-  Toggle a weekday for a single fulfillment option, returning the updated
-  `%{available_days: [...], enabled_dates: [...], disabled_dates: [...]}` map.
+  Set a weekday's rule for a single option to the given direction, returning
+  the updated `%{available_days: [...], enabled_dates: [...], disabled_dates: [...]}`
+  map. Idempotent — already-matching options pass through unchanged.
 
   Prunes any now-redundant overrides whose direction matches the new weekday
   rule: an `enabled_dates` entry on a now-available weekday is dropped (the
@@ -137,26 +138,221 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   "every override genuinely contradicts the weekday rule" so the override
   mark in the UI never lies.
   """
-  @spec toggle_weekday(FulfillmentOption.t(), Weekday.t()) :: %{
+  @spec set_weekday(FulfillmentOption.t(), Weekday.t(), :on | :off) :: %{
           available_days: [Weekday.t()],
           enabled_dates: [Date.t()],
           disabled_dates: [Date.t()]
         }
-  def toggle_weekday(%FulfillmentOption{} = option, weekday) when weekday in @weekdays do
+  def set_weekday(%FulfillmentOption{} = option, weekday, direction)
+      when weekday in @weekdays and direction in [:on, :off] do
+    currently_available? = weekday in option.available_days
+
     available =
-      if weekday in option.available_days do
-        List.delete(option.available_days, weekday)
-      else
-        [weekday | option.available_days]
+      case {direction, currently_available?} do
+        {:on, false} -> [weekday | option.available_days]
+        {:off, true} -> List.delete(option.available_days, weekday)
+        _no_change -> option.available_days
       end
 
     enabled = Enum.reject(option.enabled_dates, &(Weekday.from_date(&1) in available))
     disabled = Enum.reject(option.disabled_dates, &(Weekday.from_date(&1) not in available))
 
     %{available_days: available, enabled_dates: enabled, disabled_dates: disabled}
+    |> preserve_key_dates_on_weekday(option, weekday)
+  end
+
+  # After a weekday rule change, any key dates on that weekday whose open/closed
+  # state would flip get an override restoring their pre-toggle state. Key dates
+  # are never collaterally moved by a smart toggle — the florist has to click
+  # them individually.
+  defp preserve_key_dates_on_weekday(new_attrs, original_option, weekday) do
+    virtual_option = struct(original_option, new_attrs)
+
+    weekday
+    |> key_dates_on_weekday()
+    |> Enum.reduce(new_attrs, fn date, attrs ->
+      old_open? = open?(original_option, date)
+      new_open? = open?(virtual_option, date)
+
+      if old_open? == new_open?, do: attrs, else: restore(attrs, date, old_open?)
+    end)
+  end
+
+  # Key dates on `weekday` within the relevant lookahead. KeyDates lookups
+  # are per-year, so we cover this year and next.
+  defp key_dates_on_weekday(weekday) do
+    year = Date.utc_today().year
+
+    [year, year + 1]
+    |> Enum.flat_map(&KeyDates.for_year/1)
+    |> Enum.map(& &1.date)
+    |> Enum.filter(&(Weekday.from_date(&1) == weekday))
+  end
+
+  # Past-agnostic openness — would the rule + overrides leave this date open?
+  defp open?(option, date) do
+    cond do
+      date in option.disabled_dates -> false
+      date in option.enabled_dates -> true
+      true -> Weekday.from_date(date) in option.available_days
+    end
+  end
+
+  defp restore(attrs, date, _was_open? = true) do
+    %{
+      attrs
+      | enabled_dates: Enum.uniq([date | attrs.enabled_dates]),
+        disabled_dates: List.delete(attrs.disabled_dates, date)
+    }
+  end
+
+  defp restore(attrs, date, _was_open? = false) do
+    %{
+      attrs
+      | disabled_dates: Enum.uniq([date | attrs.disabled_dates]),
+        enabled_dates: List.delete(attrs.enabled_dates, date)
+    }
+  end
+
+  @doc """
+  Smart-toggle direction across a scope. If any option in `options` has the
+  weekday available, the bulk gesture closes it everywhere; otherwise it
+  opens it everywhere. The aggregate intent ("close it" / "open it") is the
+  same single click whether viewed at one option or across all of them.
+  """
+  @spec weekday_toggle_direction([FulfillmentOption.t()], Weekday.t()) :: :on | :off
+  def weekday_toggle_direction(options, weekday) when is_list(options) do
+    if Enum.any?(options, &(weekday in &1.available_days)), do: :off, else: :on
+  end
+
+  @typedoc """
+  Summary of a week's openness for one option, used to label and enable/disable
+  the per-week toggle button.
+
+  - `:all_open` — every non-past cell in the week is open.
+  - `:all_closed` — every non-past cell is closed (by weekday rule or override).
+  - `:mixed` — some non-past cells are open, others closed.
+  - `:all_past` — every cell in the week is in the past; the week isn't actionable.
+  """
+  @type week_state :: :all_open | :all_closed | :mixed | :all_past
+
+  @doc """
+  Classify a week's openness for one option, against `today`. Used by the
+  per-week toggle button to pick its label and to disable itself when the
+  whole week is in the past.
+  """
+  @spec week_state(FulfillmentOption.t(), [Date.t()], Date.t()) :: week_state()
+  def week_state(%FulfillmentOption{} = option, week, %Date{} = today) when is_list(week) do
+    # Smart toggles never touch key dates, so they shouldn't drive the
+    # button's state either — otherwise a week containing only a key date
+    # would look actionable but the click would no-op.
+    actionable =
+      week
+      |> Enum.reject(&(Date.compare(&1, today) == :lt))
+      |> Enum.reject(&KeyDates.icon_for/1)
+
+    case actionable do
+      [] ->
+        :all_past
+
+      dates ->
+        states = Enum.map(dates, &Fulfillments.admin_cell_state(option, &1, today))
+
+        cond do
+          Enum.all?(states, &(&1 == :open)) -> :all_open
+          Enum.any?(states, &(&1 == :open)) -> :mixed
+          true -> :all_closed
+        end
+    end
+  end
+
+  @doc """
+  Set every non-past date in `week` to the given direction for a single
+  option, returning the updated `%{enabled_dates: [...], disabled_dates: [...]}`
+  map. Idempotent per-date: cells already in the target direction pass
+  through unchanged.
+
+  Each per-date flip uses the same minimal-override discipline as
+  `toggle_date/2`: a redundant override (matching the weekday rule) is never
+  written.
+  """
+  @spec set_week(FulfillmentOption.t(), [Date.t()], Date.t(), :open | :closed) :: %{
+          enabled_dates: [Date.t()],
+          disabled_dates: [Date.t()]
+        }
+  def set_week(%FulfillmentOption{} = option, week, %Date{} = today, direction)
+      when is_list(week) and direction in [:open, :closed] do
+    week
+    |> Enum.reject(&(Date.compare(&1, today) == :lt))
+    |> Enum.reject(&KeyDates.icon_for/1)
+    |> Enum.reduce(%{enabled_dates: option.enabled_dates, disabled_dates: option.disabled_dates}, fn date, acc ->
+      set_date(option, acc, date, direction)
+    end)
+  end
+
+  @doc """
+  Smart-toggle direction across a scope. If any option has at least one open
+  non-past cell in the week, the bulk gesture closes the week everywhere;
+  otherwise it opens what's closed. Returns `nil` when no option has any
+  actionable (non-past) cell — the week is entirely past, nothing to do.
+  """
+  @spec week_toggle_direction([FulfillmentOption.t()], [Date.t()], Date.t()) :: :open | :closed | nil
+  def week_toggle_direction(options, week, %Date{} = today) when is_list(options) and is_list(week) do
+    any_actionable? =
+      Enum.any?(options, fn option -> week_state(option, week, today) != :all_past end)
+
+    cond do
+      not any_actionable? -> nil
+      Enum.any?(options, fn option -> week_state(option, week, today) in [:all_open, :mixed] end) -> :closed
+      true -> :open
+    end
+  end
+
+  # Move a single date to the target direction in the given enabled/disabled
+  # accumulator, without writing a redundant override.
+  defp set_date(option, %{enabled_dates: enabled, disabled_dates: disabled}, date, :open) do
+    cond do
+      weekday_available?(option, date) ->
+        %{enabled_dates: List.delete(enabled, date), disabled_dates: List.delete(disabled, date)}
+
+      date in enabled ->
+        %{enabled_dates: enabled, disabled_dates: List.delete(disabled, date)}
+
+      true ->
+        %{enabled_dates: [date | enabled], disabled_dates: List.delete(disabled, date)}
+    end
+  end
+
+  defp set_date(option, %{enabled_dates: enabled, disabled_dates: disabled}, date, :closed) do
+    cond do
+      not weekday_available?(option, date) ->
+        %{enabled_dates: List.delete(enabled, date), disabled_dates: List.delete(disabled, date)}
+
+      date in disabled ->
+        %{enabled_dates: List.delete(enabled, date), disabled_dates: disabled}
+
+      true ->
+        %{enabled_dates: List.delete(enabled, date), disabled_dates: [date | disabled]}
+    end
   end
 
   defp weekday_available?(option, date) do
     Weekday.from_date(date) in option.available_days
+  end
+
+  @doc """
+  Reset attributes for a full-wipe gesture: every weekday open, no overrides.
+
+  Independent of the option's current state — this is a confirmed-destructive
+  reset, not a toggle. Key-date protection deliberately does not apply: the
+  florist has explicitly asked for everything to clear.
+  """
+  @spec reset() :: %{
+          available_days: [Weekday.t()],
+          enabled_dates: [Date.t()],
+          disabled_dates: [Date.t()]
+        }
+  def reset do
+    %{available_days: @weekdays, enabled_dates: [], disabled_dates: []}
   end
 end

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -105,13 +105,26 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
         # Remove the explicit off-override.
         %{enabled_dates: enabled, disabled_dates: List.delete(disabled, date)}
 
-      weekday_available?(option, date) ->
-        # Currently open by weekday default → add an off-override.
+      open_by_rules?(option, date) ->
+        # Currently open (by weekday rule or key-date protection) → close it.
         %{enabled_dates: enabled, disabled_dates: [date | disabled]}
 
       true ->
-        # Currently closed by weekday default → add an on-override.
+        # Currently closed by weekday rule → open it.
         %{enabled_dates: [date | enabled], disabled_dates: disabled}
+    end
+  end
+
+  # Whether `date` is open given the option's rules — same predicate as
+  # `cell_state`, minus the past-date check. `toggle_date` works on rules,
+  # not the calendar clock, so a hypothetical past-date click should still
+  # produce a sensible result.
+  defp open_by_rules?(option, date) do
+    cond do
+      date in option.disabled_dates -> false
+      date in option.enabled_dates -> true
+      key_date?(date) -> true
+      true -> weekday_available?(option, date)
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_calendar.ex
@@ -24,7 +24,7 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   """
 
   alias Edenflowers.Fulfillments
-  alias Edenflowers.Store.{FulfillmentOption, KeyDates}
+  alias Edenflowers.Store.FulfillmentOption
 
   @weekdays [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
 
@@ -47,7 +47,6 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
       Date.compare(date, today) == :lt -> :past
       date in option.disabled_dates -> :override_off
       date in option.enabled_dates -> :open
-      key_date?(date) -> :open
       weekday_available?(option, date) -> :open
       true -> :weekday_off
     end
@@ -113,35 +112,25 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   end
 
   @doc """
-  Single-date admin view: cell state, override flag, and the optional key-date
-  name (used for the confirm prompt when an admin closes a holiday).
+  Single-date admin view: cell state and override flag together so the render
+  function makes one call per cell instead of two.
 
-  Returns the three pieces together so the render function makes one call per
-  cell instead of three. `override?` is intentionally `false` when scope is
-  `:all` — across options, "some override, some don't" can't be summarized
-  by one dot.
+  `override?` is intentionally `false` when scope is `:all` — across options,
+  "some override, some don't" can't be summarized by one dot.
   """
-  @type cell_view :: %{state: cell_state(), override?: boolean(), key_date_name: String.t() | nil}
+  @type cell_view :: %{state: cell_state(), override?: boolean()}
   @spec view_model(:all | String.t(), [FulfillmentOption.t()], Date.t(), Date.t()) :: cell_view()
   def view_model(:all, options, date, today) do
-    %{
-      state: cell_state_for_options(options, date, today),
-      override?: false,
-      key_date_name: KeyDates.name_for(date)
-    }
+    %{state: cell_state_for_options(options, date, today), override?: false}
   end
 
   def view_model(option_id, options, date, today) do
     case Enum.find(options, &(&1.id == option_id)) do
       nil ->
-        %{state: :open, override?: false, key_date_name: KeyDates.name_for(date)}
+        %{state: :open, override?: false}
 
       option ->
-        %{
-          state: cell_state(option, date, today),
-          override?: override?(option, date),
-          key_date_name: KeyDates.name_for(date)
-        }
+        %{state: cell_state(option, date, today), override?: override?(option, date)}
     end
   end
 
@@ -162,33 +151,16 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
 
     cond do
       date in enabled ->
-        # Remove the explicit on-override. Date returns to its weekday default.
         %{enabled_dates: List.delete(enabled, date), disabled_dates: disabled}
 
       date in disabled ->
-        # Remove the explicit off-override.
         %{enabled_dates: enabled, disabled_dates: List.delete(disabled, date)}
 
-      open_by_rules?(option, date) ->
-        # Currently open (by weekday rule or key-date protection) → close it.
+      weekday_available?(option, date) ->
         %{enabled_dates: enabled, disabled_dates: [date | disabled]}
 
       true ->
-        # Currently closed by weekday rule → open it.
         %{enabled_dates: [date | enabled], disabled_dates: disabled}
-    end
-  end
-
-  # Whether `date` is open given the option's rules — same predicate as
-  # `cell_state`, minus the past-date check. `toggle_date` works on rules,
-  # not the calendar clock, so a hypothetical past-date click should still
-  # produce a sensible result.
-  defp open_by_rules?(option, date) do
-    cond do
-      date in option.disabled_dates -> false
-      date in option.enabled_dates -> true
-      key_date?(date) -> true
-      true -> weekday_available?(option, date)
     end
   end
 
@@ -216,19 +188,8 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
         [weekday | option.available_days]
       end
 
-    # An override is stale when its presence and absence yield the same
-    # cell_state. For enabled_dates: open by rule, or a key date (which is
-    # protected regardless). For disabled_dates: closed by rule AND not a key
-    # date (key dates need the explicit disable to stay closed).
-    enabled =
-      Enum.reject(option.enabled_dates, fn date ->
-        weekday_atom(date) in available or key_date?(date)
-      end)
-
-    disabled =
-      Enum.reject(option.disabled_dates, fn date ->
-        weekday_atom(date) not in available and not key_date?(date)
-      end)
+    enabled = Enum.reject(option.enabled_dates, &(weekday_atom(&1) in available))
+    disabled = Enum.reject(option.disabled_dates, &(weekday_atom(&1) not in available))
 
     %{available_days: available, enabled_dates: enabled, disabled_dates: disabled}
   end
@@ -236,8 +197,6 @@ defmodule Edenflowers.Store.FulfillmentCalendar do
   defp weekday_available?(option, date) do
     weekday_atom(date) in option.available_days
   end
-
-  defp key_date?(date), do: not is_nil(KeyDates.icon_for(date))
 
   defp weekday_atom(date) do
     case Date.day_of_week(date) do

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -62,9 +62,6 @@ defmodule Edenflowers.Store.FulfillmentOption do
         :max_dist_km,
         :same_day,
         :order_deadline,
-        :available_days,
-        :enabled_dates,
-        :disabled_dates,
         :tax_rate_id
       ]
     ]

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -23,6 +23,8 @@ defmodule Edenflowers.Store.FulfillmentOption do
     define :list_for_checkout, action: :list_for_checkout
     define :get_by_id, action: :by_id, args: [:id]
     define :update_calendar, action: :update_calendar
+    define :toggle_date, action: :toggle_date, args: [:date]
+    define :toggle_weekday, action: :toggle_weekday, args: [:weekday]
   end
 
   actions do
@@ -80,6 +82,22 @@ defmodule Edenflowers.Store.FulfillmentOption do
                     "Prevents accidental writes to pricing or fulfillment-method attrs."
 
       accept [:available_days, :enabled_dates, :disabled_dates]
+    end
+
+    update :toggle_date do
+      description "Toggle a single date on or off, mutating enabled_dates / disabled_dates per the click semantics in FulfillmentCalendar."
+      # The change reads the existing option to compute the new override sets,
+      # so it can't be expressed as a single DB expression.
+      require_atomic? false
+      argument :date, :date, allow_nil?: false
+      change Edenflowers.Store.FulfillmentOption.Changes.ToggleDate
+    end
+
+    update :toggle_weekday do
+      description "Toggle a single weekday on or off, also pruning now-redundant overrides per FulfillmentCalendar."
+      require_atomic? false
+      argument :weekday, :atom, allow_nil?: false
+      change Edenflowers.Store.FulfillmentOption.Changes.ToggleWeekday
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -24,7 +24,9 @@ defmodule Edenflowers.Store.FulfillmentOption do
     define :get_by_id, action: :by_id, args: [:id]
     define :update_calendar, action: :update_calendar
     define :toggle_date, action: :toggle_date, args: [:date]
-    define :toggle_weekday, action: :toggle_weekday, args: [:weekday]
+    define :set_weekday, action: :set_weekday, args: [:weekday, :direction]
+    define :set_week, action: :set_week, args: [:week, :today, :direction]
+    define :reset_calendar, action: :reset_calendar
   end
 
   actions do
@@ -93,11 +95,27 @@ defmodule Edenflowers.Store.FulfillmentOption do
       change Edenflowers.Store.FulfillmentOption.Changes.ToggleDate
     end
 
-    update :toggle_weekday do
-      description "Toggle a single weekday on or off, also pruning now-redundant overrides per FulfillmentCalendar."
+    update :set_weekday do
+      description "Set a weekday's rule to :on or :off, idempotently. Prunes now-redundant overrides per FulfillmentCalendar."
       require_atomic? false
       argument :weekday, :atom, allow_nil?: false
-      change Edenflowers.Store.FulfillmentOption.Changes.ToggleWeekday
+      argument :direction, :atom, allow_nil?: false, constraints: [one_of: [:on, :off]]
+      change Edenflowers.Store.FulfillmentOption.Changes.SetWeekday
+    end
+
+    update :set_week do
+      description "Set every non-past date in `week` to :open or :closed, idempotently."
+      require_atomic? false
+      argument :week, {:array, :date}, allow_nil?: false
+      argument :today, :date, allow_nil?: false
+      argument :direction, :atom, allow_nil?: false, constraints: [one_of: [:open, :closed]]
+      change Edenflowers.Store.FulfillmentOption.Changes.SetWeek
+    end
+
+    update :reset_calendar do
+      description "Reset the calendar to fully-open / no overrides. Destructive — the admin reset button confirms before invoking."
+      require_atomic? false
+      change Edenflowers.Store.FulfillmentOption.Changes.ResetCalendar
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_option.ex
+++ b/lib/edenflowers/store/fulfillment_option.ex
@@ -22,6 +22,7 @@ defmodule Edenflowers.Store.FulfillmentOption do
     define :list, action: :read
     define :list_for_checkout, action: :list_for_checkout
     define :get_by_id, action: :by_id, args: [:id]
+    define :update_calendar, action: :update_calendar
   end
 
   actions do
@@ -72,6 +73,13 @@ defmodule Edenflowers.Store.FulfillmentOption do
 
     read :list_for_checkout do
       prepare build(sort: [sort_key: :asc, name: :asc])
+    end
+
+    update :update_calendar do
+      description "Admin-only update narrowed to the calendar overrides. " <>
+                    "Prevents accidental writes to pricing or fulfillment-method attrs."
+
+      accept [:available_days, :enabled_dates, :disabled_dates]
     end
   end
 

--- a/lib/edenflowers/store/fulfillment_option/changes/reset_calendar.ex
+++ b/lib/edenflowers/store/fulfillment_option/changes/reset_calendar.ex
@@ -1,0 +1,21 @@
+defmodule Edenflowers.Store.FulfillmentOption.Changes.ResetCalendar do
+  @moduledoc """
+  Wipes the option's calendar attributes back to "fully open, no overrides"
+  via `FulfillmentCalendar.reset/0`. Confirmed-destructive gesture — used by
+  the admin reset button, not by smart toggles.
+  """
+  use Ash.Resource.Change
+
+  alias Edenflowers.Store.FulfillmentCalendar
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    %{available_days: available, enabled_dates: enabled, disabled_dates: disabled} =
+      FulfillmentCalendar.reset()
+
+    changeset
+    |> Ash.Changeset.force_change_attribute(:available_days, available)
+    |> Ash.Changeset.force_change_attribute(:enabled_dates, enabled)
+    |> Ash.Changeset.force_change_attribute(:disabled_dates, disabled)
+  end
+end

--- a/lib/edenflowers/store/fulfillment_option/changes/set_week.ex
+++ b/lib/edenflowers/store/fulfillment_option/changes/set_week.ex
@@ -1,0 +1,25 @@
+defmodule Edenflowers.Store.FulfillmentOption.Changes.SetWeek do
+  @moduledoc """
+  Applies the directional per-week date change from
+  `FulfillmentCalendar.set_week/4` to the changeset. Delegates to the pure
+  function so the calculation stays unit-testable without a DB roundtrip.
+  """
+  use Ash.Resource.Change
+
+  alias Edenflowers.Store.FulfillmentCalendar
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    week = Ash.Changeset.get_argument(changeset, :week)
+    today = Ash.Changeset.get_argument(changeset, :today)
+    direction = Ash.Changeset.get_argument(changeset, :direction)
+    option = changeset.data
+
+    %{enabled_dates: enabled, disabled_dates: disabled} =
+      FulfillmentCalendar.set_week(option, week, today, direction)
+
+    changeset
+    |> Ash.Changeset.force_change_attribute(:enabled_dates, enabled)
+    |> Ash.Changeset.force_change_attribute(:disabled_dates, disabled)
+  end
+end

--- a/lib/edenflowers/store/fulfillment_option/changes/set_weekday.ex
+++ b/lib/edenflowers/store/fulfillment_option/changes/set_weekday.ex
@@ -1,8 +1,9 @@
-defmodule Edenflowers.Store.FulfillmentOption.Changes.ToggleWeekday do
+defmodule Edenflowers.Store.FulfillmentOption.Changes.SetWeekday do
   @moduledoc """
-  Applies the weekday-toggle semantics from `FulfillmentCalendar.toggle_weekday/2`
-  to the changeset. Delegates to the pure function so the calculation stays
-  unit-testable without a DB roundtrip.
+  Applies the directional per-weekday rule change from
+  `FulfillmentCalendar.set_weekday/3` to the changeset. Delegates to the
+  pure function so the calculation stays unit-testable without a DB
+  roundtrip.
   """
   use Ash.Resource.Change
 
@@ -11,10 +12,11 @@ defmodule Edenflowers.Store.FulfillmentOption.Changes.ToggleWeekday do
   @impl true
   def change(changeset, _opts, _context) do
     weekday = Ash.Changeset.get_argument(changeset, :weekday)
+    direction = Ash.Changeset.get_argument(changeset, :direction)
     option = changeset.data
 
     %{available_days: available, enabled_dates: enabled, disabled_dates: disabled} =
-      FulfillmentCalendar.toggle_weekday(option, weekday)
+      FulfillmentCalendar.set_weekday(option, weekday, direction)
 
     changeset
     |> Ash.Changeset.force_change_attribute(:available_days, available)

--- a/lib/edenflowers/store/fulfillment_option/changes/toggle_date.ex
+++ b/lib/edenflowers/store/fulfillment_option/changes/toggle_date.ex
@@ -1,0 +1,23 @@
+defmodule Edenflowers.Store.FulfillmentOption.Changes.ToggleDate do
+  @moduledoc """
+  Applies the per-date toggle semantics from `FulfillmentCalendar.toggle_date/2`
+  to the changeset. Delegates to the pure function so the calculation stays
+  unit-testable without a DB roundtrip.
+  """
+  use Ash.Resource.Change
+
+  alias Edenflowers.Store.FulfillmentCalendar
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    date = Ash.Changeset.get_argument(changeset, :date)
+    option = changeset.data
+
+    %{enabled_dates: enabled, disabled_dates: disabled} =
+      FulfillmentCalendar.toggle_date(option, date)
+
+    changeset
+    |> Ash.Changeset.force_change_attribute(:enabled_dates, enabled)
+    |> Ash.Changeset.force_change_attribute(:disabled_dates, disabled)
+  end
+end

--- a/lib/edenflowers/store/fulfillment_option/changes/toggle_weekday.ex
+++ b/lib/edenflowers/store/fulfillment_option/changes/toggle_weekday.ex
@@ -1,0 +1,24 @@
+defmodule Edenflowers.Store.FulfillmentOption.Changes.ToggleWeekday do
+  @moduledoc """
+  Applies the weekday-toggle semantics from `FulfillmentCalendar.toggle_weekday/2`
+  to the changeset. Delegates to the pure function so the calculation stays
+  unit-testable without a DB roundtrip.
+  """
+  use Ash.Resource.Change
+
+  alias Edenflowers.Store.FulfillmentCalendar
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    weekday = Ash.Changeset.get_argument(changeset, :weekday)
+    option = changeset.data
+
+    %{available_days: available, enabled_dates: enabled, disabled_dates: disabled} =
+      FulfillmentCalendar.toggle_weekday(option, weekday)
+
+    changeset
+    |> Ash.Changeset.force_change_attribute(:available_days, available)
+    |> Ash.Changeset.force_change_attribute(:enabled_dates, enabled)
+    |> Ash.Changeset.force_change_attribute(:disabled_dates, disabled)
+  end
+end

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -1,19 +1,20 @@
 defmodule Edenflowers.Store.KeyDates do
   @moduledoc """
-  Florist-relevant key dates rendered as decorations in the checkout calendar.
+  Florist-relevant key dates rendered as decorations in both the customer
+  checkout calendar and the admin fulfillment calendar.
 
-  The list is intentionally code-defined rather than DB-backed: these holidays
+  The list is intentionally code-defined rather than DB-backed: these dates
   are stable for years at a time, and version-controlling the list keeps every
   change reviewable. Per-customer reminder dates (the wider auto-send feature)
   will live in a separate, customer-scoped resource.
   """
 
   @typedoc "A florist key date materialised for a specific year — the shape returned by `for_year/1`."
-  @type holiday :: %{date: Date.t(), name: String.t(), icon: String.t()}
+  @type key_date :: %{date: Date.t(), name: String.t(), icon: String.t()}
 
   @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
 
-  @holidays [
+  @key_dates [
     %{name: "Valentine's Day", icon: "hero-heart-solid", rule: {:fixed, 2, 14}},
     %{name: "Women's Day", icon: "hero-sparkles-solid", rule: {:fixed, 3, 8}},
     %{name: "Mother's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 5, :sunday, 2}},
@@ -21,10 +22,10 @@ defmodule Edenflowers.Store.KeyDates do
     %{name: "Christmas Eve", icon: "hero-gift-solid", rule: {:fixed, 12, 24}}
   ]
 
-  @spec for_year(integer()) :: [holiday()]
+  @spec for_year(integer()) :: [key_date()]
   def for_year(year) do
-    Enum.map(@holidays, fn %{rule: rule} = holiday ->
-      holiday
+    Enum.map(@key_dates, fn %{rule: rule} = key_date ->
+      key_date
       |> Map.delete(:rule)
       |> Map.put(:date, materialise(rule, year))
     end)
@@ -32,7 +33,7 @@ defmodule Edenflowers.Store.KeyDates do
 
   @spec icon_for(Date.t()) :: String.t() | nil
   def icon_for(%Date{} = date) do
-    Enum.find_value(@holidays, fn %{rule: rule, icon: icon} ->
+    Enum.find_value(@key_dates, fn %{rule: rule, icon: icon} ->
       if materialise(rule, date.year) == date, do: icon
     end)
   end

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -12,6 +12,9 @@ defmodule Edenflowers.Store.KeyDates do
   @typedoc "A florist key date materialised for a specific year — the shape returned by `for_year/1`."
   @type key_date :: %{date: Date.t(), name: String.t(), icon: String.t(), colour_class: String.t()}
 
+  @typedoc "The visual decoration for a key date, returned by `lookup_for/1`."
+  @type decoration :: %{icon: String.t(), colour_class: String.t()}
+
   @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
 
   # `colour_class` is the Tailwind text colour applied to the heart in the
@@ -35,18 +38,34 @@ defmodule Edenflowers.Store.KeyDates do
     end)
   end
 
-  @spec icon_for(Date.t()) :: String.t() | nil
-  def icon_for(%Date{} = date) do
-    Enum.find_value(@key_dates, fn %{rule: rule, icon: icon} ->
-      if materialise(rule, date.year) == date, do: icon
+  @doc """
+  Combined icon + colour lookup for a date. Returns `nil` for non-key dates.
+  One traversal serves both pieces of the decoration so per-cell rendering
+  doesn't scan the key-date list twice.
+  """
+  @spec lookup_for(Date.t()) :: decoration() | nil
+  def lookup_for(%Date{} = date) do
+    Enum.find_value(@key_dates, fn %{rule: rule, icon: icon, colour_class: colour_class} ->
+      if materialise(rule, date.year) == date, do: %{icon: icon, colour_class: colour_class}
     end)
   end
 
-  @spec colour_class_for(Date.t()) :: String.t() | nil
-  def colour_class_for(%Date{} = date) do
-    Enum.find_value(@key_dates, fn %{rule: rule, colour_class: colour_class} ->
-      if materialise(rule, date.year) == date, do: colour_class
-    end)
+  @doc "Whether `date` is one of the florist key dates."
+  @spec key_date?(Date.t()) :: boolean()
+  def key_date?(%Date{} = date), do: lookup_for(date) != nil
+
+  @doc """
+  Key dates falling on `weekday` for the current and following year. The
+  two-year lookahead matches the calendar's visible horizon.
+  """
+  @spec dates_for_weekday(Edenflowers.Weekday.t()) :: [Date.t()]
+  def dates_for_weekday(weekday) do
+    year = Date.utc_today().year
+
+    [year, year + 1]
+    |> Enum.flat_map(&for_year/1)
+    |> Enum.map(& &1.date)
+    |> Enum.filter(&(Edenflowers.Weekday.from_date(&1) == weekday))
   end
 
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -1,0 +1,45 @@
+defmodule Edenflowers.Store.KeyDates do
+  @moduledoc """
+  Florist-relevant key dates rendered as decorations in the checkout calendar.
+
+  The list is intentionally code-defined rather than DB-backed: these holidays
+  are stable for years at a time, and version-controlling the list keeps every
+  change reviewable. Per-customer reminder dates (the wider auto-send feature)
+  will live in a separate, customer-scoped resource.
+  """
+
+  @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
+
+  @holidays [
+    %{name: "Valentine's Day", icon: "hero-heart-solid", rule: {:fixed, 2, 14}},
+    %{name: "Women's Day", icon: "hero-sparkles-solid", rule: {:fixed, 3, 8}},
+    %{name: "Mother's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 5, :sunday, 2}},
+    %{name: "Father's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 11, :sunday, 2}},
+    %{name: "Christmas Eve", icon: "hero-gift-solid", rule: {:fixed, 12, 24}}
+  ]
+
+  @spec for_year(integer()) :: [%{date: Date.t(), icon: String.t(), name: String.t()}]
+  def for_year(year) do
+    Enum.map(@holidays, fn %{rule: rule} = holiday ->
+      holiday
+      |> Map.delete(:rule)
+      |> Map.put(:date, materialise(rule, year))
+    end)
+  end
+
+  @spec icons_by_date(integer()) :: %{Date.t() => String.t()}
+  def icons_by_date(year) do
+    year
+    |> for_year()
+    |> Map.new(fn %{date: date, icon: icon} -> {date, icon} end)
+  end
+
+  defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)
+
+  defp materialise({:nth_weekday, month, weekday, n}, year) do
+    target = Map.fetch!(@weekdays, weekday)
+    first = Date.new!(year, month, 1)
+    offset = Integer.mod(target - Date.day_of_week(first), 7)
+    Date.add(first, offset + (n - 1) * 7)
+  end
+end

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -34,17 +34,6 @@ defmodule Edenflowers.Store.KeyDates do
     end)
   end
 
-  @doc """
-  The display name of the key date if `date` is a florist key date, else `nil`.
-  Used by admin guard rails to name dates in confirm prompts.
-  """
-  @spec name_for(Date.t()) :: String.t() | nil
-  def name_for(%Date{} = date) do
-    Enum.find_value(@holidays, fn %{rule: rule, name: name} ->
-      if materialise(rule, date.year) == date, do: name
-    end)
-  end
-
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)
 
   defp materialise({:nth_weekday, month, weekday, n}, year) do

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -27,11 +27,11 @@ defmodule Edenflowers.Store.KeyDates do
     end)
   end
 
-  @spec icons_by_date(integer()) :: %{Date.t() => String.t()}
-  def icons_by_date(year) do
-    year
-    |> for_year()
-    |> Map.new(fn %{date: date, icon: icon} -> {date, icon} end)
+  @spec icon_for(Date.t()) :: String.t() | nil
+  def icon_for(%Date{} = date) do
+    Enum.find_value(@holidays, fn %{rule: rule, icon: icon} ->
+      if materialise(rule, date.year) == date, do: icon
+    end)
   end
 
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -8,6 +8,9 @@ defmodule Edenflowers.Store.KeyDates do
   will live in a separate, customer-scoped resource.
   """
 
+  @typedoc "A florist key date materialised for a specific year — the shape returned by `for_year/1`."
+  @type holiday :: %{date: Date.t(), name: String.t(), icon: String.t()}
+
   @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
 
   @holidays [
@@ -18,7 +21,7 @@ defmodule Edenflowers.Store.KeyDates do
     %{name: "Christmas Eve", icon: "hero-gift-solid", rule: {:fixed, 12, 24}}
   ]
 
-  @spec for_year(integer()) :: [%{date: Date.t(), icon: String.t(), name: String.t()}]
+  @spec for_year(integer()) :: [holiday()]
   def for_year(year) do
     Enum.map(@holidays, fn %{rule: rule} = holiday ->
       holiday

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -10,16 +10,20 @@ defmodule Edenflowers.Store.KeyDates do
   """
 
   @typedoc "A florist key date materialised for a specific year — the shape returned by `for_year/1`."
-  @type key_date :: %{date: Date.t(), name: String.t(), icon: String.t()}
+  @type key_date :: %{date: Date.t(), name: String.t(), icon: String.t(), colour_class: String.t()}
 
   @weekdays %{monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6, sunday: 7}
 
+  # `colour_class` is the Tailwind text colour applied to the heart in the
+  # calendar watermark. Each date gets its own colour so the four key dates
+  # remain distinguishable when only the heart shape is shared.
+  # Valentine's Day reads as "Friend's Day" (Ystävänpäivä) in Finland — hence
+  # the friendly green rather than the romantic red.
   @key_dates [
-    %{name: "Valentine's Day", icon: "hero-heart-solid", rule: {:fixed, 2, 14}},
-    %{name: "Women's Day", icon: "hero-sparkles-solid", rule: {:fixed, 3, 8}},
-    %{name: "Mother's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 5, :sunday, 2}},
-    %{name: "Father's Day", icon: "hero-heart-solid", rule: {:nth_weekday, 11, :sunday, 2}},
-    %{name: "Christmas Eve", icon: "hero-gift-solid", rule: {:fixed, 12, 24}}
+    %{name: "Valentine's Day", icon: "hero-heart", colour_class: "text-emerald-500", rule: {:fixed, 2, 14}},
+    %{name: "Women's Day", icon: "hero-heart", colour_class: "text-violet-500", rule: {:fixed, 3, 8}},
+    %{name: "Mother's Day", icon: "hero-heart", colour_class: "text-rose-500", rule: {:nth_weekday, 5, :sunday, 2}},
+    %{name: "Father's Day", icon: "hero-heart", colour_class: "text-sky-500", rule: {:nth_weekday, 11, :sunday, 2}}
   ]
 
   @spec for_year(integer()) :: [key_date()]
@@ -35,6 +39,13 @@ defmodule Edenflowers.Store.KeyDates do
   def icon_for(%Date{} = date) do
     Enum.find_value(@key_dates, fn %{rule: rule, icon: icon} ->
       if materialise(rule, date.year) == date, do: icon
+    end)
+  end
+
+  @spec colour_class_for(Date.t()) :: String.t() | nil
+  def colour_class_for(%Date{} = date) do
+    Enum.find_value(@key_dates, fn %{rule: rule, colour_class: colour_class} ->
+      if materialise(rule, date.year) == date, do: colour_class
     end)
   end
 

--- a/lib/edenflowers/store/key_dates.ex
+++ b/lib/edenflowers/store/key_dates.ex
@@ -34,6 +34,17 @@ defmodule Edenflowers.Store.KeyDates do
     end)
   end
 
+  @doc """
+  The display name of the key date if `date` is a florist key date, else `nil`.
+  Used by admin guard rails to name dates in confirm prompts.
+  """
+  @spec name_for(Date.t()) :: String.t() | nil
+  def name_for(%Date{} = date) do
+    Enum.find_value(@holidays, fn %{rule: rule, name: name} ->
+      if materialise(rule, date.year) == date, do: name
+    end)
+  end
+
   defp materialise({:fixed, month, day}, year), do: Date.new!(year, month, day)
 
   defp materialise({:nth_weekday, month, weekday, n}, year) do

--- a/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
+++ b/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
@@ -26,8 +26,8 @@ defmodule Edenflowers.Store.Order.Validations.ValidateFulfillmentDate do
     case FulfillmentOption.get_by_id(option_id, authorize?: false) do
       {:ok, option} ->
         case Fulfillments.fulfill_on_date(option, date) do
-          {true, _} -> :ok
-          {false, reason} -> {:error, field: :fulfillment_date, message: unavailable_message(reason)}
+          :ok -> :ok
+          {:error, reason} -> {:error, field: :fulfillment_date, message: unavailable_message(reason)}
         end
 
       _ ->

--- a/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
+++ b/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
@@ -2,9 +2,13 @@ defmodule Edenflowers.Store.Order.Validations.ValidateFulfillmentDate do
   use Ash.Resource.Validation
   use GettextSigils, backend: EdenflowersWeb.Gettext
 
+  alias Edenflowers.Fulfillments
+  alias Edenflowers.Store.FulfillmentOption
+
   @impl true
   def validate(changeset, _opts, _context) do
     fulfillment_date = Ash.Changeset.get_attribute(changeset, :fulfillment_date)
+    option_id = Ash.Changeset.get_attribute(changeset, :fulfillment_option_id)
 
     cond do
       is_nil(fulfillment_date) ->
@@ -14,7 +18,27 @@ defmodule Edenflowers.Store.Order.Validations.ValidateFulfillmentDate do
         {:error, field: :fulfillment_date, message: ~t"Fulfillment date cannot be in the past"}
 
       true ->
+        check_availability(option_id, fulfillment_date)
+    end
+  end
+
+  defp check_availability(nil, _date), do: :ok
+
+  defp check_availability(option_id, date) do
+    case FulfillmentOption.get_by_id(option_id, authorize?: false) do
+      {:ok, option} ->
+        case Fulfillments.fulfill_on_date(option, date) do
+          {true, _} -> :ok
+          {false, reason} -> {:error, field: :fulfillment_date, message: unavailable_message(reason)}
+        end
+
+      _ ->
         :ok
     end
   end
+
+  defp unavailable_message(:past), do: ~t"Fulfillment date cannot be in the past"
+  defp unavailable_message(:same_day_delivery_disabled), do: ~t"Same-day fulfillment is not available"
+  defp unavailable_message(:order_deadline_passed), do: ~t"The order deadline for today has passed"
+  defp unavailable_message(_), do: ~t"This date is no longer available, please choose another"
 end

--- a/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
+++ b/lib/edenflowers/store/order/validations/validate_fulfillment_date.ex
@@ -10,15 +10,13 @@ defmodule Edenflowers.Store.Order.Validations.ValidateFulfillmentDate do
     fulfillment_date = Ash.Changeset.get_attribute(changeset, :fulfillment_date)
     option_id = Ash.Changeset.get_attribute(changeset, :fulfillment_option_id)
 
-    cond do
-      is_nil(fulfillment_date) ->
-        {:error, field: :fulfillment_date, message: "is required"}
-
-      Date.compare(fulfillment_date, Date.utc_today()) == :lt ->
-        {:error, field: :fulfillment_date, message: ~t"Fulfillment date cannot be in the past"}
-
-      true ->
-        check_availability(option_id, fulfillment_date)
+    if is_nil(fulfillment_date) do
+      {:error, field: :fulfillment_date, message: "is required"}
+    else
+      # All other rules (past, weekday, disabled_dates, same-day deadline) live
+      # in Fulfillments.fulfill_on_date/3 so the validator and the calendar
+      # share one source of truth — including the Helsinki timezone used there.
+      check_availability(option_id, fulfillment_date)
     end
   end
 

--- a/lib/edenflowers/weekday.ex
+++ b/lib/edenflowers/weekday.ex
@@ -3,6 +3,7 @@ defmodule Edenflowers.Weekday do
   Maps `Date.day_of_week/1` integers to atoms used by `FulfillmentOption.available_days`.
   """
 
+  @typedoc "Day-of-week atom matching the values stored in `FulfillmentOption.available_days`."
   @type t :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
 
   @spec from_date(Date.t()) :: t()

--- a/lib/edenflowers/weekday.ex
+++ b/lib/edenflowers/weekday.ex
@@ -1,0 +1,19 @@
+defmodule Edenflowers.Weekday do
+  @moduledoc """
+  Maps `Date.day_of_week/1` integers to atoms used by `FulfillmentOption.available_days`.
+  """
+
+  @type t :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
+
+  @spec from_date(Date.t()) :: t()
+  def from_date(%Date{} = date), do: from_integer(Date.day_of_week(date))
+
+  @spec from_integer(1..7) :: t()
+  def from_integer(1), do: :monday
+  def from_integer(2), do: :tuesday
+  def from_integer(3), do: :wednesday
+  def from_integer(4), do: :thursday
+  def from_integer(5), do: :friday
+  def from_integer(6), do: :saturday
+  def from_integer(7), do: :sunday
+end

--- a/lib/edenflowers/weekday.ex
+++ b/lib/edenflowers/weekday.ex
@@ -17,4 +17,13 @@ defmodule Edenflowers.Weekday do
   def from_integer(5), do: :friday
   def from_integer(6), do: :saturday
   def from_integer(7), do: :sunday
+
+  @spec to_integer(t()) :: 1..7
+  def to_integer(:monday), do: 1
+  def to_integer(:tuesday), do: 2
+  def to_integer(:wednesday), do: 3
+  def to_integer(:thursday), do: 4
+  def to_integer(:friday), do: 5
+  def to_integer(:saturday), do: 6
+  def to_integer(:sunday), do: 7
 end

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -1,0 +1,181 @@
+defmodule EdenflowersWeb.Admin.CalendarComponent do
+  @moduledoc """
+  Admin wrapper around `EdenflowersWeb.CalendarComponent`.
+
+  Holds every admin-specific binding — styling, key-date confirm, override
+  decoration, weekday-click — so the LiveView only orchestrates state. The
+  inner component keeps its checkout-shaped contract; this module bridges to
+  the admin view.
+  """
+  use EdenflowersWeb, :html
+
+  alias Edenflowers.Store.{FulfillmentCalendar, KeyDates}
+
+  # Shared swatch shape for the "options disagree" state. Used by cells, the
+  # weekday header, and the legend, so they always read the same.
+  @mixed_tile_class "bg-base-content/8 ring-1 ring-inset ring-base-content/15"
+
+  # Base box for the legend swatch — sized and positioned so the strike and
+  # corner fragments can be reused unchanged.
+  @swatch_base "relative inline-block w-4 h-4 mr-2 rounded align-middle"
+
+  attr :id, :string, required: true
+  attr :scope, :any, required: true, doc: "`:all` or a FulfillmentOption id"
+  attr :options, :list, required: true
+  attr :today, :any, required: true, doc: "`Date.t()` — passed in so render stays pure"
+
+  def admin_calendar(assigns) do
+    ~H"""
+    <.live_component
+      id={@id}
+      field={nil}
+      module={EdenflowersWeb.CalendarComponent}
+      selected_date={nil}
+      cell_state={fn date -> FulfillmentCalendar.view_model(@scope, @options, date, @today).state end}
+      cell_class={
+        fn day, state, opts ->
+          view = FulfillmentCalendar.view_model(@scope, @options, day, @today)
+          cell_class(day, state, opts, view.override?)
+        end
+      }
+      cell_confirm={
+        fn date ->
+          view = FulfillmentCalendar.view_model(@scope, @options, date, @today)
+          key_date_close_confirm(date, view)
+        end
+      }
+      clickable_states={[:open, :weekday_off, :override_off]}
+      on_click={:fulfillment_date_toggled}
+      on_weekday_click={:fulfillment_weekday_toggled}
+      weekday_class={
+        fn weekday ->
+          weekday_class(FulfillmentCalendar.weekday_state(@scope, @options, weekday))
+        end
+      }
+    >
+      <:day_decoration :let={day}>
+        <.icon
+          :if={icon = KeyDates.icon_for(day)}
+          name={icon}
+          class="text-error absolute right-0 bottom-0 left-0 m-auto h-3 w-3 -translate-y-0.5"
+        />
+      </:day_decoration>
+    </.live_component>
+    """
+  end
+
+  @doc """
+  Static legend that matches the admin cell vocabulary. Kept next to the
+  cell/weekday class functions so a change to either stays visible.
+  """
+  def admin_calendar_legend(assigns) do
+    ~H"""
+    <aside class="text-sm md:max-w-xs md:pt-2">
+      <h2 class="eyebrow text-base-content/55 mb-3">Legend</h2>
+      <ul class="text-base-content/85 space-y-2 leading-snug">
+        <li class="flex items-center"><span class={legend_swatch(:closed)}></span> Closed</li>
+        <li class="flex items-center">
+          <span class={legend_swatch(:override)}></span> Override (contradicts weekday rule)
+        </li>
+        <li class="flex items-center"><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
+      </ul>
+    </aside>
+    """
+  end
+
+  # Confirm message when an admin clicks a currently-open key date — they're
+  # about to close a florist-relevant holiday. Re-opening is safe, no confirm.
+  defp key_date_close_confirm(date, %{state: :open, key_date_name: name}) when is_binary(name) do
+    "#{name} (#{date}) is a florist key date. Close it?"
+  end
+
+  defp key_date_close_confirm(_date, _view), do: nil
+
+  # Visual language: a florist's printed planner. Closed dates are crossed
+  # out with a diagonal strike — the cell itself is marked as cancelled, not
+  # just the digit. A muted gray background keeps closed cells visually
+  # distinct from open ones. Cells whose state contradicts their weekday
+  # rule (explicit overrides) carry a small sage triangle in the top-right.
+  defp cell_class(_day, state, opts, override?) do
+    today? = Keyword.get(opts, :today?, false)
+
+    base =
+      "relative aspect-square rounded text-sm font-medium leading-none flex items-center justify-center " <>
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
+
+    # `after:` for the strike — the cell uses `before:` for the override
+    # corner so the two pseudo-elements don't collide.
+    closed_class =
+      "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-base-content/15 hover:after:bg-error " <>
+        diagonal_strike("after")
+
+    state_class =
+      case state do
+        :open -> "cursor-pointer text-base-content hover:bg-primary/10"
+        :weekday_off -> closed_class
+        :override_off -> closed_class
+        :past -> "cursor-not-allowed text-base-content/25"
+        :mixed -> "cursor-not-allowed text-base-content/55 #{@mixed_tile_class}"
+      end
+
+    today_class = if today?, do: " font-bold text-primary", else: ""
+    override_class = if override?, do: " " <> override_corner("before"), else: ""
+
+    "#{base} #{state_class}#{today_class}#{override_class}"
+  end
+
+  defp weekday_class(state) do
+    base =
+      "rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
+
+    state_class =
+      case state do
+        :on ->
+          "cursor-pointer text-base-content/65 hover:text-base-content hover:bg-primary/10"
+
+        :off ->
+          "cursor-pointer bg-base-content/10 text-base-content/65 line-through decoration-2 decoration-error/75 " <>
+            "hover:bg-base-content/15 hover:decoration-error"
+
+        :mixed ->
+          "cursor-not-allowed text-base-content/45 #{@mixed_tile_class}"
+      end
+
+    "#{base} #{state_class}"
+  end
+
+  # The :closed swatch mirrors a closed cell in miniature, the :override swatch
+  # mirrors a cell with a triangle corner. They reuse the same fragments as the
+  # cell so the legend can't drift from the real thing.
+  defp legend_swatch(:closed) do
+    "#{@swatch_base} bg-base-content/10 #{diagonal_strike("before")}"
+  end
+
+  defp legend_swatch(:override) do
+    "#{@swatch_base} ring-1 ring-inset ring-base-content/15 #{override_corner("after")}"
+  end
+
+  defp legend_swatch(:mixed) do
+    "inline-block w-4 h-4 mr-2 rounded align-middle #{@mixed_tile_class}"
+  end
+
+  # Diagonal strike, ~22° off horizontal, ~56% of the container width.
+  # Parameterized over `:before` vs `:after` because cells use the override
+  # corner on `before:` already, while the legend swatch is free to use
+  # `before:` for the strike itself.
+  defp diagonal_strike(prefix) do
+    "#{prefix}:absolute #{prefix}:left-[22%] #{prefix}:right-[22%] #{prefix}:top-1/2 #{prefix}:h-[2px] " <>
+      "#{prefix}:-translate-y-1/2 #{prefix}:rotate-[-22deg] #{prefix}:bg-error/75 #{prefix}:content-[''] " <>
+      "#{prefix}:rounded-full"
+  end
+
+  # Folded-page corner — small right-angled triangle in the top-right. Reads
+  # as "marked by hand" without competing with the closed strike (centred) or
+  # the today digit (centred).
+  defp override_corner(prefix) do
+    "#{prefix}:absolute #{prefix}:top-0 #{prefix}:right-0 #{prefix}:h-2 #{prefix}:w-2 " <>
+      "#{prefix}:bg-primary/75 #{prefix}:content-[''] " <>
+      "#{prefix}:[clip-path:polygon(100%_0,0_0,100%_100%)]"
+  end
+end

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -48,6 +48,12 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
           weekday_class(FulfillmentCalendar.weekday_state(@scope, @options, weekday))
         end
       }
+      on_week_click={:fulfillment_week_toggled}
+      week_class={
+        fn week ->
+          week_class(scope_week_state(@scope, @options, week, @today))
+        end
+      }
     >
       <:day_decoration :let={%{date: day, state: state}}>
         <.key_date_icon date={day} muted?={state == :past} />
@@ -65,11 +71,18 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     <aside class="text-sm md:max-w-xs md:pt-2">
       <h2 class="eyebrow text-base-content/55 mb-3">Legend</h2>
       <ul class="text-base-content/85 space-y-2 leading-snug">
-        <li class="flex items-center"><span class={legend_swatch(:closed)}></span> Closed</li>
         <li class="flex items-center">
-          <span class={legend_swatch(:override)}></span> Override (contradicts weekday rule)
+          <span class={legend_swatch(:closed)}></span>
+          <span>Closed for bookings <span class="text-base-content/55">— not selectable by customers</span></span>
         </li>
-        <li class="flex items-center"><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
+        <li class="flex items-center">
+          <span class={legend_swatch(:override)}></span>
+          <span>Manually changed <span class="text-base-content/55">— your override on this date</span></span>
+        </li>
+        <li class="flex items-center">
+          <span class={legend_swatch(:mixed)}></span>
+          <span>Varies by option <span class="text-base-content/55">— switch to a single option to edit</span></span>
+        </li>
       </ul>
     </aside>
     """
@@ -83,6 +96,33 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     case Enum.find(options, &(&1.id == option_id)) do
       nil -> :open
       option -> Fulfillments.admin_cell_state(option, date, today)
+    end
+  end
+
+  # Aggregate week state across the current scope. From the button's POV three
+  # outcomes matter: everything open, everything closed, anything else (mixed),
+  # or whole week in the past. Cross-option disagreement just folds into :mixed
+  # — the bulk gesture is the gesture for that case.
+  defp scope_week_state(scope, options, week, today) do
+    targets =
+      case scope do
+        :all -> options
+        id -> Enum.filter(options, &(&1.id == id))
+      end
+
+    case targets do
+      [] ->
+        :all_open
+
+      list ->
+        states = Enum.map(list, &FulfillmentCalendar.week_state(&1, week, today))
+
+        cond do
+          Enum.all?(states, &(&1 == :all_past)) -> :all_past
+          Enum.all?(states, &(&1 == :all_open)) -> :all_open
+          Enum.all?(states, &(&1 == :all_closed)) -> :all_closed
+          true -> :mixed
+        end
     end
   end
 
@@ -121,6 +161,25 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     "#{base} #{state_class}#{today_class}#{override_class}"
   end
 
+  defp week_class(state) do
+    base =
+      "flex items-center justify-center rounded text-base-content/55 " <>
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
+
+    case state do
+      :all_past ->
+        "#{base} cursor-not-allowed text-base-content/20"
+
+      :all_closed ->
+        # Click re-opens what's closed by override. Muted to signal that the
+        # default direction is "open" — the opposite of every other state.
+        "#{base} cursor-pointer text-base-content/35 hover:bg-primary/10 hover:text-base-content/65"
+
+      _open_or_mixed ->
+        "#{base} cursor-pointer hover:bg-primary/10 hover:text-base-content/85"
+    end
+  end
+
   defp weekday_class(state) do
     base =
       "relative rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
@@ -137,7 +196,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
           "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 calendar-strike-after-tight"
 
         :mixed ->
-          "cursor-not-allowed text-base-content/85 #{@mixed_tile_class}"
+          "cursor-pointer text-base-content/85 hover:bg-primary/10 #{@mixed_tile_class}"
       end
 
     "#{base} #{state_class}"

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -14,9 +14,9 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   alias Edenflowers.Fulfillments
   alias Edenflowers.Store.FulfillmentCalendar
 
-  # Shared swatch shape for the "options disagree" state. Used by cells, the
-  # weekday header, and the legend, so they always read the same.
-  @mixed_tile_class "bg-base-content/8 ring-1 ring-inset ring-base-content/15"
+  # Shared "options disagree" tile — diagonal stripes via the calendar-mixed
+  # @utility in app.css. Used by cells, the weekday header, and the legend.
+  @mixed_tile_class "calendar-mixed"
 
   # Base box for the legend swatch — sized and positioned so the strike and
   # corner fragments can be reused unchanged.
@@ -112,7 +112,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
         :weekday_disabled -> closed_class
         :date_disabled -> closed_class
         :past -> "cursor-not-allowed text-base-content/35"
-        :mixed -> "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
+        :mixed -> "cursor-not-allowed text-base-content/85 #{@mixed_tile_class}"
       end
 
     today_class = if today?, do: " underline", else: ""
@@ -138,7 +138,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
             "hover:bg-primary/10 hover:decoration-error"
 
         :mixed ->
-          "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
+          "cursor-not-allowed text-base-content/85 #{@mixed_tile_class}"
       end
 
     "#{base} #{state_class}"

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -9,6 +9,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   """
   use EdenflowersWeb, :html
 
+  alias Edenflowers.Fulfillments
   alias Edenflowers.Store.{FulfillmentCalendar, KeyDates}
 
   # Shared swatch shape for the "options disagree" state. Used by cells, the
@@ -31,11 +32,10 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       field={nil}
       module={EdenflowersWeb.CalendarComponent}
       selected_date={nil}
-      cell_state={fn date -> FulfillmentCalendar.view_model(@scope, @options, date, @today).state end}
+      cell_state={fn date -> scope_cell_state(@scope, @options, date, @today) end}
       cell_class={
         fn day, state, opts ->
-          view = FulfillmentCalendar.view_model(@scope, @options, day, @today)
-          cell_class(day, state, opts, view.override?)
+          cell_class(day, state, opts, scope_override?(@scope, @options, day))
         end
       }
       clickable_states={[:open, :weekday_off, :override_off]}
@@ -75,6 +75,29 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       </ul>
     </aside>
     """
+  end
+
+  defp scope_cell_state(:all, options, date, today) do
+    FulfillmentCalendar.cell_state_for_options(options, date, today)
+  end
+
+  defp scope_cell_state(option_id, options, date, today) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> :open
+      option -> Fulfillments.cell_state(option, date, today, audience: :admin)
+    end
+  end
+
+  # `:all` collapses to `false` — across options, "some override, some don't"
+  # can't be summarized by a single corner mark. Same behaviour the old
+  # `view_model` enforced.
+  defp scope_override?(:all, _options, _date), do: false
+
+  defp scope_override?(option_id, options, date) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> false
+      option -> FulfillmentCalendar.override?(option, date)
+    end
   end
 
   # Visual language: a florist's printed planner. Closed dates are crossed

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -89,8 +89,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   end
 
   # `:all` collapses to `false` — across options, "some override, some don't"
-  # can't be summarized by a single corner mark. Same behaviour the old
-  # `view_model` enforced.
+  # can't be summarized by a single corner mark.
   defp scope_override?(:all, _options, _date), do: false
 
   defp scope_override?(option_id, options, date) do
@@ -100,18 +99,6 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     end
   end
 
-  # Muted-text opacity ladder, used by both cells and the weekday header.
-  # `/85` primary, `/65` secondary/closed, `/35` disabled. Anything outside
-  # this set is a typography choice (eyebrow, list copy), not a cell state.
-  #
-  # Clickable elements share `hover:bg-primary/10` so cells, weekday headers,
-  # and the scope chips (in `FulfillmentCalendarLive`) feel like one system.
-
-  # Visual language: a florist's printed planner. Closed dates are crossed
-  # out with a diagonal strike — the cell itself is marked as cancelled, not
-  # just the digit. A muted gray background keeps closed cells visually
-  # distinct from open ones. Cells whose state contradicts their weekday
-  # rule (explicit overrides) carry a small sage triangle in the top-right.
   defp cell_class(_day, state, opts, override?) do
     today? = Keyword.get(opts, :today?, false)
 
@@ -119,8 +106,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       "relative aspect-square rounded text-sm font-medium leading-none flex items-center justify-center " <>
         "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
 
-    # `after:` for the strike — the cell uses `before:` for the override
-    # corner so the two pseudo-elements don't collide.
+    # Strike on `after:`, override corner on `before:` — pseudo-elements split so they don't collide.
     closed_class =
       "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 hover:after:bg-error " <>
         diagonal_strike("after")
@@ -163,9 +149,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     "#{base} #{state_class}"
   end
 
-  # The :closed swatch mirrors a closed cell in miniature, the :override swatch
-  # mirrors a cell with a triangle corner. They reuse the same fragments as the
-  # cell so the legend can't drift from the real thing.
+  # Reuses diagonal_strike/override_corner so the legend can't drift from the real cells.
   defp legend_swatch(:closed) do
     "#{@swatch_base} bg-base-content/10 #{diagonal_strike("before")}"
   end
@@ -178,19 +162,15 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     "#{@swatch_base} #{@mixed_tile_class}"
   end
 
-  # Diagonal strike, ~22° off horizontal, ~56% of the container width.
-  # Parameterized over `:before` vs `:after` because cells use the override
-  # corner on `before:` already, while the legend swatch is free to use
-  # `before:` for the strike itself.
+  # Parameterised over `before` vs `after` so cells can pair the strike with the
+  # override corner (which holds `before:`) while the legend swatch reuses `before:`.
   defp diagonal_strike(prefix) do
     "#{prefix}:absolute #{prefix}:left-[22%] #{prefix}:right-[22%] #{prefix}:top-1/2 #{prefix}:h-[2px] " <>
       "#{prefix}:-translate-y-1/2 #{prefix}:rotate-[-22deg] #{prefix}:bg-error/75 #{prefix}:content-[''] " <>
       "#{prefix}:rounded-full"
   end
 
-  # Folded-page corner — small right-angled triangle in the top-right. Reads
-  # as "marked by hand" without competing with the closed strike (centred) or
-  # the today digit (centred).
+  # Top-right triangle — sits clear of the centred strike and the centred today digit.
   defp override_corner(prefix) do
     "#{prefix}:absolute #{prefix}:top-0 #{prefix}:right-0 #{prefix}:h-2 #{prefix}:w-2 " <>
       "#{prefix}:bg-primary/75 #{prefix}:content-[''] " <>

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -9,8 +9,10 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   """
   use EdenflowersWeb, :html
 
+  import EdenflowersWeb.KeyDateIcon
+
   alias Edenflowers.Fulfillments
-  alias Edenflowers.Store.{FulfillmentCalendar, KeyDates}
+  alias Edenflowers.Store.FulfillmentCalendar
 
   # Shared swatch shape for the "options disagree" state. Used by cells, the
   # weekday header, and the legend, so they always read the same.
@@ -48,11 +50,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       }
     >
       <:day_decoration :let={day}>
-        <.icon
-          :if={icon = KeyDates.icon_for(day)}
-          name={icon}
-          class="text-error absolute right-0 bottom-0 left-0 m-auto h-3 w-3 -translate-y-0.5"
-        />
+        <.key_date_icon date={day} />
       </:day_decoration>
     </.live_component>
     """

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -49,8 +49,8 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
         end
       }
     >
-      <:day_decoration :let={day}>
-        <.key_date_icon date={day} />
+      <:day_decoration :let={%{date: day, state: state}}>
+        <.key_date_icon date={day} muted?={state == :past} />
       </:day_decoration>
     </.live_component>
     """
@@ -115,7 +115,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
         :mixed -> "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
       end
 
-    today_class = if today?, do: " font-bold text-primary", else: ""
+    today_class = if today?, do: " underline", else: ""
     override_class = if override?, do: " calendar-corner-before", else: ""
 
     "#{base} #{state_class}#{today_class}#{override_class}"

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -11,7 +11,6 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
 
   import EdenflowersWeb.KeyDateIcon
 
-  alias Edenflowers.Fulfillments
   alias Edenflowers.Store.FulfillmentCalendar
 
   # Shared "options disagree" tile — diagonal stripes via the calendar-mixed
@@ -34,7 +33,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       field={nil}
       module={EdenflowersWeb.CalendarComponent}
       selected_date={nil}
-      cell_state={fn date -> scope_cell_state(@scope, @options, date, @today) end}
+      cell_state={fn date -> FulfillmentCalendar.cell_state_for_scope(@scope, @options, date, @today) end}
       cell_class={
         fn day, state, opts ->
           cell_class(day, state, opts, scope_override?(@scope, @options, day))
@@ -88,29 +87,12 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     """
   end
 
-  defp scope_cell_state(:all, options, date, today) do
-    FulfillmentCalendar.cell_state_for_options(options, date, today)
-  end
-
-  defp scope_cell_state(option_id, options, date, today) do
-    case Enum.find(options, &(&1.id == option_id)) do
-      nil -> :open
-      option -> Fulfillments.admin_cell_state(option, date, today)
-    end
-  end
-
   # Aggregate week state across the current scope. From the button's POV three
   # outcomes matter: everything open, everything closed, anything else (mixed),
   # or whole week in the past. Cross-option disagreement just folds into :mixed
   # — the bulk gesture is the gesture for that case.
   defp scope_week_state(scope, options, week, today) do
-    targets =
-      case scope do
-        :all -> options
-        id -> Enum.filter(options, &(&1.id == id))
-      end
-
-    case targets do
+    case FulfillmentCalendar.scoped_options(scope, options) do
       [] ->
         :all_open
 

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -106,10 +106,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       "relative aspect-square rounded text-sm font-medium leading-none flex items-center justify-center " <>
         "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
 
-    # Strike on `after:`, override corner on `before:` — pseudo-elements split so they don't collide.
-    closed_class =
-      "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 hover:after:bg-error " <>
-        diagonal_strike("after")
+    closed_class = "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 calendar-strike-after"
 
     state_class =
       case state do
@@ -121,7 +118,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
       end
 
     today_class = if today?, do: " font-bold text-primary", else: ""
-    override_class = if override?, do: " " <> override_corner("before"), else: ""
+    override_class = if override?, do: " calendar-corner-before", else: ""
 
     "#{base} #{state_class}#{today_class}#{override_class}"
   end
@@ -149,31 +146,9 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     "#{base} #{state_class}"
   end
 
-  # Reuses diagonal_strike/override_corner so the legend can't drift from the real cells.
-  defp legend_swatch(:closed) do
-    "#{@swatch_base} bg-base-content/10 #{diagonal_strike("before")}"
-  end
-
-  defp legend_swatch(:override) do
-    "#{@swatch_base} ring-1 ring-inset ring-base-content/15 #{override_corner("after")}"
-  end
-
-  defp legend_swatch(:mixed) do
-    "#{@swatch_base} #{@mixed_tile_class}"
-  end
-
-  # Parameterised over `before` vs `after` so cells can pair the strike with the
-  # override corner (which holds `before:`) while the legend swatch reuses `before:`.
-  defp diagonal_strike(prefix) do
-    "#{prefix}:absolute #{prefix}:left-[22%] #{prefix}:right-[22%] #{prefix}:top-1/2 #{prefix}:h-[2px] " <>
-      "#{prefix}:-translate-y-1/2 #{prefix}:rotate-[-22deg] #{prefix}:bg-error/75 #{prefix}:content-[''] " <>
-      "#{prefix}:rounded-full"
-  end
-
-  # Top-right triangle — sits clear of the centred strike and the centred today digit.
-  defp override_corner(prefix) do
-    "#{prefix}:absolute #{prefix}:top-0 #{prefix}:right-0 #{prefix}:h-2 #{prefix}:w-2 " <>
-      "#{prefix}:bg-primary/75 #{prefix}:content-[''] " <>
-      "#{prefix}:[clip-path:polygon(100%_0,0_0,100%_100%)]"
-  end
+  # Uses the same calendar-strike-* / calendar-corner-* utilities as the
+  # cells (defined in app.css), so the legend can't drift from the real cells.
+  defp legend_swatch(:closed), do: "#{@swatch_base} bg-base-content/10 calendar-strike-before"
+  defp legend_swatch(:override), do: "#{@swatch_base} ring-1 ring-inset ring-base-content/15 calendar-corner-after"
+  defp legend_swatch(:mixed), do: "#{@swatch_base} #{@mixed_tile_class}"
 end

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -38,7 +38,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
           cell_class(day, state, opts, scope_override?(@scope, @options, day))
         end
       }
-      clickable_states={[:open, :weekday_off, :override_off]}
+      clickable_states={[:open, :weekday_disabled, :date_disabled]}
       on_click={:fulfillment_date_toggled}
       on_weekday_click={:fulfillment_weekday_toggled}
       weekday_class={
@@ -84,7 +84,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   defp scope_cell_state(option_id, options, date, today) do
     case Enum.find(options, &(&1.id == option_id)) do
       nil -> :open
-      option -> Fulfillments.cell_state(option, date, today, audience: :admin)
+      option -> Fulfillments.admin_cell_state(option, date, today)
     end
   end
 
@@ -114,8 +114,8 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     state_class =
       case state do
         :open -> "cursor-pointer text-base-content/85 hover:bg-primary/10"
-        :weekday_off -> closed_class
-        :override_off -> closed_class
+        :weekday_disabled -> closed_class
+        :date_disabled -> closed_class
         :past -> "cursor-not-allowed text-base-content/35"
         :mixed -> "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
       end

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -123,7 +123,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
 
   defp weekday_class(state) do
     base =
-      "rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
+      "relative rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
         "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
 
     state_class =
@@ -134,8 +134,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
           "cursor-pointer text-base-content/65 hover:text-base-content/85 hover:bg-primary/10"
 
         :off ->
-          "cursor-pointer bg-base-content/10 text-base-content/65 line-through decoration-2 decoration-error/75 " <>
-            "hover:bg-primary/10 hover:decoration-error"
+          "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 calendar-strike-after-tight"
 
         :mixed ->
           "cursor-not-allowed text-base-content/85 #{@mixed_tile_class}"

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -100,6 +100,13 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     end
   end
 
+  # Muted-text opacity ladder, used by both cells and the weekday header.
+  # `/85` primary, `/65` secondary/closed, `/35` disabled. Anything outside
+  # this set is a typography choice (eyebrow, list copy), not a cell state.
+  #
+  # Clickable elements share `hover:bg-primary/10` so cells, weekday headers,
+  # and the scope chips (in `FulfillmentCalendarLive`) feel like one system.
+
   # Visual language: a florist's printed planner. Closed dates are crossed
   # out with a diagonal strike — the cell itself is marked as cancelled, not
   # just the digit. A muted gray background keeps closed cells visually
@@ -115,16 +122,16 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     # `after:` for the strike — the cell uses `before:` for the override
     # corner so the two pseudo-elements don't collide.
     closed_class =
-      "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-base-content/15 hover:after:bg-error " <>
+      "cursor-pointer bg-base-content/10 text-base-content/65 hover:bg-primary/10 hover:after:bg-error " <>
         diagonal_strike("after")
 
     state_class =
       case state do
-        :open -> "cursor-pointer text-base-content hover:bg-primary/10"
+        :open -> "cursor-pointer text-base-content/85 hover:bg-primary/10"
         :weekday_off -> closed_class
         :override_off -> closed_class
-        :past -> "cursor-not-allowed text-base-content/25"
-        :mixed -> "cursor-not-allowed text-base-content/55 #{@mixed_tile_class}"
+        :past -> "cursor-not-allowed text-base-content/35"
+        :mixed -> "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
       end
 
     today_class = if today?, do: " font-bold text-primary", else: ""
@@ -141,14 +148,16 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     state_class =
       case state do
         :on ->
-          "cursor-pointer text-base-content/65 hover:text-base-content hover:bg-primary/10"
+          # On hover the text shifts from /65 → /85 so a "live" header signals
+          # interactivity even before the background fills in.
+          "cursor-pointer text-base-content/65 hover:text-base-content/85 hover:bg-primary/10"
 
         :off ->
           "cursor-pointer bg-base-content/10 text-base-content/65 line-through decoration-2 decoration-error/75 " <>
-            "hover:bg-base-content/15 hover:decoration-error"
+            "hover:bg-primary/10 hover:decoration-error"
 
         :mixed ->
-          "cursor-not-allowed text-base-content/45 #{@mixed_tile_class}"
+          "cursor-not-allowed text-base-content/65 #{@mixed_tile_class}"
       end
 
     "#{base} #{state_class}"
@@ -166,7 +175,7 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   end
 
   defp legend_swatch(:mixed) do
-    "inline-block w-4 h-4 mr-2 rounded align-middle #{@mixed_tile_class}"
+    "#{@swatch_base} #{@mixed_tile_class}"
   end
 
   # Diagonal strike, ~22° off horizontal, ~56% of the container width.

--- a/lib/edenflowers_web/components/admin/calendar_component.ex
+++ b/lib/edenflowers_web/components/admin/calendar_component.ex
@@ -2,10 +2,10 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
   @moduledoc """
   Admin wrapper around `EdenflowersWeb.CalendarComponent`.
 
-  Holds every admin-specific binding — styling, key-date confirm, override
-  decoration, weekday-click — so the LiveView only orchestrates state. The
-  inner component keeps its checkout-shaped contract; this module bridges to
-  the admin view.
+  Holds every admin-specific binding — styling, override decoration,
+  weekday-click — so the LiveView only orchestrates state. The inner
+  component keeps its checkout-shaped contract; this module bridges to the
+  admin view.
   """
   use EdenflowersWeb, :html
 
@@ -36,12 +36,6 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
         fn day, state, opts ->
           view = FulfillmentCalendar.view_model(@scope, @options, day, @today)
           cell_class(day, state, opts, view.override?)
-        end
-      }
-      cell_confirm={
-        fn date ->
-          view = FulfillmentCalendar.view_model(@scope, @options, date, @today)
-          key_date_close_confirm(date, view)
         end
       }
       clickable_states={[:open, :weekday_off, :override_off]}
@@ -82,14 +76,6 @@ defmodule EdenflowersWeb.Admin.CalendarComponent do
     </aside>
     """
   end
-
-  # Confirm message when an admin clicks a currently-open key date — they're
-  # about to close a florist-relevant holiday. Re-opening is safe, no confirm.
-  defp key_date_close_confirm(date, %{state: :open, key_date_name: name}) when is_binary(name) do
-    "#{name} (#{date}) is a florist key date. Close it?"
-  end
-
-  defp key_date_close_confirm(_date, _view), do: nil
 
   # Visual language: a florist's printed planner. Closed dates are crossed
   # out with a diagonal strike — the cell itself is marked as cancelled, not

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -163,8 +163,8 @@ defmodule EdenflowersWeb.CalendarComponent do
         <% end %>
       </div>
 
-      <div id={"#{@id}-grid"} class="mt-1">
-        <div :for={week <- @week_rows} class="grid grid-cols-7">
+      <div id={"#{@id}-grid"} class="mt-1 flex flex-col gap-0.5">
+        <div :for={week <- @week_rows} class="grid grid-cols-7 gap-0.5">
           <%= for day <- week do %>
             <%= if current_month?(day, @view_date) do %>
               <% state = @cell_state.(day) %>

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -93,7 +93,14 @@ defmodule EdenflowersWeb.CalendarComponent do
         "`on_weekday_click` is set. Defaults to a neutral button look."
 
   attr :error, :boolean, default: false
-  slot :day_decoration, required: false
+
+  slot :day_decoration,
+    required: false,
+    doc:
+      "Optional inner content rendered after the date digit. Receives a map " <>
+        "via `:let` with `:date`, `:state` (the result of `cell_state.(date)`), " <>
+        "and `:selected?`. Decoration components can use those to adapt their " <>
+        "visual to the cell's state — e.g. hide on a selected cell."
 
   def render(assigns) do
     ~H"""
@@ -188,10 +195,10 @@ defmodule EdenflowersWeb.CalendarComponent do
     selected?: selected?(day, @selected_date),
     today?: day == @today_date)}
               >
-                <time datetime={Date.to_iso8601(day)} aria-hidden="true">
+                <time datetime={Date.to_iso8601(day)} aria-hidden="true" class="relative z-10">
                   {Localize.DateTime.to_string!(day, format: "d")}
                 </time>
-                {render_slot(@day_decoration, day)}
+                {render_slot(@day_decoration, %{date: day, state: state, selected?: selected?(day, @selected_date)})}
               </button>
             <% else %>
               <div aria-hidden="true" class="aspect-square"></div>

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -92,6 +92,18 @@ defmodule EdenflowersWeb.CalendarComponent do
       "Optional (weekday_atom -> css_classes). Applied to each weekday header. Only meaningful when " <>
         "`on_weekday_click` is set. Defaults to a neutral button look."
 
+  attr :on_week_click, :any,
+    default: nil,
+    doc:
+      "Optional. When set, each week gets a leading button that emits `{tag, [Date.t()]}` " <>
+        "with the week's 7 dates. When unset, no button is rendered."
+
+  attr :week_class, :any,
+    default: nil,
+    doc:
+      "Optional ([Date.t()] -> css_classes). Applied to each week button. Only meaningful when " <>
+        "`on_week_click` is set. Defaults to a neutral button look."
+
   attr :error, :boolean, default: false
 
   slot :day_decoration,
@@ -151,8 +163,9 @@ defmodule EdenflowersWeb.CalendarComponent do
 
       <div
         aria-hidden={if @on_weekday_click, do: nil, else: "true"}
-        class="border-base-content/20 mt-2 grid grid-cols-7 border-b text-center text-sm leading-6"
+        class={["border-base-content/20 mt-2 grid border-b text-center text-sm leading-6", if(@on_week_click, do: "grid-cols-[1.5rem_repeat(7,_1fr)] gap-x-1", else: "grid-cols-7")]}
       >
+        <span :if={@on_week_click} aria-hidden="true"></span>
         <%= for week_day <- List.first(@week_rows) do %>
           <%= if @on_weekday_click do %>
             <button
@@ -174,7 +187,23 @@ defmodule EdenflowersWeb.CalendarComponent do
       </div>
 
       <div id={"#{@id}-grid"} class="mt-1 flex flex-col gap-0.5">
-        <div :for={week <- @week_rows} class="grid grid-cols-7 gap-0.5">
+        <div
+          :for={week <- @week_rows}
+          class={if @on_week_click,
+      do: "grid-cols-[1.5rem_repeat(7,_1fr)] grid gap-x-1 gap-y-0.5",
+      else: "grid grid-cols-7 gap-0.5"}
+        >
+          <button
+            :if={@on_week_click}
+            type="button"
+            phx-target={@myself}
+            phx-click="week-click"
+            phx-value-week={Enum.map_join(week, ",", &Date.to_iso8601/1)}
+            aria-label={week_aria_label(week)}
+            class={@week_class.(week)}
+          >
+            <.icon name="hero-arrows-right-left" class="h-3 w-3" />
+          </button>
           <%= for day <- week do %>
             <%= if current_month?(day, @view_date) do %>
               <% state = @cell_state.(day) %>
@@ -238,6 +267,15 @@ defmodule EdenflowersWeb.CalendarComponent do
   def handle_event("weekday-click", %{"weekday" => weekday_string}, socket) do
     if tag = socket.assigns.on_weekday_click do
       send(self(), {tag, String.to_existing_atom(weekday_string)})
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("week-click", %{"week" => week_string}, socket) do
+    if tag = socket.assigns.on_week_click do
+      week = week_string |> String.split(",") |> Enum.map(&Date.from_iso8601!/1)
+      send(self(), {tag, week})
     end
 
     {:noreply, socket}
@@ -321,6 +359,12 @@ defmodule EdenflowersWeb.CalendarComponent do
   defp weekday_aria_label(date) do
     full = Localize.DateTime.to_string!(date, format: "EEEE")
     ~t"Toggle " <> full
+  end
+
+  defp week_aria_label(week) do
+    first = Localize.DateTime.to_string!(List.first(week), format: "d MMM")
+    last = Localize.DateTime.to_string!(List.last(week), format: "d MMM")
+    ~t"Toggle week" <> " #{first} – #{last}"
   end
 
   defp day_aria_label(day, today_date, selected_date, selectable?) do

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -273,12 +273,13 @@ defmodule EdenflowersWeb.CalendarComponent do
   end
 
   def handle_event("week-click", %{"week" => week_string}, socket) do
-    if tag = socket.assigns.on_week_click do
-      week = week_string |> String.split(",") |> Enum.map(&Date.from_iso8601!/1)
+    with tag when not is_nil(tag) <- socket.assigns.on_week_click,
+         {:ok, week} <- parse_week(week_string) do
       send(self(), {tag, week})
+      {:noreply, socket}
+    else
+      _ -> {:noreply, socket}
     end
-
-    {:noreply, socket}
   end
 
   def handle_event("keydown", %{"key" => key, "viewDate" => view_date}, socket) do
@@ -296,6 +297,21 @@ defmodule EdenflowersWeb.CalendarComponent do
   end
 
   # Helper Functions
+
+  defp parse_week(week_string) do
+    week_string
+    |> String.split(",")
+    |> Enum.reduce_while({:ok, []}, fn iso, {:ok, acc} ->
+      case Date.from_iso8601(iso) do
+        {:ok, date} -> {:cont, {:ok, [date | acc]}}
+        {:error, _} -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, dates} -> {:ok, Enum.reverse(dates)}
+      :error -> :error
+    end
+  end
 
   defp previous_month_button_class(view_date, today_date) do
     is_disabled = current_month?(view_date, today_date)

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -15,12 +15,18 @@ defmodule EdenflowersWeb.CalendarComponent do
      |> assign(selected_date: nil)
      |> assign(week_begins: @week_begins)
      |> assign(today_date: today_date)
-     |> assign(selectable?: fn _ -> true end)
+     |> assign(cell_state: fn _ -> :open end)
+     |> assign(cell_class: &default_cell_class/3)
+     |> assign(clickable_states: [:open])
+     |> assign(on_click: :date_selected)
+     |> assign(on_weekday_click: nil)
+     |> assign(weekday_class: &default_weekday_class/1)
      |> update_calendar_view(today_date)}
   end
 
   def update(assigns, socket) do
     selected_date = parse_date(assigns.selected_date)
+    assigns = normalize_optional_assigns(assigns)
 
     socket =
       socket
@@ -44,9 +50,44 @@ defmodule EdenflowersWeb.CalendarComponent do
   attr :field, :any, required: true
   attr :selected_date, :string, required: false
 
-  attr :selectable?, :any,
+  attr :cell_state, :any,
     default: nil,
-    doc: "(Date.t() -> boolean()). Called lazily per visible cell. Defaults to always-selectable."
+    doc:
+      "(Date.t() -> :open | :past | :weekday_off | :override_off). " <>
+        "Drives both clickability (only :open is clickable) and styling. " <>
+        "Defaults to always-:open."
+
+  attr :cell_class, :any,
+    default: nil,
+    doc:
+      "Optional (Date.t(), cell_state, opts -> css_classes). Overrides default per-state styling. " <>
+        "`opts` is a keyword list with `:selected?` and `:today?` so the override can compose with " <>
+        "the standard selected/today affordances. Defaults to a single closed style for all non-:open states."
+
+  attr :clickable_states, :any,
+    default: nil,
+    doc:
+      "List of cell states that propagate a click. Defaults to `[:open]` (checkout's " <>
+        "guarantee that only valid dates reach the parent). Admin editors typically pass " <>
+        "`[:open, :weekday_off, :override_off]` so every cell can be toggled."
+
+  attr :on_click, :any,
+    default: :date_selected,
+    doc:
+      "Message tag (atom) sent to the parent as `{tag, date}` on a valid click. " <>
+        "Defaults to `:date_selected` (the legacy checkout contract)."
+
+  attr :on_weekday_click, :any,
+    default: nil,
+    doc:
+      "Optional. When set, weekday headers become buttons and emit `{tag, weekday_atom}` (e.g. `:sunday`). " <>
+        "When unset, headers remain static labels."
+
+  attr :weekday_class, :any,
+    default: nil,
+    doc:
+      "Optional (weekday_atom -> css_classes). Applied to each weekday header. Only meaningful when " <>
+        "`on_weekday_click` is set. Defaults to a neutral button look."
 
   attr :error, :boolean, default: false
   slot :day_decoration, required: false
@@ -55,7 +96,7 @@ defmodule EdenflowersWeb.CalendarComponent do
     ~H"""
     <div
       id={"#{@id}"}
-      class={"#{if @error, do: "border-error", else: "border-base-content/20"} bg-base-100 select-none rounded border p-2 sm:max-w-xs"}
+      class={"#{if @error, do: "border-error", else: "border-base-content/20"} bg-base-100 select-none rounded border p-2"}
       phx-hook="CalendarHook"
       data-view-date={Date.to_iso8601(@view_date)}
       data-focusable-dates={get_focusable_dates_json(@view_date)}
@@ -99,18 +140,35 @@ defmodule EdenflowersWeb.CalendarComponent do
       </div>
 
       <div
-        aria-hidden="true"
+        aria-hidden={if @on_weekday_click, do: nil, else: "true"}
         class="border-base-content/20 mt-2 grid grid-cols-7 border-b text-center text-sm leading-6"
       >
-        <span :for={week_day <- List.first(@week_rows)}>
-          {Localize.DateTime.to_string!(week_day, format: "EEEEEE")}
-        </span>
+        <%= for week_day <- List.first(@week_rows) do %>
+          <%= if @on_weekday_click do %>
+            <button
+              type="button"
+              phx-target={@myself}
+              phx-click="weekday-click"
+              phx-value-weekday={Atom.to_string(weekday_atom(week_day))}
+              aria-label={weekday_aria_label(week_day)}
+              class={@weekday_class.(weekday_atom(week_day))}
+            >
+              {Localize.DateTime.to_string!(week_day, format: "EEEEEE")}
+            </button>
+          <% else %>
+            <span>
+              {Localize.DateTime.to_string!(week_day, format: "EEEEEE")}
+            </span>
+          <% end %>
+        <% end %>
       </div>
 
       <div id={"#{@id}-grid"} class="mt-1">
         <div :for={week <- @week_rows} class="grid grid-cols-7">
           <%= for day <- week do %>
             <%= if current_month?(day, @view_date) do %>
+              <% state = @cell_state.(day) %>
+              <% selectable? = state in @clickable_states %>
               <button
                 id={"#{@id}-day-#{day}"}
                 phx-target={@myself}
@@ -118,12 +176,14 @@ defmodule EdenflowersWeb.CalendarComponent do
                 phx-value-date={day}
                 data-key-targets={key_targets_json(day, @today_date)}
                 type="button"
-                aria-label={day_aria_label(day, @today_date, @selected_date, @selectable?.(day))}
+                aria-label={day_aria_label(day, @today_date, @selected_date, selectable?)}
                 aria-pressed={if @selected_date && selected?(day, @selected_date), do: "true", else: "false"}
                 aria-current={if day == @today_date, do: "date"}
-                aria-disabled={if not @selectable?.(day), do: "true"}
+                aria-disabled={if not selectable?, do: "true"}
                 tabindex="-1"
-                class={calendar_day_class(day, @selected_date, @today_date, @selectable?.(day))}
+                class={@cell_class.(day, state,
+    selected?: selected?(day, @selected_date),
+    today?: day == @today_date)}
               >
                 <time datetime={Date.to_iso8601(day)} aria-hidden="true">
                   {Localize.DateTime.to_string!(day, format: "d")}
@@ -157,16 +217,20 @@ defmodule EdenflowersWeb.CalendarComponent do
   def handle_event("select", %{"date" => date_string}, socket) do
     with {:ok, date} <- Date.from_iso8601(date_string),
          true <- current_month?(date, socket.assigns.view_date),
-         true <- socket.assigns.selectable?.(date) do
-      send(self(), {:date_selected, date})
-
-      {:noreply,
-       socket
-       |> assign(selected_date: date)
-       |> update_calendar_view(date)}
+         true <- socket.assigns.cell_state.(date) in socket.assigns.clickable_states do
+      send(self(), {socket.assigns.on_click, date})
+      {:noreply, update_calendar_view(socket, date)}
     else
       _ -> {:noreply, socket}
     end
+  end
+
+  def handle_event("weekday-click", %{"weekday" => weekday_string}, socket) do
+    if tag = socket.assigns.on_weekday_click do
+      send(self(), {tag, String.to_existing_atom(weekday_string)})
+    end
+
+    {:noreply, socket}
   end
 
   def handle_event("keydown", %{"key" => key, "viewDate" => view_date}, socket) do
@@ -198,26 +262,67 @@ defmodule EdenflowersWeb.CalendarComponent do
     end
   end
 
-  defp calendar_day_class(day, selected_date, today_date, selectable?) do
-    is_selected = selected?(day, selected_date)
-    is_today = day == today_date
-    is_disabled = not selectable?
+  @doc false
+  # Default per-state styling. All non-:open states collapse to a single closed style
+  # so customers see one "unavailable" look. The admin editor passes its own `cell_class`
+  # to distinguish weekday-off vs override-off vs past.
+  def default_cell_class(_day, state, opts) do
+    selected? = Keyword.get(opts, :selected?, false)
+    today? = Keyword.get(opts, :today?, false)
 
     base = "relative aspect-square rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2"
 
-    state =
+    state_class =
       cond do
-        is_disabled ->
+        state != :open ->
           "cursor-not-allowed text-base-content/20 focus-visible:outline-base-content"
 
-        is_selected ->
+        selected? ->
           "cursor-pointer bg-primary text-primary-content hover:bg-primary/90 focus-visible:outline-base-content"
 
         true ->
           "cursor-pointer hover:bg-base-content/20 focus-visible:outline-base-content"
       end
 
-    if is_today, do: "#{base} #{state} underline", else: "#{base} #{state}"
+    if today?, do: "#{base} #{state_class} underline", else: "#{base} #{state_class}"
+  end
+
+  defp normalize_optional_assigns(assigns) do
+    assigns
+    |> maybe_default(:cell_state, fn _ -> :open end)
+    |> maybe_default(:cell_class, &default_cell_class/3)
+    |> maybe_default(:on_click, :date_selected)
+    |> maybe_default(:clickable_states, [:open])
+    |> maybe_default(:weekday_class, &default_weekday_class/1)
+  end
+
+  @doc false
+  def default_weekday_class(_weekday) do
+    "hover:bg-base-content/10 focus-visible:outline-base-content cursor-pointer rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2"
+  end
+
+  defp maybe_default(assigns, key, default) do
+    case Map.get(assigns, key) do
+      nil -> Map.put(assigns, key, default)
+      _value -> assigns
+    end
+  end
+
+  defp weekday_atom(date) do
+    case Date.day_of_week(date) do
+      1 -> :monday
+      2 -> :tuesday
+      3 -> :wednesday
+      4 -> :thursday
+      5 -> :friday
+      6 -> :saturday
+      7 -> :sunday
+    end
+  end
+
+  defp weekday_aria_label(date) do
+    full = Localize.DateTime.to_string!(date, format: "EEEE")
+    ~t"Toggle " <> full
   end
 
   defp day_aria_label(day, today_date, selected_date, selectable?) do

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -54,29 +54,31 @@ defmodule EdenflowersWeb.CalendarComponent do
   attr :cell_state, :any,
     default: nil,
     doc:
-      "(Date.t() -> :open | :past | :weekday_off | :override_off). " <>
-        "Drives both clickability (only :open is clickable) and styling. " <>
-        "Defaults to always-:open."
+      "(Date.t() -> atom). The caller picks the vocabulary; this component only " <>
+        "uses the returned atom to look up styling (`cell_class`) and clickability " <>
+        "(`clickable_states`). Customer checkout uses `:open | :closed | :past`; " <>
+        "the admin editor uses `:open | :past | :weekday_disabled | :date_disabled | :mixed`. " <>
+        "Defaults to always-`:open`."
 
   attr :cell_class, :any,
     default: nil,
     doc:
       "Optional (Date.t(), cell_state, opts -> css_classes). Overrides default per-state styling. " <>
         "`opts` is a keyword list with `:selected?` and `:today?` so the override can compose with " <>
-        "the standard selected/today affordances. Defaults to a single closed style for all non-:open states."
+        "the standard selected/today affordances. Defaults to a single closed style for all non-`:open` states."
 
   attr :clickable_states, :any,
     default: nil,
     doc:
       "List of cell states that propagate a click. Defaults to `[:open]` (checkout's " <>
-        "guarantee that only valid dates reach the parent). Admin editors typically pass " <>
-        "`[:open, :weekday_off, :override_off]` so every cell can be toggled."
+        "guarantee that only valid dates reach the parent). Admin editors pass the set " <>
+        "of toggleable admin states so every editable cell propagates a click."
 
   attr :on_click, :any,
     default: :date_selected,
     doc:
       "Message tag (atom) sent to the parent as `{tag, date}` on a valid click. " <>
-        "Defaults to `:date_selected` (the legacy checkout contract)."
+        "Defaults to `:date_selected`, which the checkout LiveView handles."
 
   attr :on_weekday_click, :any,
     default: nil,
@@ -264,9 +266,9 @@ defmodule EdenflowersWeb.CalendarComponent do
   end
 
   @doc false
-  # Default per-state styling. All non-:open states collapse to a single closed style
+  # Default per-state styling. All non-`:open` states collapse to a single closed style
   # so customers see one "unavailable" look. The admin editor passes its own `cell_class`
-  # to distinguish weekday-off vs override-off vs past.
+  # to distinguish `:weekday_disabled`, `:date_disabled`, and `:past`.
   def default_cell_class(_day, state, opts) do
     selected? = Keyword.get(opts, :selected?, false)
     today? = Keyword.get(opts, :today?, false)

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -21,6 +21,7 @@ defmodule EdenflowersWeb.CalendarComponent do
      |> assign(on_click: :date_selected)
      |> assign(on_weekday_click: nil)
      |> assign(weekday_class: &default_weekday_class/1)
+     |> assign(cell_confirm: fn _ -> nil end)
      |> update_calendar_view(today_date)}
   end
 
@@ -88,6 +89,12 @@ defmodule EdenflowersWeb.CalendarComponent do
     doc:
       "Optional (weekday_atom -> css_classes). Applied to each weekday header. Only meaningful when " <>
         "`on_weekday_click` is set. Defaults to a neutral button look."
+
+  attr :cell_confirm, :any,
+    default: nil,
+    doc:
+      "Optional (Date.t() -> String.t() | nil). When the function returns a string, the cell's click " <>
+        "is gated by a browser confirm dialog with that message. Returning `nil` clicks straight through."
 
   attr :error, :boolean, default: false
   slot :day_decoration, required: false
@@ -174,6 +181,7 @@ defmodule EdenflowersWeb.CalendarComponent do
                 phx-target={@myself}
                 phx-click="select"
                 phx-value-date={day}
+                data-confirm={@cell_confirm.(day)}
                 data-key-targets={key_targets_json(day, @today_date)}
                 type="button"
                 aria-label={day_aria_label(day, @today_date, @selected_date, selectable?)}
@@ -294,6 +302,7 @@ defmodule EdenflowersWeb.CalendarComponent do
     |> maybe_default(:on_click, :date_selected)
     |> maybe_default(:clickable_states, [:open])
     |> maybe_default(:weekday_class, &default_weekday_class/1)
+    |> maybe_default(:cell_confirm, fn _ -> nil end)
   end
 
   @doc false

--- a/lib/edenflowers_web/components/calendar_component.ex
+++ b/lib/edenflowers_web/components/calendar_component.ex
@@ -2,6 +2,7 @@ defmodule EdenflowersWeb.CalendarComponent do
   use EdenflowersWeb, :live_component
   require Logger
 
+  alias Edenflowers.Weekday
   alias EdenflowersWeb.CalendarComponent.Keymap
 
   @week_begins :default
@@ -21,7 +22,6 @@ defmodule EdenflowersWeb.CalendarComponent do
      |> assign(on_click: :date_selected)
      |> assign(on_weekday_click: nil)
      |> assign(weekday_class: &default_weekday_class/1)
-     |> assign(cell_confirm: fn _ -> nil end)
      |> update_calendar_view(today_date)}
   end
 
@@ -90,12 +90,6 @@ defmodule EdenflowersWeb.CalendarComponent do
       "Optional (weekday_atom -> css_classes). Applied to each weekday header. Only meaningful when " <>
         "`on_weekday_click` is set. Defaults to a neutral button look."
 
-  attr :cell_confirm, :any,
-    default: nil,
-    doc:
-      "Optional (Date.t() -> String.t() | nil). When the function returns a string, the cell's click " <>
-        "is gated by a browser confirm dialog with that message. Returning `nil` clicks straight through."
-
   attr :error, :boolean, default: false
   slot :day_decoration, required: false
 
@@ -156,9 +150,9 @@ defmodule EdenflowersWeb.CalendarComponent do
               type="button"
               phx-target={@myself}
               phx-click="weekday-click"
-              phx-value-weekday={Atom.to_string(weekday_atom(week_day))}
+              phx-value-weekday={Atom.to_string(Weekday.from_date(week_day))}
               aria-label={weekday_aria_label(week_day)}
-              class={@weekday_class.(weekday_atom(week_day))}
+              class={@weekday_class.(Weekday.from_date(week_day))}
             >
               {Localize.DateTime.to_string!(week_day, format: "EEEEEE")}
             </button>
@@ -181,7 +175,6 @@ defmodule EdenflowersWeb.CalendarComponent do
                 phx-target={@myself}
                 phx-click="select"
                 phx-value-date={day}
-                data-confirm={@cell_confirm.(day)}
                 data-key-targets={key_targets_json(day, @today_date)}
                 type="button"
                 aria-label={day_aria_label(day, @today_date, @selected_date, selectable?)}
@@ -302,7 +295,6 @@ defmodule EdenflowersWeb.CalendarComponent do
     |> maybe_default(:on_click, :date_selected)
     |> maybe_default(:clickable_states, [:open])
     |> maybe_default(:weekday_class, &default_weekday_class/1)
-    |> maybe_default(:cell_confirm, fn _ -> nil end)
   end
 
   @doc false
@@ -314,18 +306,6 @@ defmodule EdenflowersWeb.CalendarComponent do
     case Map.get(assigns, key) do
       nil -> Map.put(assigns, key, default)
       _value -> assigns
-    end
-  end
-
-  defp weekday_atom(date) do
-    case Date.day_of_week(date) do
-      1 -> :monday
-      2 -> :tuesday
-      3 -> :wednesday
-      4 -> :thursday
-      5 -> :friday
-      6 -> :saturday
-      7 -> :sunday
     end
   end
 

--- a/lib/edenflowers_web/components/key_date_icon.ex
+++ b/lib/edenflowers_web/components/key_date_icon.ex
@@ -10,13 +10,19 @@ defmodule EdenflowersWeb.KeyDateIcon do
   alias Edenflowers.Store.KeyDates
 
   attr :date, Date, required: true
+  attr :muted?, :boolean, default: false, doc: "Render at lower opacity (use on faded cells, e.g. past dates)."
 
   def key_date_icon(assigns) do
+    assigns =
+      assigns
+      |> assign(:icon, KeyDates.icon_for(assigns.date))
+      |> assign(:colour_class, KeyDates.colour_class_for(assigns.date))
+
     ~H"""
     <.icon
-      :if={icon = KeyDates.icon_for(@date)}
-      name={icon}
-      class="text-error absolute top-0.5 left-0.5 h-2.5 w-2.5"
+      :if={@icon}
+      name={@icon}
+      class={["pointer-events-none absolute inset-0 m-auto h-9 w-9", @colour_class, @muted? && "opacity-50"]}
     />
     """
   end

--- a/lib/edenflowers_web/components/key_date_icon.ex
+++ b/lib/edenflowers_web/components/key_date_icon.ex
@@ -13,16 +13,13 @@ defmodule EdenflowersWeb.KeyDateIcon do
   attr :muted?, :boolean, default: false, doc: "Render at lower opacity (use on faded cells, e.g. past dates)."
 
   def key_date_icon(assigns) do
-    assigns =
-      assigns
-      |> assign(:icon, KeyDates.icon_for(assigns.date))
-      |> assign(:colour_class, KeyDates.colour_class_for(assigns.date))
+    assigns = assign(assigns, :decoration, KeyDates.lookup_for(assigns.date))
 
     ~H"""
     <.icon
-      :if={@icon}
-      name={@icon}
-      class={["pointer-events-none absolute inset-0 m-auto h-9 w-9", @colour_class, @muted? && "opacity-50"]}
+      :if={@decoration}
+      name={@decoration.icon}
+      class={["pointer-events-none absolute inset-0 m-auto h-9 w-9", @decoration.colour_class, @muted? && "opacity-50"]}
     />
     """
   end

--- a/lib/edenflowers_web/components/key_date_icon.ex
+++ b/lib/edenflowers_web/components/key_date_icon.ex
@@ -1,0 +1,23 @@
+defmodule EdenflowersWeb.KeyDateIcon do
+  @moduledoc """
+  Renders the florist-relevant key-date marker for a single date, used as a
+  decoration in both the checkout calendar and the admin fulfillment
+  calendar. Both calendars route through this component so the marker's
+  visual treatment can't drift between them.
+  """
+  use EdenflowersWeb, :html
+
+  alias Edenflowers.Store.KeyDates
+
+  attr :date, Date, required: true
+
+  def key_date_icon(assigns) do
+    ~H"""
+    <.icon
+      :if={icon = KeyDates.icon_for(@date)}
+      name={icon}
+      class="text-error absolute top-0.5 left-0.5 h-2.5 w-2.5"
+    />
+    """
+  end
+end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -105,28 +105,22 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     end
   end
 
-  defp apply_to_scope(%{assigns: %{scope: :all, options: options, current_user: actor}} = socket, fun) do
-    options
-    |> Enum.map(&persist(&1, fun.(&1), actor))
-    |> reload(socket)
-  end
+  defp apply_to_scope(socket, fun) do
+    %{scope: scope, options: options, current_user: actor} = socket.assigns
 
-  defp apply_to_scope(%{assigns: %{scope: id, options: options, current_user: actor}} = socket, fun) do
-    case Enum.find(options, &(&1.id == id)) do
-      nil -> socket
-      option -> reload([persist(option, fun.(option), actor)], socket)
-    end
-  end
+    targets =
+      case scope do
+        :all -> options
+        id -> Enum.filter(options, &(&1.id == id))
+      end
 
-  defp persist(option, attrs, actor) do
-    {:ok, updated} = FulfillmentOption.update_calendar(option, attrs, actor: actor)
-    updated
-  end
+    updated_by_id =
+      Map.new(targets, fn option ->
+        {:ok, updated} = FulfillmentOption.update_calendar(option, fun.(option), actor: actor)
+        {option.id, updated}
+      end)
 
-  defp reload(updated_options, socket) do
-    by_id = Map.new(updated_options, &{&1.id, &1})
-    options = Enum.map(socket.assigns.options, &Map.get(by_id, &1.id, &1))
-    assign(socket, :options, options)
+    assign(socket, :options, Enum.map(options, &Map.get(updated_by_id, &1.id, &1)))
   end
 
   defp scope_button_class(true) do

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -12,7 +12,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   """
   use EdenflowersWeb, :live_view
 
-  alias Edenflowers.Store.{FulfillmentCalendar, FulfillmentOption}
+  alias Edenflowers.Store.{FulfillmentCalendar, FulfillmentOption, KeyDates}
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_admin_required}
 
@@ -30,15 +30,16 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="container mx-auto p-6">
-      <header class="mb-6">
-        <h1 class="text-2xl font-semibold">Fulfillment Calendar</h1>
-        <p class="text-base-content/70 mt-1 text-sm">
-          Click a date to toggle it on/off. Click a weekday header (Mon, Tue&hellip;) to toggle that weekday everywhere.
+    <div class="container mx-auto py-10">
+      <header class="mb-8 max-w-2xl">
+        <p class="eyebrow text-base-content/55 mb-2">Availability</p>
+        <h1 class="page-title">Fulfillment Calendar</h1>
+        <p class="text-base-content/70 mt-3 text-sm leading-relaxed">
+          Click a date to toggle it on or off. Click a weekday header (Mon, Tue&hellip;) to toggle that weekday everywhere.
         </p>
       </header>
 
-      <section class="mb-4 flex flex-wrap gap-2" aria-label="Fulfillment option scope">
+      <section class="mb-6 flex flex-wrap gap-2" aria-label="Fulfillment option scope">
         <button
           type="button"
           phx-click="set-scope"
@@ -58,27 +59,39 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
         </button>
       </section>
 
-      <div class="flex flex-col gap-6 md:flex-row md:items-start">
-        <div class="w-full max-w-2xl">
+      <div class="flex flex-col gap-8 md:flex-row md:items-start">
+        <div class="w-full max-w-xl">
           <.live_component
             id="admin-fulfillment-calendar"
             field={nil}
             module={EdenflowersWeb.CalendarComponent}
             selected_date={nil}
             cell_state={fn date -> current_cell_state(@scope, @options, date) end}
-            cell_class={&admin_cell_class/3}
+            cell_class={fn day, state, opts -> admin_cell_class(day, state, opts, override?(@scope, @options, day)) end}
+            cell_confirm={fn date -> key_date_close_confirm(date, current_cell_state(@scope, @options, date)) end}
             clickable_states={[:open, :weekday_off, :override_off]}
             on_click={:fulfillment_date_toggled}
             on_weekday_click={:fulfillment_weekday_toggled}
             weekday_class={fn weekday -> admin_weekday_class(weekday_state(@scope, @options, weekday)) end}
-          />
+          >
+            <:day_decoration :let={day}>
+              <.icon
+                :if={icon = KeyDates.icon_for(day)}
+                name={icon}
+                class="text-error absolute right-0 bottom-0 left-0 m-auto h-3 w-3 -translate-y-0.5"
+              />
+            </:day_decoration>
+          </.live_component>
         </div>
 
-        <aside class="text-sm">
-          <h2 class="mb-2 font-semibold">Legend</h2>
-          <ul class="space-y-1">
-            <li><span class={legend_swatch(:closed)}></span> Closed</li>
-            <li><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
+        <aside class="text-sm md:max-w-xs md:pt-2">
+          <h2 class="eyebrow text-base-content/55 mb-3">Legend</h2>
+          <ul class="text-base-content/85 space-y-2 leading-snug">
+            <li class="flex items-center"><span class={legend_swatch(:closed)}></span> Closed</li>
+            <li class="flex items-center">
+              <span class={legend_swatch(:override)}></span> Override (contradicts weekday rule)
+            </li>
+            <li class="flex items-center"><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
           </ul>
         </aside>
       </div>
@@ -141,6 +154,30 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     end
   end
 
+  # Only show the override mark when scope is a single option — across all
+  # options, "one option overrides, others don't" can't be summarized by a
+  # single dot without lying.
+  defp override?(:all, _options, _date), do: false
+
+  defp override?(option_id, options, date) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> false
+      option -> FulfillmentCalendar.override?(option, date)
+    end
+  end
+
+  # Confirm message when an admin clicks a currently-open key date — they're
+  # about to close a florist-relevant holiday. Returns nil for non-key dates
+  # or for key dates that are already closed (re-opening is safe, no confirm).
+  defp key_date_close_confirm(date, :open) do
+    case KeyDates.name_for(date) do
+      nil -> nil
+      name -> "#{name} (#{date}) is a florist key date. Close it?"
+    end
+  end
+
+  defp key_date_close_confirm(_date, _state), do: nil
+
   defp weekday_state(:all, options, weekday) do
     options
     |> Enum.map(&(weekday in &1.available_days))
@@ -159,57 +196,99 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     end
   end
 
-  defp scope_button_class(true),
-    do: "rounded border border-primary bg-primary text-primary-content px-3 py-1 text-sm"
+  defp scope_button_class(true) do
+    "rounded border border-primary bg-primary text-primary-content px-3.5 py-1.5 text-sm font-medium " <>
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+  end
 
-  defp scope_button_class(false),
-    do: "rounded border border-base-content/20 px-3 py-1 text-sm hover:bg-base-content/10"
+  defp scope_button_class(false) do
+    "rounded border border-base-content/20 px-3.5 py-1.5 text-sm text-base-content/80 " <>
+      "hover:border-base-content/40 hover:bg-base-content/5 hover:text-base-content " <>
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+  end
 
-  defp admin_cell_class(_day, state, opts) do
+  # Visual language: a florist's printed planner. Closed dates are crossed
+  # out with a diagonal strike — the cell itself is marked as cancelled, not
+  # just the digit. A muted gray background keeps closed cells visually
+  # distinct from open ones. Cells whose state contradicts their weekday
+  # rule (explicit overrides) carry a small sage dot in the bottom-right.
+  defp admin_cell_class(_day, state, opts, override?) do
     today? = Keyword.get(opts, :today?, false)
 
-    base = "relative aspect-square rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2"
+    base =
+      "relative aspect-square rounded text-sm font-medium leading-none flex items-center justify-center " <>
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
+
+    # The strike is an absolute-positioned bar rotated 22° that spans most of
+    # the cell width. Using `after:` keeps the digit clean and lets the bar
+    # grow wider than the digit's footprint.
+    closed_class =
+      "cursor-pointer bg-base-content/10 text-base-content/65 " <>
+        "after:absolute after:left-[22%] after:right-[22%] after:top-1/2 after:h-[2px] " <>
+        "after:-translate-y-1/2 after:rotate-[-22deg] after:bg-error/75 after:content-[''] " <>
+        "after:rounded-full hover:bg-base-content/15 hover:after:bg-error"
 
     state_class =
       case state do
-        :open ->
-          "cursor-pointer hover:bg-base-content/20 focus-visible:outline-base-content"
-
-        :weekday_off ->
-          "cursor-pointer bg-error/10 hover:bg-error/20 text-base-content/70 focus-visible:outline-base-content"
-
-        :override_off ->
-          "cursor-pointer bg-error/10 hover:bg-error/20 text-base-content/70 focus-visible:outline-base-content"
-
-        :past ->
-          "cursor-not-allowed text-base-content/20 focus-visible:outline-base-content"
-
-        :mixed ->
-          "cursor-not-allowed bg-base-content/10 text-base-content/50 focus-visible:outline-base-content"
+        :open -> "cursor-pointer text-base-content hover:bg-primary/10"
+        :weekday_off -> closed_class
+        :override_off -> closed_class
+        :past -> "cursor-not-allowed text-base-content/25"
+        :mixed -> "cursor-not-allowed text-base-content/55 bg-base-content/8 ring-1 ring-inset ring-base-content/15"
       end
 
-    if today?, do: "#{base} #{state_class} underline", else: "#{base} #{state_class}"
+    today_class = if today?, do: " font-bold text-primary", else: ""
+
+    # Top-right corner flag for explicit overrides — a small right-angled
+    # triangle clipped from a positioned div. Sits over the cell like a folded
+    # page corner, reading as "marked by hand" without competing with the
+    # closed strike (bottom-half of the cell) or the today digit (centered).
+    override_class =
+      if override?,
+        do:
+          " before:absolute before:top-0 before:right-0 before:h-2 before:w-2 " <>
+            "before:bg-primary/75 before:content-[''] before:[clip-path:polygon(100%_0,0_0,100%_100%)]",
+        else: ""
+
+    "#{base} #{state_class}#{today_class}#{override_class}"
   end
 
   defp admin_weekday_class(state) do
     base =
-      "rounded-sm px-1 py-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+      "rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
 
     state_class =
       case state do
-        :on -> "cursor-pointer hover:bg-base-content/10"
-        :off -> "cursor-pointer bg-error/10 hover:bg-error/20"
-        :mixed -> "cursor-not-allowed bg-base-content/10 text-base-content/50"
+        :on ->
+          "cursor-pointer text-base-content/65 hover:text-base-content hover:bg-primary/10"
+
+        :off ->
+          "cursor-pointer bg-base-content/10 text-base-content/65 line-through decoration-2 decoration-error/75 " <>
+            "hover:bg-base-content/15 hover:decoration-error"
+
+        :mixed ->
+          "cursor-not-allowed text-base-content/45 bg-base-content/8 ring-1 ring-inset ring-base-content/15"
       end
 
     "#{base} #{state_class}"
   end
 
-  defp legend_swatch(state) do
-    "inline-block w-3 h-3 mr-2 rounded-sm align-middle " <>
-      case state do
-        :closed -> "bg-error/20"
-        :mixed -> "bg-base-content/20"
-      end
+  # The :closed swatch mirrors a closed cell in miniature: muted gray tile
+  # with a diagonal red strike. The :mixed swatch is a plain ringed tile.
+  defp legend_swatch(:closed) do
+    "relative inline-block w-4 h-4 mr-2 rounded bg-base-content/10 align-middle " <>
+      "before:absolute before:left-[22%] before:right-[22%] before:top-1/2 before:h-[2px] " <>
+      "before:-translate-y-1/2 before:rotate-[-22deg] before:bg-error/75 before:content-[''] before:rounded-full"
+  end
+
+  defp legend_swatch(:override) do
+    "relative inline-block w-4 h-4 mr-2 rounded align-middle ring-1 ring-inset ring-base-content/15 " <>
+      "after:absolute after:top-0 after:right-0 after:h-2 after:w-2 " <>
+      "after:bg-primary/75 after:content-[''] after:[clip-path:polygon(100%_0,0_0,100%_100%)]"
+  end
+
+  defp legend_swatch(:mixed) do
+    "inline-block w-4 h-4 mr-2 rounded align-middle ring-1 ring-inset bg-base-content/8 ring-base-content/20"
   end
 end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -92,14 +92,14 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
 
   @impl true
   def handle_info({:fulfillment_date_toggled, date}, socket) do
-    {:noreply, apply_to_scope(socket, &FulfillmentCalendar.toggle_date(&1, date))}
+    {:noreply, apply_to_scope(socket, &FulfillmentOption.toggle_date!(&1, date, actor: &2))}
   end
 
   def handle_info({:fulfillment_weekday_toggled, weekday}, socket) do
     if FulfillmentCalendar.weekday_state(socket.assigns.scope, socket.assigns.options, weekday) == :mixed do
       {:noreply, socket}
     else
-      {:noreply, apply_to_scope(socket, &FulfillmentCalendar.toggle_weekday(&1, weekday))}
+      {:noreply, apply_to_scope(socket, &FulfillmentOption.toggle_weekday!(&1, weekday, actor: &2))}
     end
   end
 
@@ -112,11 +112,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
         id -> Enum.filter(options, &(&1.id == id))
       end
 
-    updated_by_id =
-      Map.new(targets, fn option ->
-        updated = FulfillmentOption.update_calendar!(option, fun.(option), actor: actor)
-        {option.id, updated}
-      end)
+    updated_by_id = Map.new(targets, fn option -> {option.id, fun.(option, actor)} end)
 
     assign(socket, :options, Enum.map(options, &Map.get(updated_by_id, &1.id, &1)))
   end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -168,16 +168,24 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   defp admin_cell_class(_day, state, opts) do
     today? = Keyword.get(opts, :today?, false)
 
-    base =
-      "relative aspect-square rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+    base = "relative aspect-square rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2"
 
     state_class =
       case state do
-        :open -> "cursor-pointer hover:bg-base-content/10"
-        :weekday_off -> "cursor-pointer bg-error/20 hover:bg-error/30 text-base-content/70"
-        :override_off -> "cursor-pointer bg-error/20 hover:bg-error/30 text-base-content/70"
-        :past -> "cursor-not-allowed text-base-content/30"
-        :mixed -> "cursor-not-allowed bg-base-content/10 text-base-content/50"
+        :open ->
+          "cursor-pointer hover:bg-base-content/20 focus-visible:outline-base-content"
+
+        :weekday_off ->
+          "cursor-pointer bg-error/10 hover:bg-error/20 text-base-content/70 focus-visible:outline-base-content"
+
+        :override_off ->
+          "cursor-pointer bg-error/10 hover:bg-error/20 text-base-content/70 focus-visible:outline-base-content"
+
+        :past ->
+          "cursor-not-allowed text-base-content/20 focus-visible:outline-base-content"
+
+        :mixed ->
+          "cursor-not-allowed bg-base-content/10 text-base-content/50 focus-visible:outline-base-content"
       end
 
     if today?, do: "#{base} #{state_class} underline", else: "#{base} #{state_class}"
@@ -190,7 +198,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     state_class =
       case state do
         :on -> "cursor-pointer hover:bg-base-content/10"
-        :off -> "cursor-pointer bg-error/20 hover:bg-error/30"
+        :off -> "cursor-pointer bg-error/10 hover:bg-error/20"
         :mixed -> "cursor-not-allowed bg-base-content/10 text-base-content/50"
       end
 
@@ -200,7 +208,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   defp legend_swatch(state) do
     "inline-block w-3 h-3 mr-2 rounded-sm align-middle " <>
       case state do
-        :closed -> "bg-error/40"
+        :closed -> "bg-error/20"
         :mixed -> "bg-base-content/20"
       end
   end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -1,0 +1,207 @@
+defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
+  @moduledoc """
+  Admin date-toggle editor.
+
+  The florist sees a calendar overlaid on the existing fulfillment-option
+  availability rules and can click dates / weekday headers to enable or
+  disable them. Scoped to a single fulfillment option or to all options at
+  once (with a `:mixed` indicator when options disagree).
+
+  All click semantics live in `Edenflowers.Store.FulfillmentCalendar`; this
+  LiveView only orchestrates state and persistence.
+  """
+  use EdenflowersWeb, :live_view
+
+  alias Edenflowers.Store.{FulfillmentCalendar, FulfillmentOption}
+
+  on_mount {EdenflowersWeb.LiveUserAuth, :live_admin_required}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    options = FulfillmentOption.list!()
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Fulfillment Calendar")
+     |> assign(:options, options)
+     |> assign(:scope, :all)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto p-6">
+      <header class="mb-6">
+        <h1 class="text-2xl font-semibold">Fulfillment Calendar</h1>
+        <p class="text-base-content/70 mt-1 text-sm">
+          Click a date to toggle it on/off. Click a weekday header (Mon, Tue&hellip;) to toggle that weekday everywhere.
+        </p>
+      </header>
+
+      <section class="mb-4 flex flex-wrap gap-2" aria-label="Fulfillment option scope">
+        <button
+          type="button"
+          phx-click="set-scope"
+          phx-value-scope="all"
+          class={scope_button_class(@scope == :all)}
+        >
+          All options
+        </button>
+        <button
+          :for={option <- @options}
+          type="button"
+          phx-click="set-scope"
+          phx-value-scope={option.id}
+          class={scope_button_class(@scope == option.id)}
+        >
+          {option.name}
+        </button>
+      </section>
+
+      <div class="flex flex-col gap-6 md:flex-row md:items-start">
+        <div class="w-full max-w-2xl">
+          <.live_component
+            id="admin-fulfillment-calendar"
+            field={nil}
+            module={EdenflowersWeb.CalendarComponent}
+            selected_date={nil}
+            cell_state={fn date -> current_cell_state(@scope, @options, date) end}
+            cell_class={&admin_cell_class/3}
+            clickable_states={[:open, :weekday_off, :override_off]}
+            on_click={:fulfillment_date_toggled}
+            on_weekday_click={:fulfillment_weekday_toggled}
+            weekday_class={fn weekday -> admin_weekday_class(weekday_state(@scope, @options, weekday)) end}
+          />
+        </div>
+
+        <aside class="text-sm">
+          <h2 class="mb-2 font-semibold">Legend</h2>
+          <ul class="space-y-1">
+            <li><span class={legend_swatch(:closed)}></span> Closed</li>
+            <li><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
+          </ul>
+        </aside>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("set-scope", %{"scope" => "all"}, socket) do
+    {:noreply, assign(socket, :scope, :all)}
+  end
+
+  def handle_event("set-scope", %{"scope" => id}, socket) do
+    {:noreply, assign(socket, :scope, id)}
+  end
+
+  @impl true
+  def handle_info({:fulfillment_date_toggled, date}, socket) do
+    {:noreply, apply_to_scope(socket, &FulfillmentCalendar.toggle_date(&1, date))}
+  end
+
+  def handle_info({:fulfillment_weekday_toggled, weekday}, socket) do
+    if weekday_state(socket.assigns.scope, socket.assigns.options, weekday) == :mixed do
+      {:noreply, socket}
+    else
+      {:noreply, apply_to_scope(socket, &FulfillmentCalendar.toggle_weekday(&1, weekday))}
+    end
+  end
+
+  defp apply_to_scope(%{assigns: %{scope: :all, options: options, current_user: actor}} = socket, fun) do
+    options
+    |> Enum.map(&persist(&1, fun.(&1), actor))
+    |> reload(socket)
+  end
+
+  defp apply_to_scope(%{assigns: %{scope: id, options: options, current_user: actor}} = socket, fun) do
+    case Enum.find(options, &(&1.id == id)) do
+      nil -> socket
+      option -> reload([persist(option, fun.(option), actor)], socket)
+    end
+  end
+
+  defp persist(option, attrs, actor) do
+    {:ok, updated} = Ash.update(option, attrs, actor: actor)
+    updated
+  end
+
+  defp reload(updated_options, socket) do
+    by_id = Map.new(updated_options, &{&1.id, &1})
+    options = Enum.map(socket.assigns.options, &Map.get(by_id, &1.id, &1))
+    assign(socket, :options, options)
+  end
+
+  defp current_cell_state(:all, options, date), do: FulfillmentCalendar.cell_state_for_options(options, date)
+
+  defp current_cell_state(option_id, options, date) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> :open
+      option -> FulfillmentCalendar.cell_state(option, date)
+    end
+  end
+
+  defp weekday_state(:all, options, weekday) do
+    options
+    |> Enum.map(&(weekday in &1.available_days))
+    |> Enum.uniq()
+    |> case do
+      [true] -> :on
+      [false] -> :off
+      _mixed -> :mixed
+    end
+  end
+
+  defp weekday_state(option_id, options, weekday) do
+    case Enum.find(options, &(&1.id == option_id)) do
+      nil -> :on
+      option -> if weekday in option.available_days, do: :on, else: :off
+    end
+  end
+
+  defp scope_button_class(true),
+    do: "rounded border border-primary bg-primary text-primary-content px-3 py-1 text-sm"
+
+  defp scope_button_class(false),
+    do: "rounded border border-base-content/20 px-3 py-1 text-sm hover:bg-base-content/10"
+
+  defp admin_cell_class(_day, state, opts) do
+    today? = Keyword.get(opts, :today?, false)
+
+    base =
+      "relative aspect-square rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+
+    state_class =
+      case state do
+        :open -> "cursor-pointer hover:bg-base-content/10"
+        :weekday_off -> "cursor-pointer bg-error/20 hover:bg-error/30 text-base-content/70"
+        :override_off -> "cursor-pointer bg-error/20 hover:bg-error/30 text-base-content/70"
+        :past -> "cursor-not-allowed text-base-content/30"
+        :mixed -> "cursor-not-allowed bg-base-content/10 text-base-content/50"
+      end
+
+    if today?, do: "#{base} #{state_class} underline", else: "#{base} #{state_class}"
+  end
+
+  defp admin_weekday_class(state) do
+    base =
+      "rounded-sm px-1 py-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+
+    state_class =
+      case state do
+        :on -> "cursor-pointer hover:bg-base-content/10"
+        :off -> "cursor-pointer bg-error/20 hover:bg-error/30"
+        :mixed -> "cursor-not-allowed bg-base-content/10 text-base-content/50"
+      end
+
+    "#{base} #{state_class}"
+  end
+
+  defp legend_swatch(state) do
+    "inline-block w-3 h-3 mr-2 rounded-sm align-middle " <>
+      case state do
+        :closed -> "bg-error/40"
+        :mixed -> "bg-base-content/20"
+      end
+  end
+end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -114,7 +114,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
 
     updated_by_id =
       Map.new(targets, fn option ->
-        {:ok, updated} = FulfillmentOption.update_calendar(option, fun.(option), actor: actor)
+        updated = FulfillmentOption.update_calendar!(option, fun.(option), actor: actor)
         {option.id, updated}
       end)
 

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -128,9 +128,11 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
       "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
   end
 
+  # Inactive chip uses the same hover (`bg-primary/10`) as cells and weekday
+  # headers in CalendarComponent so the whole page reads as one interaction system.
   defp scope_button_class(false) do
-    "rounded border border-base-content/20 px-3.5 py-1.5 text-sm text-base-content/80 " <>
-      "hover:border-base-content/40 hover:bg-base-content/5 hover:text-base-content " <>
+    "rounded border border-base-content/20 px-3.5 py-1.5 text-sm text-base-content/65 " <>
+      "hover:border-primary/40 hover:text-base-content/85 hover:bg-primary/10 " <>
       "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
   end
 end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -29,14 +29,12 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
      socket
      |> assign(:page_title, "Fulfillment Calendar")
      |> assign(:options, options)
-     |> assign(:scope, :all)}
+     |> assign(:scope, :all)
+     |> assign(:today, today())}
   end
 
   @impl true
   def render(assigns) do
-    today = @timezone |> DateTime.now!() |> DateTime.to_date()
-    assigns = assign(assigns, :today, today)
-
     ~H"""
     <div class="container mx-auto py-10">
       <header class="mb-8 max-w-2xl">
@@ -122,6 +120,8 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
 
     assign(socket, :options, Enum.map(options, &Map.get(updated_by_id, &1.id, &1)))
   end
+
+  defp today, do: @timezone |> DateTime.now!() |> DateTime.to_date()
 
   defp scope_button_class(true) do
     "rounded border border-primary bg-primary text-primary-content px-3.5 py-1.5 text-sm font-medium " <>

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -75,7 +75,18 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
           />
         </div>
 
-        <.admin_calendar_legend />
+        <div class="flex flex-col gap-4">
+          <.admin_calendar_legend />
+          <button
+            type="button"
+            phx-click="reset-calendar"
+            data-confirm={reset_confirm_message()}
+            aria-label="Reset calendar to defaults"
+            class={reset_button_class()}
+          >
+            Reset
+          </button>
+        </div>
       </div>
     </div>
     """
@@ -90,18 +101,40 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     {:noreply, assign(socket, :scope, id)}
   end
 
+  def handle_event("reset-calendar", _, socket) do
+    {:noreply, apply_to_scope(socket, &FulfillmentOption.reset_calendar!(&1, actor: &2))}
+  end
+
   @impl true
   def handle_info({:fulfillment_date_toggled, date}, socket) do
     {:noreply, apply_to_scope(socket, &FulfillmentOption.toggle_date!(&1, date, actor: &2))}
   end
 
   def handle_info({:fulfillment_weekday_toggled, weekday}, socket) do
-    if FulfillmentCalendar.weekday_state(socket.assigns.scope, socket.assigns.options, weekday) == :mixed do
-      {:noreply, socket}
-    else
-      {:noreply, apply_to_scope(socket, &FulfillmentOption.toggle_weekday!(&1, weekday, actor: &2))}
+    targets = scoped_options(socket)
+    direction = FulfillmentCalendar.weekday_toggle_direction(targets, weekday)
+
+    {:noreply, apply_to_scope(socket, &FulfillmentOption.set_weekday!(&1, weekday, direction, actor: &2))}
+  end
+
+  def handle_info({:fulfillment_week_toggled, week}, socket) do
+    %{today: today} = socket.assigns
+    targets = scoped_options(socket)
+
+    case FulfillmentCalendar.week_toggle_direction(targets, week, today) do
+      nil ->
+        # Whole week is in the past — nothing to do.
+        {:noreply, socket}
+
+      direction ->
+        {:noreply, apply_to_scope(socket, &FulfillmentOption.set_week!(&1, week, today, direction, actor: &2))}
     end
   end
+
+  defp scoped_options(%{assigns: %{scope: :all, options: options}}), do: options
+
+  defp scoped_options(%{assigns: %{scope: id, options: options}}),
+    do: Enum.filter(options, &(&1.id == id))
 
   defp apply_to_scope(socket, fun) do
     %{scope: scope, options: options, current_user: actor} = socket.assigns
@@ -118,6 +151,14 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   end
 
   defp today, do: @timezone |> DateTime.now!() |> DateTime.to_date()
+
+  defp reset_confirm_message, do: "Are you sure you want to reset the calendar? This action is destructive."
+
+  defp reset_button_class do
+    "self-start rounded px-3.5 py-1.5 text-sm text-base-content/55 " <>
+      "hover:text-base-content/85 hover:bg-error/10 " <>
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
+  end
 
   defp scope_button_class(true) do
     "rounded border border-primary bg-primary text-primary-content px-3.5 py-1.5 text-sm font-medium " <>

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -7,14 +7,19 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   disable them. Scoped to a single fulfillment option or to all options at
   once (with a `:mixed` indicator when options disagree).
 
-  All click semantics live in `Edenflowers.Store.FulfillmentCalendar`; this
+  Click semantics live in `Edenflowers.Store.FulfillmentCalendar`. Admin
+  presentation lives in `EdenflowersWeb.Admin.CalendarComponent`. This
   LiveView only orchestrates state and persistence.
   """
   use EdenflowersWeb, :live_view
 
-  alias Edenflowers.Store.{FulfillmentCalendar, FulfillmentOption, KeyDates}
+  import EdenflowersWeb.Admin.CalendarComponent, only: [admin_calendar: 1, admin_calendar_legend: 1]
+
+  alias Edenflowers.Store.{FulfillmentCalendar, FulfillmentOption}
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_admin_required}
+
+  @timezone "Europe/Helsinki"
 
   @impl true
   def mount(_params, _session, socket) do
@@ -29,6 +34,9 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
 
   @impl true
   def render(assigns) do
+    today = @timezone |> DateTime.now!() |> DateTime.to_date()
+    assigns = assign(assigns, :today, today)
+
     ~H"""
     <div class="container mx-auto py-10">
       <header class="mb-8 max-w-2xl">
@@ -61,39 +69,15 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
 
       <div class="flex flex-col gap-8 md:flex-row md:items-start">
         <div class="w-full max-w-xl">
-          <.live_component
+          <.admin_calendar
             id="admin-fulfillment-calendar"
-            field={nil}
-            module={EdenflowersWeb.CalendarComponent}
-            selected_date={nil}
-            cell_state={fn date -> current_cell_state(@scope, @options, date) end}
-            cell_class={fn day, state, opts -> admin_cell_class(day, state, opts, override?(@scope, @options, day)) end}
-            cell_confirm={fn date -> key_date_close_confirm(date, current_cell_state(@scope, @options, date)) end}
-            clickable_states={[:open, :weekday_off, :override_off]}
-            on_click={:fulfillment_date_toggled}
-            on_weekday_click={:fulfillment_weekday_toggled}
-            weekday_class={fn weekday -> admin_weekday_class(weekday_state(@scope, @options, weekday)) end}
-          >
-            <:day_decoration :let={day}>
-              <.icon
-                :if={icon = KeyDates.icon_for(day)}
-                name={icon}
-                class="text-error absolute right-0 bottom-0 left-0 m-auto h-3 w-3 -translate-y-0.5"
-              />
-            </:day_decoration>
-          </.live_component>
+            scope={@scope}
+            options={@options}
+            today={@today}
+          />
         </div>
 
-        <aside class="text-sm md:max-w-xs md:pt-2">
-          <h2 class="eyebrow text-base-content/55 mb-3">Legend</h2>
-          <ul class="text-base-content/85 space-y-2 leading-snug">
-            <li class="flex items-center"><span class={legend_swatch(:closed)}></span> Closed</li>
-            <li class="flex items-center">
-              <span class={legend_swatch(:override)}></span> Override (contradicts weekday rule)
-            </li>
-            <li class="flex items-center"><span class={legend_swatch(:mixed)}></span> Mixed (options disagree)</li>
-          </ul>
-        </aside>
+        <.admin_calendar_legend />
       </div>
     </div>
     """
@@ -114,7 +98,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   end
 
   def handle_info({:fulfillment_weekday_toggled, weekday}, socket) do
-    if weekday_state(socket.assigns.scope, socket.assigns.options, weekday) == :mixed do
+    if FulfillmentCalendar.weekday_state(socket.assigns.scope, socket.assigns.options, weekday) == :mixed do
       {:noreply, socket}
     else
       {:noreply, apply_to_scope(socket, &FulfillmentCalendar.toggle_weekday(&1, weekday))}
@@ -135,7 +119,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
   end
 
   defp persist(option, attrs, actor) do
-    {:ok, updated} = Ash.update(option, attrs, actor: actor)
+    {:ok, updated} = FulfillmentOption.update_calendar(option, attrs, actor: actor)
     updated
   end
 
@@ -143,57 +127,6 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     by_id = Map.new(updated_options, &{&1.id, &1})
     options = Enum.map(socket.assigns.options, &Map.get(by_id, &1.id, &1))
     assign(socket, :options, options)
-  end
-
-  defp current_cell_state(:all, options, date), do: FulfillmentCalendar.cell_state_for_options(options, date)
-
-  defp current_cell_state(option_id, options, date) do
-    case Enum.find(options, &(&1.id == option_id)) do
-      nil -> :open
-      option -> FulfillmentCalendar.cell_state(option, date)
-    end
-  end
-
-  # Only show the override mark when scope is a single option — across all
-  # options, "one option overrides, others don't" can't be summarized by a
-  # single dot without lying.
-  defp override?(:all, _options, _date), do: false
-
-  defp override?(option_id, options, date) do
-    case Enum.find(options, &(&1.id == option_id)) do
-      nil -> false
-      option -> FulfillmentCalendar.override?(option, date)
-    end
-  end
-
-  # Confirm message when an admin clicks a currently-open key date — they're
-  # about to close a florist-relevant holiday. Returns nil for non-key dates
-  # or for key dates that are already closed (re-opening is safe, no confirm).
-  defp key_date_close_confirm(date, :open) do
-    case KeyDates.name_for(date) do
-      nil -> nil
-      name -> "#{name} (#{date}) is a florist key date. Close it?"
-    end
-  end
-
-  defp key_date_close_confirm(_date, _state), do: nil
-
-  defp weekday_state(:all, options, weekday) do
-    options
-    |> Enum.map(&(weekday in &1.available_days))
-    |> Enum.uniq()
-    |> case do
-      [true] -> :on
-      [false] -> :off
-      _mixed -> :mixed
-    end
-  end
-
-  defp weekday_state(option_id, options, weekday) do
-    case Enum.find(options, &(&1.id == option_id)) do
-      nil -> :on
-      option -> if weekday in option.available_days, do: :on, else: :off
-    end
   end
 
   defp scope_button_class(true) do
@@ -205,90 +138,5 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     "rounded border border-base-content/20 px-3.5 py-1.5 text-sm text-base-content/80 " <>
       "hover:border-base-content/40 hover:bg-base-content/5 hover:text-base-content " <>
       "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-base-content"
-  end
-
-  # Visual language: a florist's printed planner. Closed dates are crossed
-  # out with a diagonal strike — the cell itself is marked as cancelled, not
-  # just the digit. A muted gray background keeps closed cells visually
-  # distinct from open ones. Cells whose state contradicts their weekday
-  # rule (explicit overrides) carry a small sage dot in the bottom-right.
-  defp admin_cell_class(_day, state, opts, override?) do
-    today? = Keyword.get(opts, :today?, false)
-
-    base =
-      "relative aspect-square rounded text-sm font-medium leading-none flex items-center justify-center " <>
-        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
-
-    # The strike is an absolute-positioned bar rotated 22° that spans most of
-    # the cell width. Using `after:` keeps the digit clean and lets the bar
-    # grow wider than the digit's footprint.
-    closed_class =
-      "cursor-pointer bg-base-content/10 text-base-content/65 " <>
-        "after:absolute after:left-[22%] after:right-[22%] after:top-1/2 after:h-[2px] " <>
-        "after:-translate-y-1/2 after:rotate-[-22deg] after:bg-error/75 after:content-[''] " <>
-        "after:rounded-full hover:bg-base-content/15 hover:after:bg-error"
-
-    state_class =
-      case state do
-        :open -> "cursor-pointer text-base-content hover:bg-primary/10"
-        :weekday_off -> closed_class
-        :override_off -> closed_class
-        :past -> "cursor-not-allowed text-base-content/25"
-        :mixed -> "cursor-not-allowed text-base-content/55 bg-base-content/8 ring-1 ring-inset ring-base-content/15"
-      end
-
-    today_class = if today?, do: " font-bold text-primary", else: ""
-
-    # Top-right corner flag for explicit overrides — a small right-angled
-    # triangle clipped from a positioned div. Sits over the cell like a folded
-    # page corner, reading as "marked by hand" without competing with the
-    # closed strike (bottom-half of the cell) or the today digit (centered).
-    override_class =
-      if override?,
-        do:
-          " before:absolute before:top-0 before:right-0 before:h-2 before:w-2 " <>
-            "before:bg-primary/75 before:content-[''] before:[clip-path:polygon(100%_0,0_0,100%_100%)]",
-        else: ""
-
-    "#{base} #{state_class}#{today_class}#{override_class}"
-  end
-
-  defp admin_weekday_class(state) do
-    base =
-      "rounded px-1.5 py-1 text-xs font-semibold uppercase tracking-wider " <>
-        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-base-content"
-
-    state_class =
-      case state do
-        :on ->
-          "cursor-pointer text-base-content/65 hover:text-base-content hover:bg-primary/10"
-
-        :off ->
-          "cursor-pointer bg-base-content/10 text-base-content/65 line-through decoration-2 decoration-error/75 " <>
-            "hover:bg-base-content/15 hover:decoration-error"
-
-        :mixed ->
-          "cursor-not-allowed text-base-content/45 bg-base-content/8 ring-1 ring-inset ring-base-content/15"
-      end
-
-    "#{base} #{state_class}"
-  end
-
-  # The :closed swatch mirrors a closed cell in miniature: muted gray tile
-  # with a diagonal red strike. The :mixed swatch is a plain ringed tile.
-  defp legend_swatch(:closed) do
-    "relative inline-block w-4 h-4 mr-2 rounded bg-base-content/10 align-middle " <>
-      "before:absolute before:left-[22%] before:right-[22%] before:top-1/2 before:h-[2px] " <>
-      "before:-translate-y-1/2 before:rotate-[-22deg] before:bg-error/75 before:content-[''] before:rounded-full"
-  end
-
-  defp legend_swatch(:override) do
-    "relative inline-block w-4 h-4 mr-2 rounded align-middle ring-1 ring-inset ring-base-content/15 " <>
-      "after:absolute after:top-0 after:right-0 after:h-2 after:w-2 " <>
-      "after:bg-primary/75 after:content-[''] after:[clip-path:polygon(100%_0,0_0,100%_100%)]"
-  end
-
-  defp legend_swatch(:mixed) do
-    "inline-block w-4 h-4 mr-2 rounded align-middle ring-1 ring-inset bg-base-content/8 ring-base-content/20"
   end
 end

--- a/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
+++ b/lib/edenflowers_web/live/admin/fulfillment_calendar_live.ex
@@ -131,19 +131,12 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLive do
     end
   end
 
-  defp scoped_options(%{assigns: %{scope: :all, options: options}}), do: options
-
-  defp scoped_options(%{assigns: %{scope: id, options: options}}),
-    do: Enum.filter(options, &(&1.id == id))
+  defp scoped_options(%{assigns: %{scope: scope, options: options}}),
+    do: FulfillmentCalendar.scoped_options(scope, options)
 
   defp apply_to_scope(socket, fun) do
-    %{scope: scope, options: options, current_user: actor} = socket.assigns
-
-    targets =
-      case scope do
-        :all -> options
-        id -> Enum.filter(options, &(&1.id == id))
-      end
+    %{options: options, current_user: actor} = socket.assigns
+    targets = scoped_options(socket)
 
     updated_by_id = Map.new(targets, fn option -> {option.id, fun.(option, actor)} end)
 

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -209,7 +209,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                             }
                             selected_date={@form[:fulfillment_date].value}
                             module={EdenflowersWeb.CalendarComponent}
-                            cell_state={fn date -> Fulfillments.cell_state(@order.fulfillment_option, date) end}
+                            cell_state={fn date -> Fulfillments.customer_cell_state(@order.fulfillment_option, date) end}
                           >
                             <:day_decoration :let={day}>
                               <.icon

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -5,7 +5,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   import EdenflowersWeb.CheckoutComponents, only: [steps: 1]
 
-  alias Edenflowers.Store.{Order, FulfillmentOption, ProductVariant, ProductVariantSize}
+  alias Edenflowers.Store.{Order, FulfillmentOption, KeyDates, ProductVariant, ProductVariantSize}
   alias Edenflowers.Fulfillments
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
@@ -30,6 +30,7 @@ defmodule EdenflowersWeb.CheckoutLive do
          {:ok, fulfillment_options} <- FulfillmentOption.list_for_checkout() do
       order = ensure_fulfillment_default(order, fulfillment_options, socket.assigns[:current_user])
       card_variants = ProductVariant.for_card_drawer!()
+      key_date_icons = load_key_date_icons()
 
       {:ok,
        socket
@@ -37,6 +38,7 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:page_title, ~t"Checkout")
        |> assign(:fulfillment_options, fulfillment_options)
        |> assign(:card_variants, card_variants)
+       |> assign(:key_date_icons, key_date_icons)
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
        |> assign(:client_secret, nil)
@@ -219,8 +221,8 @@ defmodule EdenflowersWeb.CheckoutLive do
                         >
                           <:day_decoration :let={day}>
                             <.icon
-                              :if={day == ~D[2025-05-07]}
-                              name="hero-heart-solid"
+                              :if={icon = Map.get(@key_date_icons, day)}
+                              name={icon}
                               class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
                             />
                           </:day_decoration>
@@ -774,6 +776,15 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp cart_has_items?(%{cart_effectively_empty?: true}), do: {:error, :empty_cart}
   defp cart_has_items?(_order), do: :ok
+
+  defp load_key_date_icons do
+    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
+
+    Map.merge(
+      KeyDates.icons_by_date(today.year),
+      KeyDates.icons_by_date(today.year + 1)
+    )
+  end
 
   # ===========
   # DOM helpers

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -4,8 +4,9 @@ defmodule EdenflowersWeb.CheckoutLive do
   require Logger
 
   import EdenflowersWeb.CheckoutComponents, only: [steps: 1]
+  import EdenflowersWeb.KeyDateIcon
 
-  alias Edenflowers.Store.{Order, FulfillmentOption, KeyDates, ProductVariant, ProductVariantSize}
+  alias Edenflowers.Store.{Order, FulfillmentOption, ProductVariant, ProductVariantSize}
   alias Edenflowers.Fulfillments
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}
@@ -212,11 +213,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                             cell_state={fn date -> Fulfillments.customer_cell_state(@order.fulfillment_option, date) end}
                           >
                             <:day_decoration :let={day}>
-                              <.icon
-                                :if={icon = KeyDates.icon_for(day)}
-                                name={icon}
-                                class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
-                              />
+                              <.key_date_icon date={day} />
                             </:day_decoration>
                           </.live_component>
                         </div>

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -30,7 +30,6 @@ defmodule EdenflowersWeb.CheckoutLive do
          {:ok, fulfillment_options} <- FulfillmentOption.list_for_checkout() do
       order = ensure_fulfillment_default(order, fulfillment_options, socket.assigns[:current_user])
       card_variants = ProductVariant.for_card_drawer!()
-      key_date_icons = load_key_date_icons()
 
       {:ok,
        socket
@@ -38,7 +37,6 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:page_title, ~t"Checkout")
        |> assign(:fulfillment_options, fulfillment_options)
        |> assign(:card_variants, card_variants)
-       |> assign(:key_date_icons, key_date_icons)
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
        |> assign(:client_secret, nil)
@@ -221,7 +219,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                         >
                           <:day_decoration :let={day}>
                             <.icon
-                              :if={icon = Map.get(@key_date_icons, day)}
+                              :if={icon = KeyDates.icon_for(day)}
                               name={icon}
                               class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
                             />
@@ -776,15 +774,6 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   defp cart_has_items?(%{cart_effectively_empty?: true}), do: {:error, :empty_cart}
   defp cart_has_items?(_order), do: :ok
-
-  defp load_key_date_icons do
-    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
-
-    Map.merge(
-      KeyDates.icons_by_date(today.year),
-      KeyDates.icons_by_date(today.year + 1)
-    )
-  end
 
   # ===========
   # DOM helpers

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -201,7 +201,7 @@ defmodule EdenflowersWeb.CheckoutLive do
                             {~t"Pickup Date *"}
                           <% end %>
                         </label>
-                        <div class="sm:max-w-xs">
+                        <div class="sm:max-w-md">
                           <.live_component
                             id="calendar"
                             error={
@@ -212,8 +212,8 @@ defmodule EdenflowersWeb.CheckoutLive do
                             module={EdenflowersWeb.CalendarComponent}
                             cell_state={fn date -> Fulfillments.customer_cell_state(@order.fulfillment_option, date) end}
                           >
-                            <:day_decoration :let={day}>
-                              <.key_date_icon date={day} />
+                            <:day_decoration :let={%{date: day, state: state}}>
+                              <.key_date_icon date={day} muted?={state == :past} />
                             </:day_decoration>
                           </.live_component>
                         </div>

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -6,7 +6,7 @@ defmodule EdenflowersWeb.CheckoutLive do
   import EdenflowersWeb.CheckoutComponents, only: [steps: 1]
   import EdenflowersWeb.KeyDateIcon
 
-  alias Edenflowers.Store.{Order, FulfillmentOption, KeyDates, ProductVariant, ProductVariantSize}
+  alias Edenflowers.Store.{Order, FulfillmentOption, ProductVariant, ProductVariantSize}
   alias Edenflowers.Fulfillments
 
   on_mount {EdenflowersWeb.LiveUserAuth, :live_user_optional}

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -548,7 +548,10 @@ defmodule EdenflowersWeb.CheckoutLive do
 
       {:error, form} ->
         forward_delivery_address_error(form)
-        {:noreply, assign(socket, form: form)}
+        # If `submit_delivery` rejected the date, an admin may have just closed
+        # it. Reload the order so the calendar re-paints with fresh availability,
+        # then re-assign the failed form so the customer still sees the error.
+        {:noreply, socket |> reload_order() |> assign(form: form)}
     end
   end
 

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -200,31 +200,26 @@ defmodule EdenflowersWeb.CheckoutLive do
                             {~t"Pickup Date *"}
                           <% end %>
                         </label>
-                        <.live_component
-                          id="calendar"
-                          error={
-                            Phoenix.Component.used_input?(@form[:fulfillment_date]) and
-                              Enum.any?(@form[:fulfillment_date].errors)
-                          }
-                          selected_date={@form[:fulfillment_date].value}
-                          module={EdenflowersWeb.CalendarComponent}
-                          selectable?={
-                            fn date ->
-                              {fulfillable?, _reason} =
-                                Fulfillments.fulfill_on_date(@order.fulfillment_option, date)
-
-                              fulfillable?
-                            end
-                          }
-                        >
-                          <:day_decoration :let={day}>
-                            <.icon
-                              :if={icon = KeyDates.icon_for(day)}
-                              name={icon}
-                              class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
-                            />
-                          </:day_decoration>
-                        </.live_component>
+                        <div class="sm:max-w-xs">
+                          <.live_component
+                            id="calendar"
+                            error={
+                              Phoenix.Component.used_input?(@form[:fulfillment_date]) and
+                                Enum.any?(@form[:fulfillment_date].errors)
+                            }
+                            selected_date={@form[:fulfillment_date].value}
+                            module={EdenflowersWeb.CalendarComponent}
+                            cell_state={fn date -> Fulfillments.cell_state(@order.fulfillment_option, date) end}
+                          >
+                            <:day_decoration :let={day}>
+                              <.icon
+                                :if={icon = KeyDates.icon_for(day)}
+                                name={icon}
+                                class="text-error absolute top-0 right-0 left-0 m-auto h-3 w-3 translate-y-0.5"
+                              />
+                            </:day_decoration>
+                          </.live_component>
+                        </div>
                         <.field_errors field={@form[:fulfillment_date]} />
                         <.input field={@form[:fulfillment_date]} hidden />
                       </fieldset>

--- a/lib/edenflowers_web/router.ex
+++ b/lib/edenflowers_web/router.ex
@@ -74,6 +74,15 @@ defmodule EdenflowersWeb.Router do
     )
   end
 
+  scope "/admin", EdenflowersWeb do
+    pipe_through :browser
+
+    ash_authentication_live_session :admin_routes,
+      on_mount: [{EdenflowersWeb.LiveUserAuth, :live_admin_required}] do
+      live "/fulfillment-calendar", Admin.FulfillmentCalendarLive
+    end
+  end
+
   scope "/admin" do
     pipe_through :browser
 

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -2,6 +2,7 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
   use Edenflowers.DataCase
   import Generator
   alias Edenflowers.Store.FulfillmentCalendar
+  alias Edenflowers.Weekday
 
   setup do
     tax_rate = generate(tax_rate())
@@ -319,18 +320,279 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
     end
   end
 
+  describe "cell_state_for_scope/4" do
+    test ":all aggregates across options", %{tax_rate_id: tax_rate_id} do
+      open_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      closed_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      today = ~D[2024-04-01]
+      future_sunday = today |> Date.shift(month: 3) |> next_weekday(:sunday)
+
+      assert :mixed ==
+               FulfillmentCalendar.cell_state_for_scope(
+                 :all,
+                 [open_option, closed_option],
+                 future_sunday,
+                 today
+               )
+    end
+
+    test "single-option scope returns that option's admin cell state", %{tax_rate_id: tax_rate_id} do
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      today = ~D[2024-04-01]
+      future_sunday = today |> Date.shift(month: 3) |> next_weekday(:sunday)
+
+      assert :weekday_disabled ==
+               FulfillmentCalendar.cell_state_for_scope(option.id, [option], future_sunday, today)
+    end
+
+    test "falls back to :open when the scoped option id is unknown", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      assert :open ==
+               FulfillmentCalendar.cell_state_for_scope("missing-id", [option], ~D[2024-04-10], ~D[2024-04-01])
+    end
+  end
+
+  describe "scoped_options/2" do
+    test ":all returns every option", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      assert [a, b] == FulfillmentCalendar.scoped_options(:all, [a, b])
+    end
+
+    test "an id scope filters to that option", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      assert [b] == FulfillmentCalendar.scoped_options(b.id, [a, b])
+    end
+
+    test "an unknown id returns an empty list", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      assert [] == FulfillmentCalendar.scoped_options("missing-id", [a])
+    end
+  end
+
+  describe "override?/2" do
+    test "true when the date is in enabled_dates", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, enabled_dates: [~D[2024-04-07]]))
+      assert FulfillmentCalendar.override?(option, ~D[2024-04-07])
+    end
+
+    test "true when the date is in disabled_dates", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-10]]))
+      assert FulfillmentCalendar.override?(option, ~D[2024-04-10])
+    end
+
+    test "false for a date governed only by the weekday rule", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      refute FulfillmentCalendar.override?(option, ~D[2024-04-10])
+    end
+  end
+
+  describe "weekday_state/3" do
+    test ":all returns :on when every option has the weekday available", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      assert :on == FulfillmentCalendar.weekday_state(:all, [a, b], :monday)
+    end
+
+    test ":all returns :off when no option has the weekday available", %{tax_rate_id: tax_rate_id} do
+      days = [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: days))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: days))
+
+      assert :off == FulfillmentCalendar.weekday_state(:all, [a, b], :sunday)
+    end
+
+    test ":all returns :mixed when options disagree", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      b =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      assert :mixed == FulfillmentCalendar.weekday_state(:all, [a, b], :sunday)
+    end
+
+    test ":all returns :on for an empty options list" do
+      # Regression: with no options, the page renders a default `:on` header.
+      # Returning :mixed here previously made empty pages render with a "varies"
+      # treatment despite there being nothing to vary.
+      assert :on == FulfillmentCalendar.weekday_state(:all, [], :sunday)
+    end
+
+    test "single-option scope reads off that option", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      b =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      assert :on == FulfillmentCalendar.weekday_state(a.id, [a, b], :sunday)
+      assert :off == FulfillmentCalendar.weekday_state(b.id, [a, b], :sunday)
+    end
+
+    test "single-option scope falls back to :on when the id is unknown", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      assert :on == FulfillmentCalendar.weekday_state("missing-id", [a], :sunday)
+    end
+  end
+
+  describe "weekday_toggle_direction/2" do
+    test "returns :off when any option has the weekday on", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      b =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      assert :off == FulfillmentCalendar.weekday_toggle_direction([a, b], :sunday)
+    end
+
+    test "returns :on when no option has the weekday on", %{tax_rate_id: tax_rate_id} do
+      days = [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: days))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: days))
+
+      assert :on == FulfillmentCalendar.weekday_toggle_direction([a, b], :sunday)
+    end
+  end
+
+  describe "week_state/3 (without key dates)" do
+    test ":all_open when every actionable cell is open", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      # 2024-04-08 Mon .. 2024-04-14 Sun — a Mon-Sun week with no key dates.
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :all_open == FulfillmentCalendar.week_state(option, week, ~D[2024-04-01])
+    end
+
+    test ":all_closed when every actionable cell is closed", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: []))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :all_closed == FulfillmentCalendar.week_state(option, week, ~D[2024-04-01])
+    end
+
+    test ":mixed when some cells are open and some closed", %{tax_rate_id: tax_rate_id} do
+      # Closed on Sunday only.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :mixed == FulfillmentCalendar.week_state(option, week, ~D[2024-04-01])
+    end
+
+    test ":all_past when every cell is before today", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :all_past == FulfillmentCalendar.week_state(option, week, ~D[2024-04-15])
+    end
+  end
+
+  describe "week_toggle_direction/3" do
+    test "returns nil when no option has any actionable cell", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      # Today after the week → every cell is past.
+      assert nil == FulfillmentCalendar.week_toggle_direction([option], week, ~D[2024-04-15])
+    end
+
+    test "returns :closed when any option has open or mixed cells", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :closed == FulfillmentCalendar.week_toggle_direction([option], week, ~D[2024-04-01])
+    end
+
+    test "returns :open when every option's week is fully closed", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, available_days: []))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      assert :open == FulfillmentCalendar.week_toggle_direction([option], week, ~D[2024-04-01])
+    end
+  end
+
+  describe "set_week/4 (without key dates)" do
+    test ":closed adds overrides for every open weekday in the week", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      # Mon 2024-04-08 .. Sun 2024-04-14, no key dates in that range.
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+
+      result = FulfillmentCalendar.set_week(option, week, ~D[2024-04-01], :closed)
+
+      for date <- week, do: assert(date in result.disabled_dates)
+      assert result.enabled_dates == []
+    end
+
+    test ":open clears off-overrides without writing redundant on-overrides", %{tax_rate_id: tax_rate_id} do
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            disabled_dates: [~D[2024-04-08], ~D[2024-04-09]]
+          )
+        )
+
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+
+      result = FulfillmentCalendar.set_week(option, week, ~D[2024-04-01], :open)
+
+      assert result.disabled_dates == []
+      # No redundant enabled_dates entries — the weekday rule already opens these.
+      assert result.enabled_dates == []
+    end
+
+    test "ignores past cells", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2024-04-08], &1))
+      # Today mid-week — only Wed..Sun get overrides.
+      today = ~D[2024-04-10]
+
+      result = FulfillmentCalendar.set_week(option, week, today, :closed)
+
+      refute ~D[2024-04-08] in result.disabled_dates
+      refute ~D[2024-04-09] in result.disabled_dates
+      assert ~D[2024-04-10] in result.disabled_dates
+      assert ~D[2024-04-14] in result.disabled_dates
+    end
+  end
+
   defp next_weekday(date, weekday) do
-    target = weekday_to_int(weekday)
+    target = Weekday.to_integer(weekday)
 
     Stream.iterate(date, &Date.add(&1, 1))
     |> Enum.find(&(Date.day_of_week(&1) == target))
   end
-
-  defp weekday_to_int(:monday), do: 1
-  defp weekday_to_int(:tuesday), do: 2
-  defp weekday_to_int(:wednesday), do: 3
-  defp weekday_to_int(:thursday), do: 4
-  defp weekday_to_int(:friday), do: 5
-  defp weekday_to_int(:saturday), do: 6
-  defp weekday_to_int(:sunday), do: 7
 end

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -56,14 +56,14 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
     end
   end
 
-  describe "toggle_weekday/2" do
-    test "disables a currently-available weekday", %{tax_rate_id: tax_rate_id} do
+  describe "set_weekday/3" do
+    test "setting :off removes a currently-available weekday", %{tax_rate_id: tax_rate_id} do
       option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
-      %{available_days: days} = FulfillmentCalendar.toggle_weekday(option, :sunday)
+      %{available_days: days} = FulfillmentCalendar.set_weekday(option, :sunday, :off)
       refute :sunday in days
     end
 
-    test "enables a currently-disabled weekday", %{tax_rate_id: tax_rate_id} do
+    test "setting :on adds a currently-disabled weekday", %{tax_rate_id: tax_rate_id} do
       option =
         generate(
           fulfillment_option(
@@ -72,11 +72,17 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      %{available_days: days} = FulfillmentCalendar.toggle_weekday(option, :sunday)
+      %{available_days: days} = FulfillmentCalendar.set_weekday(option, :sunday, :on)
       assert :sunday in days
     end
 
-    test "enabling a weekday prunes stale enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+    test "is idempotent — :on on an already-on weekday is a no-op", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      %{available_days: days} = FulfillmentCalendar.set_weekday(option, :sunday, :on)
+      assert Enum.sort(days) == Enum.sort(option.available_days)
+    end
+
+    test "turning a weekday :on prunes stale enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
       # 2024-04-15 is a Monday. Start with Mondays off and an on-override.
       option =
         generate(
@@ -87,14 +93,14 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+      result = FulfillmentCalendar.set_weekday(option, :monday, :on)
 
       assert :monday in result.available_days
       # The on-override is no longer needed — Mondays are open now.
       refute ~D[2024-04-15] in result.enabled_dates
     end
 
-    test "enabling a weekday preserves disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+    test "turning a weekday :on preserves disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
       # Mondays off, with Mon 2024-04-15 in disabled_dates (redundant but present).
       # After turning Mondays on, the off-override is a genuine exception and must survive.
       option =
@@ -106,13 +112,13 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+      result = FulfillmentCalendar.set_weekday(option, :monday, :on)
 
       assert :monday in result.available_days
       assert ~D[2024-04-15] in result.disabled_dates
     end
 
-    test "disabling a weekday prunes stale disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+    test "turning a weekday :off prunes stale disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
       # Mondays on, with Mon 2024-04-15 in disabled_dates as an off-override.
       option =
         generate(
@@ -122,14 +128,14 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+      result = FulfillmentCalendar.set_weekday(option, :monday, :off)
 
       refute :monday in result.available_days
       # The off-override is now redundant — Mondays are closed by rule.
       refute ~D[2024-04-15] in result.disabled_dates
     end
 
-    test "disabling a weekday preserves enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+    test "turning a weekday :off preserves enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
       # Mondays on, with Mon 2024-04-15 in enabled_dates (redundant but present).
       # After turning Mondays off, the on-override is a genuine exception and must survive.
       option =
@@ -140,15 +146,15 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+      result = FulfillmentCalendar.set_weekday(option, :monday, :off)
 
       refute :monday in result.available_days
       assert ~D[2024-04-15] in result.enabled_dates
     end
 
-    test "weekday flip only touches overrides matching the toggled weekday", %{tax_rate_id: tax_rate_id} do
+    test "only touches overrides matching the targeted weekday", %{tax_rate_id: tax_rate_id} do
       # 2024-04-15 is Monday, 2024-04-16 is Tuesday.
-      # Toggling Monday should leave Tuesday's override completely alone.
+      # Setting Monday off should leave Tuesday's override completely alone.
       option =
         generate(
           fulfillment_option(
@@ -158,11 +164,120 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+      result = FulfillmentCalendar.set_weekday(option, :monday, :off)
 
       refute :monday in result.available_days
       assert ~D[2024-04-15] in result.enabled_dates
       assert ~D[2024-04-16] in result.disabled_dates
+    end
+  end
+
+  describe "reset/0" do
+    test "returns fully-open weekdays and empty override lists" do
+      result = FulfillmentCalendar.reset()
+      assert Enum.sort(result.available_days) == [:friday, :monday, :saturday, :sunday, :thursday, :tuesday, :wednesday]
+      assert result.enabled_dates == []
+      assert result.disabled_dates == []
+    end
+  end
+
+  describe "key-date protection in smart toggles" do
+    # Mother's Day 2026 is a Sunday (~D[2026-05-10]). Father's Day 2026 is also
+    # a Sunday (~D[2026-11-08]). Valentine's 2026 is a Saturday (~D[2026-02-14]).
+
+    test "set_weekday :off preserves an open key date by adding an enabled override", %{
+      tax_rate_id: tax_rate_id
+    } do
+      # Sundays currently on. Mother's Day is open by the rule.
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      result = FulfillmentCalendar.set_weekday(option, :sunday, :off)
+
+      refute :sunday in result.available_days
+      # Mother's Day must remain open via an enabled override.
+      assert ~D[2026-05-10] in result.enabled_dates
+    end
+
+    test "set_weekday :on preserves a closed key date by adding a disabled override", %{
+      tax_rate_id: tax_rate_id
+    } do
+      # Sundays currently off. Mother's Day is closed by the rule.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      result = FulfillmentCalendar.set_weekday(option, :sunday, :on)
+
+      assert :sunday in result.available_days
+      # Mother's Day must remain closed via a disabled override.
+      assert ~D[2026-05-10] in result.disabled_dates
+    end
+
+    test "set_weekday is a no-op for the rule when direction matches current state", %{
+      tax_rate_id: tax_rate_id
+    } do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      result = FulfillmentCalendar.set_weekday(option, :sunday, :on)
+
+      assert :sunday in result.available_days
+      # No protection override should appear since nothing changed.
+      refute ~D[2026-05-10] in result.enabled_dates
+      refute ~D[2026-05-10] in result.disabled_dates
+    end
+
+    test "set_week :closed skips key dates in the week", %{tax_rate_id: tax_rate_id} do
+      # All weekdays open. Week containing Mother's Day 2026-05-10 (Sunday).
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2026-05-04], &1))
+      today = ~D[2026-04-01]
+
+      result = FulfillmentCalendar.set_week(option, week, today, :closed)
+
+      # Mon..Sat closed by override; Mother's Day untouched.
+      assert ~D[2026-05-04] in result.disabled_dates
+      assert ~D[2026-05-09] in result.disabled_dates
+      refute ~D[2026-05-10] in result.disabled_dates
+      refute ~D[2026-05-10] in result.enabled_dates
+    end
+
+    test "set_week :open skips key dates in the week", %{tax_rate_id: tax_rate_id} do
+      # Sundays off, so Mother's Day is closed by the rule.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday],
+            disabled_dates: [~D[2026-05-04], ~D[2026-05-05]]
+          )
+        )
+
+      week = Enum.map(0..6, &Date.add(~D[2026-05-04], &1))
+      today = ~D[2026-04-01]
+
+      result = FulfillmentCalendar.set_week(option, week, today, :open)
+
+      # Overrides on the Mon and Tue cleared (rule already opens them).
+      refute ~D[2026-05-04] in result.disabled_dates
+      refute ~D[2026-05-05] in result.disabled_dates
+      # Mother's Day untouched — no enabled_dates entry added to flip it open.
+      refute ~D[2026-05-10] in result.enabled_dates
+    end
+
+    test "week_state ignores key dates so a key-date-only week reports as :all_past", %{
+      tax_rate_id: tax_rate_id
+    } do
+      # A week where the only non-past cell is Mother's Day. The button must
+      # not look actionable, since the click would no-op anyway.
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      week = Enum.map(0..6, &Date.add(~D[2026-05-04], &1))
+      # "today" makes Mon..Sat all past, leaving only Sun (Mother's Day) actionable.
+      today = ~D[2026-05-10]
+
+      assert :all_past == FulfillmentCalendar.week_state(option, week, today)
     end
   end
 

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -1,0 +1,126 @@
+defmodule Edenflowers.Store.FulfillmentCalendarTest do
+  use Edenflowers.DataCase
+  import Generator
+  alias Edenflowers.Store.FulfillmentCalendar
+
+  setup do
+    tax_rate = generate(tax_rate())
+    [tax_rate_id: tax_rate.id]
+  end
+
+  describe "toggle_date/2" do
+    test "closes a date when its weekday is currently available", %{tax_rate_id: tax_rate_id} do
+      # All weekdays available, no overrides
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      # 2024-04-10 is a Wednesday
+      assert %{enabled_dates: [], disabled_dates: [~D[2024-04-10]]} =
+               FulfillmentCalendar.toggle_date(option, ~D[2024-04-10])
+    end
+
+    test "opens a date when its weekday is currently disabled", %{tax_rate_id: tax_rate_id} do
+      # Sunday off, no overrides
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      # 2024-04-07 is a Sunday
+      assert %{enabled_dates: [~D[2024-04-07]], disabled_dates: []} =
+               FulfillmentCalendar.toggle_date(option, ~D[2024-04-07])
+    end
+
+    test "removes an existing off-override", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-10]]))
+
+      assert %{enabled_dates: [], disabled_dates: []} =
+               FulfillmentCalendar.toggle_date(option, ~D[2024-04-10])
+    end
+
+    test "removes an existing on-override", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, enabled_dates: [~D[2024-04-07]]))
+
+      assert %{enabled_dates: [], disabled_dates: []} =
+               FulfillmentCalendar.toggle_date(option, ~D[2024-04-07])
+    end
+
+    test "off-override does not duplicate other off-overrides", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-15]]))
+
+      assert %{disabled_dates: dates} = FulfillmentCalendar.toggle_date(option, ~D[2024-04-10])
+      assert ~D[2024-04-15] in dates
+      assert ~D[2024-04-10] in dates
+    end
+  end
+
+  describe "toggle_weekday/2" do
+    test "disables a currently-available weekday", %{tax_rate_id: tax_rate_id} do
+      option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      %{available_days: days} = FulfillmentCalendar.toggle_weekday(option, :sunday)
+      refute :sunday in days
+    end
+
+    test "enables a currently-disabled weekday", %{tax_rate_id: tax_rate_id} do
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      %{available_days: days} = FulfillmentCalendar.toggle_weekday(option, :sunday)
+      assert :sunday in days
+    end
+  end
+
+  describe "cell_state_for_options/2" do
+    test "returns the single shared state when all options agree", %{tax_rate_id: tax_rate_id} do
+      a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      b = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      # Pick a date well in the future to avoid same-day edge cases.
+      future_wednesday = Date.utc_today() |> Date.shift(month: 3) |> next_weekday(:wednesday)
+
+      assert :open == FulfillmentCalendar.cell_state_for_options([a, b], future_wednesday)
+    end
+
+    test "returns :mixed when options disagree", %{tax_rate_id: tax_rate_id} do
+      open_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+
+      closed_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      future_sunday = Date.utc_today() |> Date.shift(month: 3) |> next_weekday(:sunday)
+
+      assert :mixed == FulfillmentCalendar.cell_state_for_options([open_option, closed_option], future_sunday)
+    end
+
+    test "returns :open for an empty options list", %{tax_rate_id: _} do
+      assert :open == FulfillmentCalendar.cell_state_for_options([], ~D[2024-04-10])
+    end
+  end
+
+  defp next_weekday(date, weekday) do
+    target = weekday_to_int(weekday)
+
+    Stream.iterate(date, &Date.add(&1, 1))
+    |> Enum.find(&(Date.day_of_week(&1) == target))
+  end
+
+  defp weekday_to_int(:monday), do: 1
+  defp weekday_to_int(:tuesday), do: 2
+  defp weekday_to_int(:wednesday), do: 3
+  defp weekday_to_int(:thursday), do: 4
+  defp weekday_to_int(:friday), do: 5
+  defp weekday_to_int(:saturday), do: 6
+  defp weekday_to_int(:sunday), do: 7
+end

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -75,6 +75,135 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
       %{available_days: days} = FulfillmentCalendar.toggle_weekday(option, :sunday)
       assert :sunday in days
     end
+
+    test "enabling a weekday prunes stale enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+      # 2024-04-15 is a Monday. Start with Mondays off and an on-override.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:tuesday, :wednesday, :thursday, :friday, :saturday, :sunday],
+            enabled_dates: [~D[2024-04-15]]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+
+      assert :monday in result.available_days
+      # The on-override is no longer needed — Mondays are open now.
+      refute ~D[2024-04-15] in result.enabled_dates
+    end
+
+    test "enabling a weekday preserves disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+      # Mondays off, with Mon 2024-04-15 in disabled_dates (redundant but present).
+      # After turning Mondays on, the off-override is a genuine exception and must survive.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:tuesday, :wednesday, :thursday, :friday, :saturday, :sunday],
+            disabled_dates: [~D[2024-04-15]]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+
+      assert :monday in result.available_days
+      assert ~D[2024-04-15] in result.disabled_dates
+    end
+
+    test "disabling a weekday prunes stale disabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+      # Mondays on, with Mon 2024-04-15 in disabled_dates as an off-override.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            disabled_dates: [~D[2024-04-15]]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+
+      refute :monday in result.available_days
+      # The off-override is now redundant — Mondays are closed by rule.
+      refute ~D[2024-04-15] in result.disabled_dates
+    end
+
+    test "disabling a weekday preserves enabled_dates on that weekday", %{tax_rate_id: tax_rate_id} do
+      # Mondays on, with Mon 2024-04-15 in enabled_dates (redundant but present).
+      # After turning Mondays off, the on-override is a genuine exception and must survive.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            enabled_dates: [~D[2024-04-15]]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+
+      refute :monday in result.available_days
+      assert ~D[2024-04-15] in result.enabled_dates
+    end
+
+    test "disabling a weekday preserves disabled_dates on key dates", %{tax_rate_id: tax_rate_id} do
+      # Mother's Day 2026 is Sunday 10 May. Closed via disabled_dates. Sundays on.
+      # After turning Sundays off, the disabled_dates entry must survive — without
+      # it, the key-date branch in cell_state would flip Mother's Day back to open.
+      mothers_day = ~D[2026-05-10]
+
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            disabled_dates: [mothers_day]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :sunday)
+
+      refute :sunday in result.available_days
+      assert mothers_day in result.disabled_dates
+    end
+
+    test "enabling a weekday still prunes enabled_dates on key dates", %{tax_rate_id: tax_rate_id} do
+      # Mother's Day was redundantly in enabled_dates (key-date protection already
+      # keeps it open). Either direction of weekday flip can prune it safely.
+      mothers_day = ~D[2026-05-10]
+
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday],
+            enabled_dates: [mothers_day]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :sunday)
+
+      assert :sunday in result.available_days
+      refute mothers_day in result.enabled_dates
+    end
+
+    test "weekday flip only touches overrides matching the toggled weekday", %{tax_rate_id: tax_rate_id} do
+      # 2024-04-15 is Monday, 2024-04-16 is Tuesday.
+      # Toggling Monday should leave Tuesday's override completely alone.
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            enabled_dates: [~D[2024-04-15]],
+            disabled_dates: [~D[2024-04-16]]
+          )
+        )
+
+      result = FulfillmentCalendar.toggle_weekday(option, :monday)
+
+      refute :monday in result.available_days
+      assert ~D[2024-04-15] in result.enabled_dates
+      assert ~D[2024-04-16] in result.disabled_dates
+    end
   end
 
   describe "cell_state_for_options/2" do

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -54,25 +54,6 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
       assert ~D[2024-04-15] in dates
       assert ~D[2024-04-10] in dates
     end
-
-    test "closes a key date even when its weekday is disabled", %{tax_rate_id: tax_rate_id} do
-      # Mother's Day 2026 is Sunday 10 May. Sundays off. Without key-date
-      # protection awareness, the toggle would treat Mother's Day as
-      # "currently closed by weekday" and try to open it. The fix: ask
-      # cell_state, which counts the key-date branch as :open.
-      mothers_day = ~D[2026-05-10]
-
-      option =
-        generate(
-          fulfillment_option(
-            tax_rate_id: tax_rate_id,
-            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
-          )
-        )
-
-      assert %{enabled_dates: [], disabled_dates: [^mothers_day]} =
-               FulfillmentCalendar.toggle_date(option, mothers_day)
-    end
   end
 
   describe "toggle_weekday/2" do
@@ -163,46 +144,6 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
 
       refute :monday in result.available_days
       assert ~D[2024-04-15] in result.enabled_dates
-    end
-
-    test "disabling a weekday preserves disabled_dates on key dates", %{tax_rate_id: tax_rate_id} do
-      # Mother's Day 2026 is Sunday 10 May. Closed via disabled_dates. Sundays on.
-      # After turning Sundays off, the disabled_dates entry must survive — without
-      # it, the key-date branch in cell_state would flip Mother's Day back to open.
-      mothers_day = ~D[2026-05-10]
-
-      option =
-        generate(
-          fulfillment_option(
-            tax_rate_id: tax_rate_id,
-            disabled_dates: [mothers_day]
-          )
-        )
-
-      result = FulfillmentCalendar.toggle_weekday(option, :sunday)
-
-      refute :sunday in result.available_days
-      assert mothers_day in result.disabled_dates
-    end
-
-    test "enabling a weekday still prunes enabled_dates on key dates", %{tax_rate_id: tax_rate_id} do
-      # Mother's Day was redundantly in enabled_dates (key-date protection already
-      # keeps it open). Either direction of weekday flip can prune it safely.
-      mothers_day = ~D[2026-05-10]
-
-      option =
-        generate(
-          fulfillment_option(
-            tax_rate_id: tax_rate_id,
-            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday],
-            enabled_dates: [mothers_day]
-          )
-        )
-
-      result = FulfillmentCalendar.toggle_weekday(option, :sunday)
-
-      assert :sunday in result.available_days
-      refute mothers_day in result.enabled_dates
     end
 
     test "weekday flip only touches overrides matching the toggled weekday", %{tax_rate_id: tax_rate_id} do

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -54,6 +54,25 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
       assert ~D[2024-04-15] in dates
       assert ~D[2024-04-10] in dates
     end
+
+    test "closes a key date even when its weekday is disabled", %{tax_rate_id: tax_rate_id} do
+      # Mother's Day 2026 is Sunday 10 May. Sundays off. Without key-date
+      # protection awareness, the toggle would treat Mother's Day as
+      # "currently closed by weekday" and try to open it. The fix: ask
+      # cell_state, which counts the key-date branch as :open.
+      mothers_day = ~D[2026-05-10]
+
+      option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      assert %{enabled_dates: [], disabled_dates: [^mothers_day]} =
+               FulfillmentCalendar.toggle_date(option, mothers_day)
+    end
   end
 
   describe "toggle_weekday/2" do

--- a/test/edenflowers/store/fulfillment_calendar_test.exs
+++ b/test/edenflowers/store/fulfillment_calendar_test.exs
@@ -225,15 +225,15 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
     end
   end
 
-  describe "cell_state_for_options/2" do
+  describe "cell_state_for_options/3" do
     test "returns the single shared state when all options agree", %{tax_rate_id: tax_rate_id} do
       a = generate(fulfillment_option(tax_rate_id: tax_rate_id))
       b = generate(fulfillment_option(tax_rate_id: tax_rate_id))
 
-      # Pick a date well in the future to avoid same-day edge cases.
-      future_wednesday = Date.utc_today() |> Date.shift(month: 3) |> next_weekday(:wednesday)
+      today = ~D[2024-04-01]
+      future_wednesday = today |> Date.shift(month: 3) |> next_weekday(:wednesday)
 
-      assert :open == FulfillmentCalendar.cell_state_for_options([a, b], future_wednesday)
+      assert :open == FulfillmentCalendar.cell_state_for_options([a, b], future_wednesday, today)
     end
 
     test "returns :mixed when options disagree", %{tax_rate_id: tax_rate_id} do
@@ -247,13 +247,19 @@ defmodule Edenflowers.Store.FulfillmentCalendarTest do
           )
         )
 
-      future_sunday = Date.utc_today() |> Date.shift(month: 3) |> next_weekday(:sunday)
+      today = ~D[2024-04-01]
+      future_sunday = today |> Date.shift(month: 3) |> next_weekday(:sunday)
 
-      assert :mixed == FulfillmentCalendar.cell_state_for_options([open_option, closed_option], future_sunday)
+      assert :mixed ==
+               FulfillmentCalendar.cell_state_for_options(
+                 [open_option, closed_option],
+                 future_sunday,
+                 today
+               )
     end
 
     test "returns :open for an empty options list", %{tax_rate_id: _} do
-      assert :open == FulfillmentCalendar.cell_state_for_options([], ~D[2024-04-10])
+      assert :open == FulfillmentCalendar.cell_state_for_options([], ~D[2024-04-10], ~D[2024-04-01])
     end
   end
 

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -58,17 +58,18 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
   end
 
   describe "rendered styling" do
-    # Guardrail: the cell strike and the legend swatch share the same visual
-    # fragments via diagonal_strike/1. If someone changes one and forgets the
-    # other, this catches it — both must contain the strike's rotation token.
-    test "closed cells and the legend swatch use the same diagonal-strike fragment", %{conn: conn} do
+    # Guardrail: closed cells get the strike on ::after (so ::before is free for
+    # the override corner); the legend swatch gets it on ::before. Both reference
+    # the same underlying CSS rule in app.css, so drift in the visual is
+    # impossible at the CSS layer — but this catches accidental removal of the
+    # utility class from either element.
+    test "closed cells and the legend swatch both render the diagonal-strike utility", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/admin/fulfillment-calendar")
 
       # Sundays are closed for the delivery option set up in `setup`, so any
       # rendered Sunday in the current month carries the closed strike.
-      assert html =~ "rotate-[-22deg]"
-      # Legend swatch reuses the same fragment via `before:` instead of `after:`.
-      assert html =~ "before:rotate-[-22deg]"
+      assert html =~ "calendar-strike-after"
+      assert html =~ "calendar-strike-before"
     end
   end
 

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -281,7 +281,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
       assert {:error, {:redirect, %{to: to, flash: %{"error" => _}}}} =
                live(conn, ~p"/admin/fulfillment-calendar")
 
-      assert to == "/sign-in"
+      assert to == "/sign-in?return_to=%2Fadmin%2Ffulfillment-calendar"
     end
 
     test "redirects non-admin authenticated users to /sign-in" do
@@ -299,7 +299,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
       assert {:error, {:redirect, %{to: to, flash: %{"error" => _}}}} =
                live(conn, ~p"/admin/fulfillment-calendar")
 
-      assert to == "/sign-in"
+      assert to == "/sign-in?return_to=%2Fadmin%2Ffulfillment-calendar"
     end
   end
 

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -278,8 +278,10 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
     test "redirects unauthenticated users to /sign-in" do
       conn = Phoenix.ConnTest.build_conn() |> Plug.Test.init_test_session(%{})
 
-      assert {:error, {:redirect, %{to: "/sign-in"}}} =
+      assert {:error, {:redirect, %{to: to, flash: %{"error" => _}}}} =
                live(conn, ~p"/admin/fulfillment-calendar")
+
+      assert to == "/sign-in"
     end
 
     test "redirects non-admin authenticated users to /sign-in" do
@@ -294,8 +296,10 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
         |> Plug.Test.init_test_session(%{})
         |> Helpers.store_in_session(regular_user)
 
-      assert {:error, {:redirect, %{to: "/sign-in"}}} =
+      assert {:error, {:redirect, %{to: to, flash: %{"error" => _}}}} =
                live(conn, ~p"/admin/fulfillment-calendar")
+
+      assert to == "/sign-in"
     end
   end
 

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -1,0 +1,219 @@
+defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
+  use EdenflowersWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Generator
+
+  alias AshAuthentication.Jwt
+  alias AshAuthentication.Plug.Helpers
+  alias Edenflowers.Store.FulfillmentOption
+
+  setup %{conn: conn} do
+    tax_rate = generate(tax_rate())
+
+    delivery =
+      generate(
+        fulfillment_option(
+          tax_rate_id: tax_rate.id,
+          fulfillment_method: :delivery,
+          name: "Delivery",
+          available_days: [:monday, :tuesday, :wednesday, :thursday, :friday]
+        )
+      )
+
+    pickup =
+      generate(
+        fulfillment_option(
+          tax_rate_id: tax_rate.id,
+          fulfillment_method: :pickup,
+          name: "Pickup",
+          available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+        )
+      )
+
+    admin = generate(admin_user()) |> with_token()
+
+    conn =
+      conn
+      |> Plug.Test.init_test_session(%{})
+      |> Helpers.store_in_session(admin)
+
+    %{conn: conn, admin: admin, delivery: delivery, pickup: pickup}
+  end
+
+  describe "scope" do
+    test "defaults to :all and switches when a chip is clicked", %{conn: conn, delivery: delivery} do
+      {:ok, view, html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      assert html =~ "All options"
+      assert html =~ "Delivery"
+      assert html =~ "Pickup"
+
+      view
+      |> element(~s|button[phx-value-scope="#{delivery.id}"]|, "Delivery")
+      |> render_click()
+
+      assert render(view) =~ "Delivery"
+    end
+  end
+
+  describe "rendered styling" do
+    # Guardrail: the cell strike and the legend swatch share the same visual
+    # fragments via diagonal_strike/1. If someone changes one and forgets the
+    # other, this catches it — both must contain the strike's rotation token.
+    test "closed cells and the legend swatch use the same diagonal-strike fragment", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      # Sundays are closed for the delivery option set up in `setup`, so any
+      # rendered Sunday in the current month carries the closed strike.
+      assert html =~ "rotate-[-22deg]"
+      # Legend swatch reuses the same fragment via `before:` instead of `after:`.
+      assert html =~ "before:rotate-[-22deg]"
+    end
+  end
+
+  describe "weekday toggle" do
+    test "disables the weekday across every option when scope is :all", %{
+      conn: conn,
+      delivery: delivery,
+      pickup: pickup
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-click="weekday-click"][phx-value-weekday="monday"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded_delivery = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+      reloaded_pickup = FulfillmentOption.get_by_id!(pickup.id, authorize?: false)
+
+      refute :monday in reloaded_delivery.available_days
+      refute :monday in reloaded_pickup.available_days
+    end
+
+    test "is a no-op when the weekday is :mixed", %{
+      conn: conn,
+      delivery: delivery,
+      pickup: pickup
+    } do
+      # Saturday: delivery=off, pickup=on → :mixed
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-click="weekday-click"][phx-value-weekday="saturday"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded_delivery = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+      reloaded_pickup = FulfillmentOption.get_by_id!(pickup.id, authorize?: false)
+
+      refute :saturday in reloaded_delivery.available_days
+      assert :saturday in reloaded_pickup.available_days
+    end
+
+    test "toggling a weekday updates only the scoped option", %{
+      conn: conn,
+      delivery: delivery,
+      pickup: pickup
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-value-scope="#{delivery.id}"]|, "Delivery")
+      |> render_click()
+
+      view
+      |> element(~s|button[phx-click="weekday-click"][phx-value-weekday="monday"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded_delivery = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+      reloaded_pickup = FulfillmentOption.get_by_id!(pickup.id, authorize?: false)
+
+      refute :monday in reloaded_delivery.available_days
+      assert :monday in reloaded_pickup.available_days
+    end
+  end
+
+  describe "date toggle" do
+    test "clicking an open future date adds it to disabled_dates for the scoped option", %{
+      conn: conn,
+      delivery: delivery
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-value-scope="#{delivery.id}"]|, "Delivery")
+      |> render_click()
+
+      future = next_weekday(:monday)
+
+      view
+      |> element(~s|button[phx-click="select"][phx-value-date="#{Date.to_iso8601(future)}"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+      assert future in reloaded.disabled_dates
+    end
+  end
+
+  describe "redirects" do
+    test "redirects unauthenticated users to /sign-in" do
+      conn = Phoenix.ConnTest.build_conn() |> Plug.Test.init_test_session(%{})
+
+      assert {:error, {:redirect, %{to: "/sign-in"}}} =
+               live(conn, ~p"/admin/fulfillment-calendar")
+    end
+
+    test "redirects non-admin authenticated users to /sign-in" do
+      # A user that exists but isn't an admin should still get bounced.
+      regular_user =
+        Generator.admin_user(admin: false)
+        |> Generator.generate()
+        |> with_token()
+
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> Plug.Test.init_test_session(%{})
+        |> Helpers.store_in_session(regular_user)
+
+      assert {:error, {:redirect, %{to: "/sign-in"}}} =
+               live(conn, ~p"/admin/fulfillment-calendar")
+    end
+  end
+
+  # The component sends results to the parent via send(self(), ...), which
+  # land as handle_info messages. render_click only awaits the handle_event,
+  # so we force a sync round-trip before asserting on persisted state.
+  defp drain(view), do: _ = render(view)
+
+  # Pick the next future date that lands on a given weekday.
+  defp next_weekday(weekday_atom) do
+    target = weekday_index(weekday_atom)
+    today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
+    offset = Enum.find(1..21, &(Date.day_of_week(Date.add(today, &1)) == target))
+    Date.add(today, offset)
+  end
+
+  defp weekday_index(:monday), do: 1
+  defp weekday_index(:tuesday), do: 2
+  defp weekday_index(:wednesday), do: 3
+  defp weekday_index(:thursday), do: 4
+  defp weekday_index(:friday), do: 5
+  defp weekday_index(:saturday), do: 6
+  defp weekday_index(:sunday), do: 7
+
+  # seed_generator skips the GenerateTokenChange that normal sign-in would
+  # run, so we mint a token by hand and stash it in __metadata__ where
+  # store_in_session/2 expects to find it.
+  defp with_token(user) do
+    {:ok, token, _claims} = Jwt.token_for_user(user)
+    %{user | __metadata__: Map.put(user.__metadata__ || %{}, :token, token)}
+  end
+end

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -94,12 +94,13 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
       refute :monday in reloaded_pickup.available_days
     end
 
-    test "is a no-op when the weekday is :mixed", %{
+    test "closes the weekday everywhere when options disagree and at least one has it on", %{
       conn: conn,
       delivery: delivery,
       pickup: pickup
     } do
-      # Saturday: delivery=off, pickup=on → :mixed
+      # Saturday: delivery=off, pickup=on. The smart toggle aggregates: any
+      # option has Saturday on → click closes Saturday everywhere.
       {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
 
       view
@@ -112,7 +113,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
       reloaded_pickup = FulfillmentOption.get_by_id!(pickup.id, authorize?: false)
 
       refute :saturday in reloaded_delivery.available_days
-      assert :saturday in reloaded_pickup.available_days
+      refute :saturday in reloaded_pickup.available_days
     end
 
     test "toggling a weekday updates only the scoped option", %{
@@ -161,6 +162,73 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
 
       reloaded = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
       assert future in reloaded.disabled_dates
+    end
+  end
+
+  describe "reset" do
+    test "wipes overrides and reopens every weekday for the scoped option", %{
+      conn: conn,
+      delivery: delivery
+    } do
+      # Seed delivery with an override and a non-default weekday rule.
+      {:ok, _} =
+        FulfillmentOption.update_calendar(
+          delivery,
+          %{
+            available_days: [:monday],
+            enabled_dates: [~D[2026-12-25]],
+            disabled_dates: [~D[2026-12-26]]
+          },
+          authorize?: false
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-click="set-scope"][phx-value-scope="#{delivery.id}"]|)
+      |> render_click()
+
+      view
+      |> element(~s|button[phx-click="reset-calendar"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+
+      assert Enum.sort(reloaded.available_days) ==
+               [:friday, :monday, :saturday, :sunday, :thursday, :tuesday, :wednesday]
+
+      assert reloaded.enabled_dates == []
+      assert reloaded.disabled_dates == []
+    end
+
+    test "resets every option when scope is :all", %{
+      conn: conn,
+      delivery: delivery,
+      pickup: pickup
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-click="reset-calendar"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded_delivery = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+      reloaded_pickup = FulfillmentOption.get_by_id!(pickup.id, authorize?: false)
+
+      for option <- [reloaded_delivery, reloaded_pickup] do
+        assert :sunday in option.available_days
+        assert option.enabled_dates == []
+        assert option.disabled_dates == []
+      end
+    end
+
+    test "renders a data-confirm attribute on the reset button", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/fulfillment-calendar")
+      assert html =~ "Are you sure you want to reset the calendar?"
     end
   end
 

--- a/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
+++ b/test/edenflowers_web/live/admin/fulfillment_calendar_live_test.exs
@@ -7,6 +7,7 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
   alias AshAuthentication.Jwt
   alias AshAuthentication.Plug.Helpers
   alias Edenflowers.Store.FulfillmentOption
+  alias Edenflowers.Weekday
 
   setup %{conn: conn} do
     tax_rate = generate(tax_rate())
@@ -165,6 +166,47 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
     end
   end
 
+  describe "week toggle" do
+    test "clicking the week-toggle button closes every open cell in that week for the scoped option", %{
+      conn: conn,
+      delivery: delivery
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/fulfillment-calendar")
+
+      view
+      |> element(~s|button[phx-value-scope="#{delivery.id}"]|, "Delivery")
+      |> render_click()
+
+      # Pick a week payload whose dates are all in the future, so the click
+      # actually has something to do.
+      html = render(view)
+      today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
+
+      week_payload =
+        Regex.scan(~r/phx-click="week-click" phx-value-week="([^"]+)"/, html)
+        |> Enum.map(fn [_, payload] -> payload end)
+        |> Enum.find(fn payload ->
+          dates = payload |> String.split(",") |> Enum.map(&Date.from_iso8601!/1)
+          Enum.all?(dates, &(Date.compare(&1, today) != :lt))
+        end)
+
+      assert week_payload, "expected at least one future week button in the rendered month"
+
+      view
+      |> element(~s|button[phx-click="week-click"][phx-value-week="#{week_payload}"]|)
+      |> render_click()
+
+      drain(view)
+
+      reloaded = FulfillmentOption.get_by_id!(delivery.id, authorize?: false)
+
+      # Delivery is open Mon-Fri; clicking the week-toggle closes Mon-Fri of that week.
+      week_dates = week_payload |> String.split(",") |> Enum.map(&Date.from_iso8601!/1)
+      weekday_cells = Enum.filter(week_dates, &(Date.day_of_week(&1) in 1..5))
+      assert Enum.all?(weekday_cells, &(&1 in reloaded.disabled_dates))
+    end
+  end
+
   describe "reset" do
     test "wipes overrides and reopens every weekday for the scoped option", %{
       conn: conn,
@@ -264,19 +306,11 @@ defmodule EdenflowersWeb.Admin.FulfillmentCalendarLiveTest do
 
   # Pick the next future date that lands on a given weekday.
   defp next_weekday(weekday_atom) do
-    target = weekday_index(weekday_atom)
+    target = Weekday.to_integer(weekday_atom)
     today = "Europe/Helsinki" |> DateTime.now!() |> DateTime.to_date()
     offset = Enum.find(1..21, &(Date.day_of_week(Date.add(today, &1)) == target))
     Date.add(today, offset)
   end
-
-  defp weekday_index(:monday), do: 1
-  defp weekday_index(:tuesday), do: 2
-  defp weekday_index(:wednesday), do: 3
-  defp weekday_index(:thursday), do: 4
-  defp weekday_index(:friday), do: 5
-  defp weekday_index(:saturday), do: 6
-  defp weekday_index(:sunday), do: 7
 
   # seed_generator skips the GenerateTokenChange that normal sign-in would
   # run, so we mint a token by hand and stash it in __metadata__ where

--- a/test/fulfillments_test.exs
+++ b/test/fulfillments_test.exs
@@ -57,7 +57,7 @@ defmodule Edenflowers.FulfillmentsTest do
       assert {false, :past} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-14], now)
     end
 
-    test "returns :day_of_week_disabled when day of week is disabled", %{tax_rate_id: tax_rate_id} do
+    test "returns :weekday_disabled when day of week is disabled", %{tax_rate_id: tax_rate_id} do
       fulfillment_option =
         generate(
           fulfillment_option(
@@ -69,7 +69,7 @@ defmodule Edenflowers.FulfillmentsTest do
       now = DateTime.from_naive!(~N[2023-09-09 20:15:00], "Europe/Helsinki")
 
       # 10th Sept 2023 is a Sunday
-      assert {false, :day_of_week_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-10], now)
+      assert {false, :weekday_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-10], now)
     end
 
     test "returns :same_day_delivery_disabled when same day fulfillment is not enabled", %{tax_rate_id: tax_rate_id} do
@@ -132,24 +132,20 @@ defmodule Edenflowers.FulfillmentsTest do
     end
   end
 
-  describe "cell_state/3" do
-    setup %{tax_rate_id: tax_rate_id} do
-      [tax_rate_id: tax_rate_id]
-    end
-
+  describe "customer_cell_state/3" do
     test ":open when fulfillable", %{tax_rate_id: tax_rate_id} do
       fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
       now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
-      assert :open == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-05], now)
+      assert :open == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-05], now)
     end
 
     test ":past when date is before today", %{tax_rate_id: tax_rate_id} do
       fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
       now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
-      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-01], now)
+      assert :past == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-01], now)
     end
 
-    test ":weekday_off when weekday is disabled and no explicit enable", %{tax_rate_id: tax_rate_id} do
+    test ":closed when weekday is disabled and no explicit enable", %{tax_rate_id: tax_rate_id} do
       fulfillment_option =
         generate(
           fulfillment_option(
@@ -160,15 +156,15 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
       # 2024-04-07 is a Sunday
-      assert :weekday_off == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-07], now)
+      assert :closed == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-07], now)
     end
 
-    test ":override_off when date is explicitly disabled", %{tax_rate_id: tax_rate_id} do
+    test ":closed when date is explicitly disabled", %{tax_rate_id: tax_rate_id} do
       fulfillment_option =
         generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-10]]))
 
       now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
-      assert :override_off == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-10], now)
+      assert :closed == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-10], now)
     end
 
     test ":past when same-day disabled and date is today", %{tax_rate_id: tax_rate_id} do
@@ -176,7 +172,7 @@ defmodule Edenflowers.FulfillmentsTest do
         generate(fulfillment_option(tax_rate_id: tax_rate_id, same_day: false, order_deadline: ~T[14:00:00]))
 
       now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
-      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-02], now)
+      assert :past == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-02], now)
     end
 
     test ":past when order deadline has passed", %{tax_rate_id: tax_rate_id} do
@@ -184,7 +180,60 @@ defmodule Edenflowers.FulfillmentsTest do
         generate(fulfillment_option(tax_rate_id: tax_rate_id, same_day: true, order_deadline: ~T[14:00:00]))
 
       now = DateTime.from_naive!(~N[2024-04-02 15:00:00], "Europe/Helsinki")
-      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-02], now)
+      assert :past == Fulfillments.customer_cell_state(fulfillment_option, ~D[2024-04-02], now)
+    end
+  end
+
+  describe "admin_cell_state/3" do
+    test ":open when weekday rule allows the date", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      assert :open == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-05], ~D[2024-04-02])
+    end
+
+    test ":past when date is before today", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      assert :past == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-01], ~D[2024-04-02])
+    end
+
+    test ":weekday_disabled when weekday is disabled and no explicit enable", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      # 2024-04-07 is a Sunday
+      assert :weekday_disabled == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-07], ~D[2024-04-02])
+    end
+
+    test ":date_disabled when date is explicitly disabled", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-10]]))
+
+      assert :date_disabled == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-10], ~D[2024-04-02])
+    end
+
+    test ":open when date is explicitly enabled on an otherwise-closed weekday", %{tax_rate_id: tax_rate_id} do
+      # 2024-04-07 is a Sunday
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday],
+            enabled_dates: [~D[2024-04-07]]
+          )
+        )
+
+      assert :open == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-07], ~D[2024-04-02])
+    end
+
+    test "today is not collapsed to :past — same-day rules don't apply to admin", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(fulfillment_option(tax_rate_id: tax_rate_id, same_day: false, order_deadline: ~T[14:00:00]))
+
+      assert :open == Fulfillments.admin_cell_state(fulfillment_option, ~D[2024-04-02], ~D[2024-04-02])
     end
   end
 end

--- a/test/fulfillments_test.exs
+++ b/test/fulfillments_test.exs
@@ -54,7 +54,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2023-09-15 10:30:00], "Europe/Helsinki")
 
-      assert {false, :past} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-14], now)
+      assert {:error, :past} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-14], now)
     end
 
     test "returns :weekday_disabled when day of week is disabled", %{tax_rate_id: tax_rate_id} do
@@ -69,7 +69,7 @@ defmodule Edenflowers.FulfillmentsTest do
       now = DateTime.from_naive!(~N[2023-09-09 20:15:00], "Europe/Helsinki")
 
       # 10th Sept 2023 is a Sunday
-      assert {false, :weekday_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-10], now)
+      assert {:error, :weekday_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-10], now)
     end
 
     test "returns :same_day_delivery_disabled when same day fulfillment is not enabled", %{tax_rate_id: tax_rate_id} do
@@ -78,7 +78,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2023-09-20 09:45:00], "Europe/Helsinki")
 
-      assert {false, :same_day_delivery_disabled} =
+      assert {:error, :same_day_delivery_disabled} =
                Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-09-20], now)
     end
 
@@ -88,7 +88,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2023-06-01 13:59:00], "Europe/Helsinki")
 
-      assert {true, :ok} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-06-01], now)
+      assert :ok = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-06-01], now)
     end
 
     test "returns :order_deadline_passed when same day fulfillment is enabled but time is past cutoff", %{
@@ -99,7 +99,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2023-06-01 14:01:00], "Europe/Helsinki")
 
-      assert {false, :order_deadline_passed} =
+      assert {:error, :order_deadline_passed} =
                Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-06-01], now)
     end
 
@@ -108,7 +108,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2023-02-10 12:00:00], "Europe/Helsinki")
 
-      assert {false, :date_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-02-15], now)
+      assert {:error, :date_disabled} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2023-02-15], now)
     end
 
     test "fulfillment date overrides weekday 1/2", %{tax_rate_id: tax_rate_id} do
@@ -117,7 +117,7 @@ defmodule Edenflowers.FulfillmentsTest do
         generate(fulfillment_option(tax_rate_id: tax_rate_id, sunday: false, enabled_dates: [~D[2024-04-07]]))
 
       now = DateTime.from_naive!(~N[2024-04-06 09:20:00], "Europe/Helsinki")
-      assert {true, :ok} = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2024-04-07], now)
+      assert :ok = Fulfillments.fulfill_on_date(fulfillment_option, ~D[2024-04-07], now)
     end
 
     test "fulfillment date overrides weekday 2/2", %{tax_rate_id: tax_rate_id} do
@@ -127,7 +127,7 @@ defmodule Edenflowers.FulfillmentsTest do
 
       now = DateTime.from_naive!(~N[2024-04-02 17:50:00], "Europe/Helsinki")
 
-      assert {false, :date_disabled} =
+      assert {:error, :date_disabled} =
                Fulfillments.fulfill_on_date(fulfillment_option, ~D[2024-04-03], now)
     end
   end

--- a/test/fulfillments_test.exs
+++ b/test/fulfillments_test.exs
@@ -131,4 +131,60 @@ defmodule Edenflowers.FulfillmentsTest do
                Fulfillments.fulfill_on_date(fulfillment_option, ~D[2024-04-03], now)
     end
   end
+
+  describe "cell_state/3" do
+    setup %{tax_rate_id: tax_rate_id} do
+      [tax_rate_id: tax_rate_id]
+    end
+
+    test ":open when fulfillable", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
+      assert :open == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-05], now)
+    end
+
+    test ":past when date is before today", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option = generate(fulfillment_option(tax_rate_id: tax_rate_id))
+      now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
+      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-01], now)
+    end
+
+    test ":weekday_off when weekday is disabled and no explicit enable", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(
+          fulfillment_option(
+            tax_rate_id: tax_rate_id,
+            available_days: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+          )
+        )
+
+      now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
+      # 2024-04-07 is a Sunday
+      assert :weekday_off == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-07], now)
+    end
+
+    test ":override_off when date is explicitly disabled", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(fulfillment_option(tax_rate_id: tax_rate_id, disabled_dates: [~D[2024-04-10]]))
+
+      now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
+      assert :override_off == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-10], now)
+    end
+
+    test ":past when same-day disabled and date is today", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(fulfillment_option(tax_rate_id: tax_rate_id, same_day: false, order_deadline: ~T[14:00:00]))
+
+      now = DateTime.from_naive!(~N[2024-04-02 09:00:00], "Europe/Helsinki")
+      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-02], now)
+    end
+
+    test ":past when order deadline has passed", %{tax_rate_id: tax_rate_id} do
+      fulfillment_option =
+        generate(fulfillment_option(tax_rate_id: tax_rate_id, same_day: true, order_deadline: ~T[14:00:00]))
+
+      now = DateTime.from_naive!(~N[2024-04-02 15:00:00], "Europe/Helsinki")
+      assert :past == Fulfillments.cell_state(fulfillment_option, ~D[2024-04-02], now)
+    end
+  end
 end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -1,0 +1,53 @@
+defmodule Edenflowers.Store.KeyDatesTest do
+  use ExUnit.Case, async: true
+
+  alias Edenflowers.Store.KeyDates
+
+  describe "for_year/1" do
+    test "materialises the five known holidays for 2026" do
+      by_name = KeyDates.for_year(2026) |> Map.new(fn %{name: n, date: d} -> {n, d} end)
+
+      assert by_name["Valentine's Day"] == ~D[2026-02-14]
+      assert by_name["Women's Day"] == ~D[2026-03-08]
+      assert by_name["Mother's Day"] == ~D[2026-05-10]
+      assert by_name["Father's Day"] == ~D[2026-11-08]
+      assert by_name["Christmas Eve"] == ~D[2026-12-24]
+    end
+
+    test "nth-weekday rule shifts year-over-year" do
+      mothers_day = fn year ->
+        KeyDates.for_year(year)
+        |> Enum.find(&(&1.name == "Mother's Day"))
+        |> Map.fetch!(:date)
+      end
+
+      assert mothers_day.(2026) == ~D[2026-05-10]
+      assert mothers_day.(2027) == ~D[2027-05-09]
+      assert mothers_day.(2028) == ~D[2028-05-14]
+    end
+
+    test "every entry has a heroicon name and a human-readable name" do
+      for %{name: name, icon: icon} <- KeyDates.for_year(2026) do
+        assert is_binary(name) and name != ""
+        assert String.starts_with?(icon, "hero-")
+      end
+    end
+  end
+
+  describe "icons_by_date/1" do
+    test "maps each holiday's date to its icon" do
+      icons = KeyDates.icons_by_date(2026)
+
+      assert icons[~D[2026-02-14]] == "hero-heart-solid"
+      assert icons[~D[2026-03-08]] == "hero-sparkles-solid"
+      assert icons[~D[2026-05-10]] == "hero-heart-solid"
+      assert icons[~D[2026-11-08]] == "hero-heart-solid"
+      assert icons[~D[2026-12-24]] == "hero-gift-solid"
+    end
+
+    test "returns nil for non-holiday dates" do
+      icons = KeyDates.icons_by_date(2026)
+      assert icons[~D[2026-06-15]] == nil
+    end
+  end
+end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -4,7 +4,7 @@ defmodule Edenflowers.Store.KeyDatesTest do
   alias Edenflowers.Store.KeyDates
 
   describe "for_year/1" do
-    test "materialises the five known holidays for 2026" do
+    test "materialises the five known key dates for 2026" do
       by_name = KeyDates.for_year(2026) |> Map.new(fn %{name: n, date: d} -> {n, d} end)
 
       assert by_name["Valentine's Day"] == ~D[2026-02-14]
@@ -35,7 +35,7 @@ defmodule Edenflowers.Store.KeyDatesTest do
   end
 
   describe "icon_for/1" do
-    test "returns the icon for each holiday in 2026" do
+    test "returns the icon for each key date in 2026" do
       assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart-solid"
       assert KeyDates.icon_for(~D[2026-03-08]) == "hero-sparkles-solid"
       assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart-solid"
@@ -49,7 +49,7 @@ defmodule Edenflowers.Store.KeyDatesTest do
       assert KeyDates.icon_for(~D[2027-05-10]) == nil
     end
 
-    test "returns nil for non-holiday dates" do
+    test "returns nil for non-key dates" do
       assert KeyDates.icon_for(~D[2026-06-15]) == nil
     end
   end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -33,37 +33,40 @@ defmodule Edenflowers.Store.KeyDatesTest do
     end
   end
 
-  describe "icon_for/1" do
-    test "returns the icon for each key date in 2026" do
-      assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart"
-      assert KeyDates.icon_for(~D[2026-03-08]) == "hero-heart"
-      assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart"
-      assert KeyDates.icon_for(~D[2026-11-08]) == "hero-heart"
+  describe "lookup_for/1" do
+    test "returns the icon and colour for each key date in 2026" do
+      for date <- [~D[2026-02-14], ~D[2026-03-08], ~D[2026-05-10], ~D[2026-11-08]] do
+        assert %{icon: "hero-heart", colour_class: "text-" <> _} = KeyDates.lookup_for(date)
+      end
     end
 
     test "tracks the right year — Mother's Day shifts across years" do
-      assert KeyDates.icon_for(~D[2027-05-09]) == "hero-heart"
-      assert KeyDates.icon_for(~D[2028-05-14]) == "hero-heart"
-      assert KeyDates.icon_for(~D[2027-05-10]) == nil
+      assert %{icon: "hero-heart"} = KeyDates.lookup_for(~D[2027-05-09])
+      assert %{icon: "hero-heart"} = KeyDates.lookup_for(~D[2028-05-14])
+      assert KeyDates.lookup_for(~D[2027-05-10]) == nil
     end
 
     test "returns nil for non-key dates" do
-      assert KeyDates.icon_for(~D[2026-06-15]) == nil
+      assert KeyDates.lookup_for(~D[2026-06-15]) == nil
     end
-  end
 
-  describe "colour_class_for/1" do
     test "returns a distinct colour class for each key date" do
       colours =
         [~D[2026-02-14], ~D[2026-03-08], ~D[2026-05-10], ~D[2026-11-08]]
-        |> Enum.map(&KeyDates.colour_class_for/1)
+        |> Enum.map(&KeyDates.lookup_for/1)
+        |> Enum.map(& &1.colour_class)
 
-      assert Enum.all?(colours, &is_binary/1)
       assert Enum.uniq(colours) == colours
     end
+  end
 
-    test "returns nil for non-key dates" do
-      assert KeyDates.colour_class_for(~D[2026-06-15]) == nil
+  describe "key_date?/1" do
+    test "true for a known key date" do
+      assert KeyDates.key_date?(~D[2026-02-14])
+    end
+
+    test "false for an ordinary date" do
+      refute KeyDates.key_date?(~D[2026-06-15])
     end
   end
 end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -4,14 +4,13 @@ defmodule Edenflowers.Store.KeyDatesTest do
   alias Edenflowers.Store.KeyDates
 
   describe "for_year/1" do
-    test "materialises the five known key dates for 2026" do
+    test "materialises the four known key dates for 2026" do
       by_name = KeyDates.for_year(2026) |> Map.new(fn %{name: n, date: d} -> {n, d} end)
 
       assert by_name["Valentine's Day"] == ~D[2026-02-14]
       assert by_name["Women's Day"] == ~D[2026-03-08]
       assert by_name["Mother's Day"] == ~D[2026-05-10]
       assert by_name["Father's Day"] == ~D[2026-11-08]
-      assert by_name["Christmas Eve"] == ~D[2026-12-24]
     end
 
     test "nth-weekday rule shifts year-over-year" do
@@ -36,21 +35,35 @@ defmodule Edenflowers.Store.KeyDatesTest do
 
   describe "icon_for/1" do
     test "returns the icon for each key date in 2026" do
-      assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart-solid"
-      assert KeyDates.icon_for(~D[2026-03-08]) == "hero-sparkles-solid"
-      assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart-solid"
-      assert KeyDates.icon_for(~D[2026-11-08]) == "hero-heart-solid"
-      assert KeyDates.icon_for(~D[2026-12-24]) == "hero-gift-solid"
+      assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart"
+      assert KeyDates.icon_for(~D[2026-03-08]) == "hero-heart"
+      assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart"
+      assert KeyDates.icon_for(~D[2026-11-08]) == "hero-heart"
     end
 
     test "tracks the right year — Mother's Day shifts across years" do
-      assert KeyDates.icon_for(~D[2027-05-09]) == "hero-heart-solid"
-      assert KeyDates.icon_for(~D[2028-05-14]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2027-05-09]) == "hero-heart"
+      assert KeyDates.icon_for(~D[2028-05-14]) == "hero-heart"
       assert KeyDates.icon_for(~D[2027-05-10]) == nil
     end
 
     test "returns nil for non-key dates" do
       assert KeyDates.icon_for(~D[2026-06-15]) == nil
+    end
+  end
+
+  describe "colour_class_for/1" do
+    test "returns a distinct colour class for each key date" do
+      colours =
+        [~D[2026-02-14], ~D[2026-03-08], ~D[2026-05-10], ~D[2026-11-08]]
+        |> Enum.map(&KeyDates.colour_class_for/1)
+
+      assert Enum.all?(colours, &is_binary/1)
+      assert Enum.uniq(colours) == colours
+    end
+
+    test "returns nil for non-key dates" do
+      assert KeyDates.colour_class_for(~D[2026-06-15]) == nil
     end
   end
 end

--- a/test/key_dates_test.exs
+++ b/test/key_dates_test.exs
@@ -34,20 +34,23 @@ defmodule Edenflowers.Store.KeyDatesTest do
     end
   end
 
-  describe "icons_by_date/1" do
-    test "maps each holiday's date to its icon" do
-      icons = KeyDates.icons_by_date(2026)
+  describe "icon_for/1" do
+    test "returns the icon for each holiday in 2026" do
+      assert KeyDates.icon_for(~D[2026-02-14]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-03-08]) == "hero-sparkles-solid"
+      assert KeyDates.icon_for(~D[2026-05-10]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-11-08]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2026-12-24]) == "hero-gift-solid"
+    end
 
-      assert icons[~D[2026-02-14]] == "hero-heart-solid"
-      assert icons[~D[2026-03-08]] == "hero-sparkles-solid"
-      assert icons[~D[2026-05-10]] == "hero-heart-solid"
-      assert icons[~D[2026-11-08]] == "hero-heart-solid"
-      assert icons[~D[2026-12-24]] == "hero-gift-solid"
+    test "tracks the right year — Mother's Day shifts across years" do
+      assert KeyDates.icon_for(~D[2027-05-09]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2028-05-14]) == "hero-heart-solid"
+      assert KeyDates.icon_for(~D[2027-05-10]) == nil
     end
 
     test "returns nil for non-holiday dates" do
-      icons = KeyDates.icons_by_date(2026)
-      assert icons[~D[2026-06-15]] == nil
+      assert KeyDates.icon_for(~D[2026-06-15]) == nil
     end
   end
 end

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -989,6 +989,26 @@ defmodule Edenflowers.Store.OrderTest do
 
       assert %Ash.Error.Invalid{} = error
     end
+
+    test "save_step_3 rejects a date the option no longer allows", %{pickup_option: pickup_option} do
+      order = generate(order(state: :delivery))
+      closed_date = Date.add(Date.utc_today(), 3)
+
+      {:ok, _} =
+        pickup_option
+        |> Ash.Changeset.for_update(:update, %{disabled_dates: [closed_date]})
+        |> Ash.update(authorize?: false)
+
+      assert {:error, error} =
+               order
+               |> Ash.Changeset.for_update(:submit_delivery, %{
+                 fulfillment_option_id: pickup_option.id,
+                 fulfillment_date: closed_date
+               })
+               |> Ash.update(authorize?: false)
+
+      assert %Ash.Error.Invalid{} = error
+    end
   end
 
   describe "Order state transitions" do

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -995,9 +995,11 @@ defmodule Edenflowers.Store.OrderTest do
       closed_date = Date.add(Date.utc_today(), 3)
 
       {:ok, _} =
-        pickup_option
-        |> Ash.Changeset.for_update(:update, %{disabled_dates: [closed_date]})
-        |> Ash.update(authorize?: false)
+        Edenflowers.Store.FulfillmentOption.update_calendar(
+          pickup_option,
+          %{disabled_dates: [closed_date]},
+          authorize?: false
+        )
 
       assert {:error, error} =
                order

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -1,6 +1,8 @@
 defmodule Generator do
   use Ash.Generator
 
+  alias Edenflowers.Accounts.User
+
   alias Edenflowers.Store.{
     TaxRate,
     Promotion,
@@ -11,6 +13,20 @@ defmodule Generator do
     LineItem,
     FulfillmentOption
   }
+
+  # seed_generator bypasses actions so we can set :admin directly
+  # (the attribute is writable?: false on the resource).
+  def admin_user(opts \\ []) do
+    seed_generator(
+      %User{
+        email: sequence(:admin_email, &"admin#{&1}@example.com"),
+        name: "Admin",
+        admin: true
+      },
+      overrides: opts,
+      authorize?: false
+    )
+  end
 
   def tax_rate(opts \\ []) do
     changeset_generator(


### PR DESCRIPTION
## Summary

New `/admin/fulfillment-calendar` LiveView lets the florist toggle dates and weekdays on/off per fulfillment option or across all options at once. Mixed-state cells (options disagree) are visible but non-interactive — the florist must pick a specific option to edit.

The existing `CalendarComponent` is reshaped to a single API both calendars consume: callers pass a `cell_state` function (atom per date) and a `clickable_states` list; styling and click-propagation are driven by that vocabulary. Closed-state styling stays caller-themed so checkout keeps its single \"unavailable\" look while admin distinguishes `:weekday_disabled`, `:date_disabled`, and `:mixed`.

`Fulfillments.customer_cell_state/3` and `admin_cell_state/3` are the two shared mappings from option + date to UI state — both calendars stay in sync with the actual availability rules. `Edenflowers.Store.FulfillmentCalendar` holds the pure click→attrs translation; persistence goes through two new Ash actions (`:toggle_date`, `:toggle_weekday`) on `FulfillmentOption`, gated by the existing admin-only policy.

Also:

- `ValidateFulfillmentDate` now consults the same `fulfill_on_date/3` predicate the calendar uses, so a date the florist has since closed is rejected at submit rather than slipping through to payment.
- Key-date markers (Valentine's, Women's, Mother's, Father's) render as a coloured outline heart watermark behind the digit, in both calendars, via a shared `<.key_date_icon />` component.
- Pseudo-element decorations (the closed-cell strike, the override corner) move from string-interpolated Tailwind into four named `@utility` blocks in `app.css`.
- `Fulfillments.fulfill_on_date/3` returns `:ok | {:error, reason}`; predicates take positional args; `Edenflowers.Weekday` dedupes the day-of-week → atom mapping.

No schema changes — the three storage fields (`available_days`, `enabled_dates`, `disabled_dates`) already existed on `FulfillmentOption`.

## Notes for reviewers

- The \"All options + mixed\" gesture is deliberately non-clickable rather than collapsing to closed — the florist preferred explicit disambiguation.
- Same-day delivery + cart aggregation across products with different lead times is out of scope; will file as a follow-up.

## Test plan

- [x] `mix test` — 334 tests pass.
- [x] Compile clean with `--warnings-as-errors`.
- [ ] Smoke-check `/admin/fulfillment-calendar`: toggle a date, toggle a weekday header, switch scope. Confirm mixed cells/headers are visibly non-interactive.
- [ ] Re-run checkout to confirm no regression on the customer calendar.