### PR TITLE
Run payment intent sync off the LiveView process

### DIFF
--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -633,14 +633,16 @@ defmodule EdenflowersWeb.CheckoutLive do
   def handle_info(%Phoenix.Socket.Broadcast{topic: "line_item:changed:" <> _}, socket) do
     actor = actor(socket)
     order = Order.get_for_checkout!(socket.assigns.order.id, actor: actor)
+    socket = assign(socket, order: order)
 
     # Cart changed while the customer is on the payment step. The PaymentIntent's
     # amount must follow the new total, otherwise `confirmPayment` would charge
-    # the previous amount.
+    # the previous amount. The Stripe round-trip runs in a task so the new cart
+    # totals render immediately — matching the snappiness of earlier steps.
     if order.state == :payment and not is_nil(order.payment_intent_id) do
-      {:noreply, sync_payment_intent(assign(socket, order: order), order)}
+      {:noreply, sync_payment_intent_async(socket, order)}
     else
-      {:noreply, assign(socket, order: order)}
+      {:noreply, socket}
     end
   end
 
@@ -651,6 +653,36 @@ defmodule EdenflowersWeb.CheckoutLive do
   def handle_info({:date_selected, date}, socket) do
     form = AshPhoenix.Form.update_params(socket.assigns.form, &Map.put(&1, "fulfillment_date", date))
     {:noreply, assign(socket, form: form)}
