### PR TITLE
Return to previous page after sign in (#214)

### DIFF
--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -87,6 +87,17 @@ defmodule EdenflowersWeb.Layouts do
     """
   end
 
+  # Builds a sign-in href, attaching the current path as a `return_to` so the
+  # user lands back where they started. Filters out paths that aren't worth
+  # capturing (the sign-in page itself, the home page, anything not safe).
+  defp sign_in_href(current_path) do
+    case EdenflowersWeb.ReturnTo.safe_path(current_path) do
+      nil -> ~p"/sign-in"
+      "/" -> ~p"/sign-in"
+      path -> ~p"/sign-in?return_to=#{path}"
+    end
+  end
+
   attr :flash, :map, required: true
   attr :current_path, :string, required: true
   slot :inner_block, required: true
@@ -195,7 +206,7 @@ defmodule EdenflowersWeb.Layouts do
                 class="text-base-content group font-serif inline-flex items-center gap-3 text-3xl hover:decoration-(--color-link-underline) hover:underline hover:underline-offset-4"
                 phx-click={JS.exec("phx-hide", to: "#nav-drawer")}
                 navigate={if @current_user, do: ~p"/account"}
-                href={unless @current_user, do: ~p"/sign-in"}
+                href={unless @current_user, do: sign_in_href(@current_path)}
               >
                 <.icon name="hero-user-circle" class="h-7 w-7" />
                 {if @current_user, do: ~t"Account", else: ~t"Sign In"}
@@ -283,7 +294,7 @@ defmodule EdenflowersWeb.Layouts do
               <%!-- Sign in (desktop only — mobile lives in nav drawer) --%>
               <.link
                 navigate={if @current_user, do: ~p"/account"}
-                href={unless @current_user, do: ~p"/sign-in"}
+                href={unless @current_user, do: sign_in_href(@current_path)}
                 class="group hidden h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-1 xl:flex xl:h-auto xl:w-auto xl:gap-2"
               >
                 <.icon class="text-base-content h-5 w-5 group-hover:text-base-content/60" name="hero-user-circle" />

--- a/lib/edenflowers_web/endpoint.ex
+++ b/lib/edenflowers_web/endpoint.ex
@@ -15,8 +15,8 @@ defmodule EdenflowersWeb.Endpoint do
   ]
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
-    longpoll: [connect_info: [session: @session_options]]
+    websocket: [connect_info: [:uri, session: @session_options]],
+    longpoll: [connect_info: [:uri, session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/edenflowers_web/live_user_auth.ex
+++ b/lib/edenflowers_web/live_user_auth.ex
@@ -5,6 +5,9 @@ defmodule EdenflowersWeb.LiveUserAuth do
 
   import Phoenix.Component
   use EdenflowersWeb, :verified_routes
+  use GettextSigils, backend: EdenflowersWeb.Gettext
+
+  alias EdenflowersWeb.ReturnTo
 
   # This is used for nested liveviews to fetch the current user.
   # To use, place the following at the top of that liveview:
@@ -25,7 +28,7 @@ defmodule EdenflowersWeb.LiveUserAuth do
     if socket.assigns[:current_user] do
       {:cont, socket}
     else
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+      {:halt, bounce_to_sign_in(socket)}
     end
   end
 
@@ -33,7 +36,7 @@ defmodule EdenflowersWeb.LiveUserAuth do
     if socket.assigns[:current_user] && socket.assigns.current_user.admin do
       {:cont, socket}
     else
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+      {:halt, bounce_to_sign_in(socket)}
     end
   end
 
@@ -42,6 +45,40 @@ defmodule EdenflowersWeb.LiveUserAuth do
       {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
     else
       {:cont, assign(socket, :current_user, nil)}
+    end
+  end
+
+  # The protected page the user was trying to reach is the URL stored in
+  # `connect_info[:uri]` (declared in the endpoint). Pass it as a query string
+  # so `EdenflowersWeb.Plugs.CaptureReturnTo` can lift it into the session
+  # when the browser follows the redirect to /sign-in.
+  defp bounce_to_sign_in(socket) do
+    socket
+    |> Phoenix.LiveView.put_flash(:error, ~t"You must sign in to access this page.")
+    |> Phoenix.LiveView.redirect(to: sign_in_redirect(socket))
+  end
+
+  defp sign_in_redirect(socket) do
+    case attempted_path(socket) do
+      nil -> ~p"/sign-in"
+      path -> ~p"/sign-in?return_to=#{path}"
+    end
+  end
+
+  defp attempted_path(socket) do
+    with %URI{path: path} when is_binary(path) <- Phoenix.LiveView.get_connect_info(socket, :uri),
+         path_with_query <- append_query(path, socket),
+         safe when is_binary(safe) <- ReturnTo.safe_path(path_with_query) do
+      safe
+    else
+      _ -> nil
+    end
+  end
+
+  defp append_query(path, socket) do
+    case Phoenix.LiveView.get_connect_info(socket, :uri) do
+      %URI{query: query} when is_binary(query) and query != "" -> path <> "?" <> query
+      _ -> path
     end
   end
 end

--- a/lib/edenflowers_web/plugs/capture_return_to.ex
+++ b/lib/edenflowers_web/plugs/capture_return_to.ex
@@ -1,0 +1,27 @@
+defmodule EdenflowersWeb.Plugs.CaptureReturnTo do
+  @moduledoc """
+  Captures a `return_to` query parameter into the session on the way into the
+  sign-in page. `EdenflowersWeb.AuthController.success/4` later reads the
+  session value to send the user back where they came from.
+
+  Only same-origin, path-only targets are accepted (see `EdenflowersWeb.ReturnTo`).
+  """
+  import Plug.Conn
+
+  alias EdenflowersWeb.ReturnTo
+
+  @sign_in_path "/sign-in"
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: @sign_in_path} = conn, _opts) do
+    conn = fetch_query_params(conn)
+
+    case ReturnTo.safe_path(conn.query_params["return_to"]) do
+      nil -> conn
+      path -> put_session(conn, :return_to, path)
+    end
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/edenflowers_web/return_to.ex
+++ b/lib/edenflowers_web/return_to.ex
@@ -1,0 +1,39 @@
+defmodule EdenflowersWeb.ReturnTo do
+  @moduledoc """
+  Validates and normalises post-sign-in return targets.
+
+  Only same-origin, path-only URLs are allowed. The sign-in page itself and
+  auth callbacks are filtered out so the user never lands back inside the
+  login flow.
+  """
+
+  @disallowed_prefixes ["/sign-in", "/sign-out", "/auth", "/password-reset"]
+
+  @doc """
+  Returns the candidate if it's a safe path to redirect to after sign-in,
+  otherwise `nil`. A safe path:
+
+    * is a binary
+    * starts with `/` but not `//` (which `URI.parse/1` treats as host-relative)
+    * does not start with any auth-related prefix
+
+  Query strings and fragments are preserved.
+  """
+  def safe_path(path) when is_binary(path) do
+    cond do
+      not String.starts_with?(path, "/") -> nil
+      String.starts_with?(path, "//") -> nil
+      disallowed?(path) -> nil
+      true -> path
+    end
+  end
+
+  def safe_path(_), do: nil
+
+  defp disallowed?(path) do
+    Enum.any?(@disallowed_prefixes, fn prefix ->
+      path == prefix or String.starts_with?(path, prefix <> "/") or
+        String.starts_with?(path, prefix <> "?")
+    end)
+  end
+end

--- a/lib/edenflowers_web/router.ex
+++ b/lib/edenflowers_web/router.ex
@@ -21,6 +21,7 @@ defmodule EdenflowersWeb.Router do
       default: "en-GB"
 
     plug EdenflowersWeb.Plugs.PutLocaleSession
+    plug EdenflowersWeb.Plugs.CaptureReturnTo
     plug :load_from_session
   end
 

--- a/test/edenflowers_web/integration/capture_return_to_test.exs
+++ b/test/edenflowers_web/integration/capture_return_to_test.exs
@@ -1,0 +1,51 @@
+defmodule EdenflowersWeb.Plugs.CaptureReturnToTest do
+  use EdenflowersWeb.ConnCase, async: true
+
+  describe "GET /sign-in" do
+    test "stores a safe return_to in the session", %{conn: conn} do
+      conn = get(conn, "/sign-in", return_to: "/account")
+      assert get_session(conn, :return_to) == "/account"
+    end
+
+    test "stores a path with a query string", %{conn: conn} do
+      conn = get(conn, "/sign-in?return_to=%2Fstore%3Fcategory%3Dbouquets")
+      assert get_session(conn, :return_to) == "/store?category=bouquets"
+    end
+
+    test "ignores external return targets", %{conn: conn} do
+      conn = get(conn, "/sign-in", return_to: "https://evil.example.com/")
+      assert get_session(conn, :return_to) == nil
+    end
+
+    test "ignores protocol-relative return targets", %{conn: conn} do
+      conn = get(conn, "/sign-in", return_to: "//evil.example.com/")
+      assert get_session(conn, :return_to) == nil
+    end
+
+    test "ignores return targets pointing back at the sign-in page", %{conn: conn} do
+      conn = get(conn, "/sign-in", return_to: "/sign-in")
+      assert get_session(conn, :return_to) == nil
+    end
+
+    test "ignores return targets pointing into the auth flow", %{conn: conn} do
+      conn = get(conn, "/sign-in", return_to: "/auth/user/google")
+      assert get_session(conn, :return_to) == nil
+    end
+
+    test "no query param leaves the session value untouched", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(return_to: "/account")
+        |> get("/sign-in")
+
+      assert get_session(conn, :return_to) == "/account"
+    end
+  end
+
+  describe "other paths" do
+    test "does not write the session", %{conn: conn} do
+      conn = get(conn, "/", return_to: "/account")
+      assert get_session(conn, :return_to) == nil
+    end
+  end
+end

--- a/test/edenflowers_web/return_to_test.exs
+++ b/test/edenflowers_web/return_to_test.exs
@@ -1,0 +1,44 @@
+defmodule EdenflowersWeb.ReturnToTest do
+  use ExUnit.Case, async: true
+
+  alias EdenflowersWeb.ReturnTo
+
+  describe "safe_path/1" do
+    test "accepts path-only same-origin URLs" do
+      assert ReturnTo.safe_path("/account") == "/account"
+      assert ReturnTo.safe_path("/order/abc123") == "/order/abc123"
+      assert ReturnTo.safe_path("/store?category=bouquets") == "/store?category=bouquets"
+      assert ReturnTo.safe_path("/") == "/"
+    end
+
+    test "rejects external and protocol-relative URLs" do
+      assert ReturnTo.safe_path("https://evil.example.com/steal") == nil
+      assert ReturnTo.safe_path("//evil.example.com/steal") == nil
+      assert ReturnTo.safe_path("http://localhost:4000/account") == nil
+    end
+
+    test "rejects relative paths without a leading slash" do
+      assert ReturnTo.safe_path("account") == nil
+      assert ReturnTo.safe_path("../etc/passwd") == nil
+    end
+
+    test "rejects sign-in, sign-out, auth, and password-reset paths" do
+      assert ReturnTo.safe_path("/sign-in") == nil
+      assert ReturnTo.safe_path("/sign-in?foo=bar") == nil
+      assert ReturnTo.safe_path("/sign-out") == nil
+      assert ReturnTo.safe_path("/auth/user/google") == nil
+      assert ReturnTo.safe_path("/password-reset") == nil
+    end
+
+    test "does not reject paths that merely share a prefix with auth routes" do
+      assert ReturnTo.safe_path("/sign-in-and-share") == "/sign-in-and-share"
+      assert ReturnTo.safe_path("/authentication-guide") == "/authentication-guide"
+    end
+
+    test "rejects non-binary values" do
+      assert ReturnTo.safe_path(nil) == nil
+      assert ReturnTo.safe_path(123) == nil
+      assert ReturnTo.safe_path(%{}) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #214. After signing in, users are now sent back to the page they came from rather than always landing on the home page.

- Layout **Sign In** links carry `?return_to=<current_path>`.
- `LiveUserAuth` bounces from `/account`, `/order/:id`, and admin routes redirect to `/sign-in?return_to=<attempted>` and flash `"You must sign in to access this page."`.
- A `CaptureReturnTo` plug on `/sign-in` validates the query param via `EdenflowersWeb.ReturnTo.safe_path/1` (rejects external, protocol-relative, and auth-flow targets) and writes it to the session.
- `AuthController.success/4` already reads `:return_to`, so no change there.

## Implementation notes

- `LiveUserAuth` reads the attempted URL via `Phoenix.LiveView.get_connect_info(socket, :uri)`; this required declaring `:uri` in the endpoint's `connect_info`.
- The plug-on-entry approach (rather than phx_gen_auth's plug-on-bounce) is the LiveView-friendly variant the [ElixirForum discussion](https://elixirforum.com/t/how-to-store-return-to-url-when-navigating-from-liveview-to-another-page-liveview-regular/55480) converged on. It also handles the multi-tab case correctly because each tab's `/sign-in` URL carries its own destination.

## Test plan

- [x] `mix test` — 304 passing, including 14 new tests covering the validator and the capture plug (open-redirect attempts, sign-in/auth prefix loops, query-string preservation, no-op when query absent).
- [x] `mix compile --warnings-as-errors` clean.
- [ ] Smoke: visit `/account` logged out → bounced to `/sign-in?return_to=%2Faccount` with the flash → after OTP entry, land on `/account`.
- [ ] Smoke: from any page, click **Sign In** in the nav → `?return_to=<that_page>` → after sign in, land back there.
- [ ] Smoke: visit `/sign-in?return_to=https://evil.example.com/` directly → session value not set, post-login lands on `/`.