### PR TITLE
Drop redundant PaymentIntent sync on cart-change broadcast

### DIFF
--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -630,18 +630,12 @@ defmodule EdenflowersWeb.CheckoutLive do
   # Info Events
   # ===========
 
+  # No PaymentIntent sync here: the `pay` handler updates the amount
+  # synchronously before pushing `stripe:process_payment`, so Stripe always
+  # charges the cart total at the moment of click.
   def handle_info(%Phoenix.Socket.Broadcast{topic: "line_item:changed:" <> _}, socket) do
-    actor = actor(socket)
-    order = Order.get_for_checkout!(socket.assigns.order.id, actor: actor)
-
-    # Cart changed while the customer is on the payment step. The PaymentIntent's
-    # amount must follow the new total, otherwise `confirmPayment` would charge
-    # the previous amount.
-    if order.state == :payment and not is_nil(order.payment_intent_id) do
-      {:noreply, sync_payment_intent(assign(socket, order: order), order)}
-    else
-      {:noreply, assign(socket, order: order)}
-    end
+    order = Order.get_for_checkout!(socket.assigns.order.id, actor: actor(socket))
+    {:noreply, assign(socket, order: order)}
   end
 
   def handle_info(%Phoenix.Socket.Broadcast{topic: "order:checkout_restarted:" <> _}, socket) do
@@ -858,21 +852,6 @@ defmodule EdenflowersWeb.CheckoutLive do
         Logger.error("Failed to persist payment_intent_id for order #{order.id}: #{inspect(reason)}")
 
         stripe_unavailable(socket)
-    end
-  end
-
-  # Re-sync the existing PaymentIntent's amount with the current order total
-  # without changing the client_secret (so the already-mounted Elements UI keeps
-  # working).
-  defp sync_payment_intent(socket, order) do
-    case stripe_api().update_payment_intent(order) do
-      {:ok, _payment_intent} ->
-        socket
-
-      {:error, reason} ->
-        Logger.error("Failed to sync payment intent amount for order #{order.id}: #{inspect(reason)}")
-
-        put_flash(socket, :error, ~t"Cart changed but payment couldn't be updated. Please retry.")
     end
   end
 


### PR DESCRIPTION
## Summary

- Removes the `sync_payment_intent` call from the `line_item:changed` broadcast handler, and deletes the helper.
- The `pay` handler already runs `update_payment_intent` synchronously before pushing `stripe:process_payment` to the hook. That call is what Stripe sees at the moment of `confirmPayment`, so the broadcast-time sync was always overwritten and never affected the charged amount.
- Net change: −24 lines, +6 lines (one new comment in the broadcast handler explaining why the sync isn't there, so a future reader doesn't add it back as a "missing safety net").

## Background

This replaces the closed #216, which tried to make the broadcast-triggered sync async (`start_async` + `:payment_syncing` flag + four `handle_async` clauses). Reviewing that change surfaced two correctness gaps (server-side `pay` race; error flashes on non-payment steps) that turned out to be load-bearing parts of the async design rather than fixable nits.

Stepping back, the question became: what is the broadcast-triggered sync actually buying us? Walking through the flow:

1. User clicks Pay
2. Server-side `pay` handler calls `update_payment_intent(order)` — sets the amount on Stripe to the current order total
3. Server pushes `stripe:process_payment` to the hook
4. Hook calls `stripe.confirmPayment(...)` — uses whatever amount Stripe has *now* (i.e., what step 2 just set)

The amount Stripe charges is decided in steps 2–4 (~200ms window). Any earlier sync — including one triggered by a cart-change broadcast — is overwritten before `confirmPayment` runs. The broadcast sync's only effect was to surface Stripe errors slightly earlier, at the cost of confusing flashes the customer can't act on (e.g. "Cart changed but payment couldn't be updated" arriving while they're not even looking at the payment step in a multi-tab scenario).

## What this changes

- `handle_info(%Phoenix.Socket.Broadcast{topic: "line_item:changed:" <> _}, ...)` — now just refreshes the order assign, no Stripe call
- `sync_payment_intent/2` — deleted
- A short comment on the broadcast handler names where the load-bearing sync lives

## What this does not change

- `pay` handler behaviour: unchanged. The synchronous `update_payment_intent` there is the only sync, and it's the one that decides the charged amount.
- Stripe Elements UI lifecycle: unchanged.
- Test suite: all 311 tests still pass.

## Test plan

- [x] `mix test` — 311 passing
- [x] Manually exercise the multi-tab cart-change-on-payment-step scenario: cart total updates instantly in the sidebar; Pay button still charges the correct amount.
- [x] Reviewer to sanity-check the reasoning above and confirm we're comfortable losing the early-error-surfacing behaviour.