+  end
+
+  # ============
+  # Async Events
+  # ============
+
+  def handle_async(:sync_payment_intent, {:ok, {:ok, _payment_intent}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_async(:sync_payment_intent, {:ok, {:error, reason}}, socket) do
+    Logger.error(
+      "Failed to sync payment intent amount for order #{socket.assigns.order.id}: #{inspect(reason)}"
+    )
+
+    {:noreply, put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
+  end
+
+  # A newer cart change started a fresh sync and cancelled this one. Expected;
+  # the replacement task carries the up-to-date amount.
+  def handle_async(:sync_payment_intent, {:exit, {:shutdown, :cancel}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_async(:sync_payment_intent, {:exit, reason}, socket) do
+    Logger.error(
+      "Sync payment intent task exited for order #{socket.assigns.order.id}: #{inspect(reason)}"
+    )
+
+    {:noreply, put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
   end
 
   # =======
@@ -852,17 +884,16 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   # Re-sync the existing PaymentIntent's amount with the current order total
   # without changing the client_secret (so the already-mounted Elements UI keeps
-  # working).
-  defp sync_payment_intent(socket, order) do
-    case stripe_api().update_payment_intent(order) do
-      {:ok, _payment_intent} ->
-        socket
-
-      {:error, reason} ->
-        Logger.error("Failed to sync payment intent amount for order #{order.id}: #{inspect(reason)}")
-
-        put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")
-    end
+  # working). Runs in a task so the LiveView process isn't blocked on Stripe
+  # while the customer is staring at stale cart totals; result is handled in
+  # handle_async/3 above.
+  #
+  # start_async with the same name cancels any in-flight sync, so back-to-back
+  # cart edits can't leave Stripe at a stale amount via out-of-order responses
+  # — the latest cart-change always wins.
+  defp sync_payment_intent_async(socket, order) do
+    stripe = stripe_api()
+    start_async(socket, :sync_payment_intent, fn -> stripe.update_payment_intent(order) end)
   end
 
   defp stripe_unavailable(socket) do

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -40,6 +40,7 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
        |> assign(:client_secret, nil)
+       |> assign(:payment_syncing, false)
        |> maybe_setup_stripe(order)}
     else
       {:error, :empty_cart} ->
@@ -254,9 +255,21 @@ defmodule EdenflowersWeb.CheckoutLive do
                     <div phx-update="ignore" id="payment-element"></div>
                     <div phx-update="ignore" id="stripe-error-message" class="text-error"></div>
 
-                    <.form_button disabled={true} id="payment-button">
-                      {~t"Pay"} {Edenflowers.Utils.format_money(@order.grand_total)}
-                    </.form_button>
+                    <%!--
+                      The button's own `disabled={true}` is a static literal that
+                      the Stripe hook flips off via DOM mutation once Elements is
+                      ready (see data-stripe-ready). The fieldset below carries
+                      the orthogonal "we're re-syncing the PaymentIntent" state
+                      so the customer can't commit to a charge before the
+                      definitive total is reflected in Stripe — fieldset disabled
+                      cascades to the button without colliding with the hook's
+                      attribute toggling.
+                    --%>
+                    <fieldset disabled={@payment_syncing} class="contents">
+                      <.form_button disabled={true} id="payment-button">
+                        {~t"Pay"} {Edenflowers.Utils.format_money(@order.grand_total)}
+                      </.form_button>
+                    </fieldset>
                   </form>
 
                   <p :if={!@client_secret} class="text-error" data-testid="stripe-unavailable">
@@ -639,8 +652,14 @@ defmodule EdenflowersWeb.CheckoutLive do
     # amount must follow the new total, otherwise `confirmPayment` would charge
     # the previous amount. The Stripe round-trip runs in a task so the new cart
     # totals render immediately — matching the snappiness of earlier steps.
+    # The Pay button is disabled until the sync settles so the customer never
+    # commits to a charge before seeing the definitive total reflected in
+    # Stripe.
     if order.state == :payment and not is_nil(order.payment_intent_id) do
-      {:noreply, sync_payment_intent_async(socket, order)}
+      {:noreply,
+       socket
+       |> assign(:payment_syncing, true)
+       |> sync_payment_intent_async(order)}
     else
       {:noreply, socket}
     end
@@ -660,7 +679,7 @@ defmodule EdenflowersWeb.CheckoutLive do
   # ============
 
   def handle_async(:sync_payment_intent, {:ok, {:ok, _payment_intent}}, socket) do
-    {:noreply, socket}
+    {:noreply, assign(socket, :payment_syncing, false)}
   end
 
   def handle_async(:sync_payment_intent, {:ok, {:error, reason}}, socket) do
@@ -668,11 +687,18 @@ defmodule EdenflowersWeb.CheckoutLive do
       "Failed to sync payment intent amount for order #{socket.assigns.order.id}: #{inspect(reason)}"
     )
 
-    {:noreply, put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
+    # Re-enable the Pay button so the customer can retry — the synchronous
+    # update inside the pay handler will either succeed (this failure was
+    # transient) or surface its own error to them.
+    {:noreply,
+     socket
+     |> assign(:payment_syncing, false)
+     |> put_flash(:error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
   end
 
   # A newer cart change started a fresh sync and cancelled this one. Expected;
-  # the replacement task carries the up-to-date amount.
+  # the replacement task carries the up-to-date amount, so leave :payment_syncing
+  # true — the replacement's handle_async will clear it.
   def handle_async(:sync_payment_intent, {:exit, {:shutdown, :cancel}}, socket) do
     {:noreply, socket}
   end
@@ -682,7 +708,10 @@ defmodule EdenflowersWeb.CheckoutLive do
       "Sync payment intent task exited for order #{socket.assigns.order.id}: #{inspect(reason)}"
     )
 
-    {:noreply, put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
+    {:noreply,
+     socket
+     |> assign(:payment_syncing, false)
+     |> put_flash(:error, ~t"Cart changed but payment couldn't be updated. Please retry.")}
   end
 
   # =======


### PR DESCRIPTION
## Summary

Cart edits during the **payment** step were noticeably slower than during earlier steps. The cause: the `line_item:changed` PubSub handler did a synchronous `Stripe.PaymentIntent.update` round-trip before the LiveView could re-render, so the customer sat on stale totals for the duration of that network call. Earlier steps don't talk to Stripe on cart changes, which is why they feel snappy.

This PR moves that Stripe round-trip into `start_async/3`. New cart totals render immediately; the PaymentIntent amount is reconciled in the background via `handle_async/3`.

## Race conditions considered

1. **Out-of-order responses from two rapid cart edits.** Solved by `start_async/3` semantics: re-using the same task name cancels the in-flight task, so the latest cart-change always wins. (Same pattern used by `AddressInputComponent` for address lookups in this codebase.)
2. **Customer clicks Pay while a sync is in-flight.** The `pay` handler at `checkout_live.ex:568` still does its own *synchronous* `update_payment_intent` against `socket.assigns.order` before pushing `stripe:process_payment` to the JS hook. `socket.assigns.order` is updated to the latest in `handle_info` before the async task starts, so the pay click can never charge a stale amount — even if the background sync is mid-flight or hasn't started yet.
3. **Cancelled task arriving at `handle_async/3`.** Matched explicitly as `{:exit, {:shutdown, :cancel}}` and ignored, so cancellation doesn't surface as an error flash.

## What's *not* changed

- The `pay` handler's synchronous Stripe call (line 568) is intentionally left alone — clicking Pay is a deliberate action where blocking on Stripe is acceptable, and the synchronous call is what keeps race #2 safe.

## Test plan

- [ ] Manual: load the payment step, change cart from another tab / the cart drawer, confirm totals redraw without the Stripe-latency pause.
- [ ] Manual: change the cart twice in rapid succession on the payment step; confirm the final Stripe PaymentIntent matches the final cart total.
- [ ] Manual: simulate a Stripe failure on `update_payment_intent` (e.g. via mock); confirm the error flash appears.
- [ ] `mix test test/edenflowers_web/live/checkout_happy_path_test.exs` (couldn't run locally — no Elixir toolchain in this remote env).
- [ ] `mix test test/edenflowers_web/live/checkout_live_test.exs`.

https://claude.ai/code/session_01SUYdKZhPZZnCvM5whdz1J1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUYdKZhPZZnCvM5whdz1J1)_