### PR TITLE
Delay loading indicators (submit spinner 250ms, disconnect banner 1.5s)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -145,31 +145,9 @@ summary {
   top: 0.5rem;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  /* Dim everything body-level (header, main, drawers) in lockstep, but keep
-     the flash group crisp so the "Disconnected" toast stays readable. */
-  body > *:not(#flash-group) {
-    transition: opacity 200ms ease-out 0ms;
-  }
-  /* 400ms delay before dimming so sub-400ms socket flaps stay invisible;
-     un-dim is immediate (no delay) when the class is removed. */
-  .phx-loading body > *:not(#flash-group),
-  .phx-click-loading body > *:not(#flash-group) {
-    opacity: 0.7;
-    transition-delay: 400ms;
-  }
-  .phx-submit-loading [type="submit"],
-  .phx-submit-loading button[phx-click] {
-    cursor: progress;
-  }
-}
-
-/* Gate clicks during reconnect/loading so a tap on a CTA mid-flap doesn't
-   queue an ambiguous action. Keyboard focus and scrolling are unaffected;
-   the flash group stays interactive so toasts can be dismissed. */
-.phx-loading body > *:not(#flash-group),
-.phx-click-loading body > *:not(#flash-group) {
-  pointer-events: none;
+.phx-submit-loading [type="submit"],
+.phx-submit-loading button[phx-click] {
+  cursor: progress;
 }
 
 /* FOUC fix: https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/ */

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -744,29 +744,40 @@ Hooks.FlashHandler = {
   },
 
   disconnected() {
-    if (document.getElementById("flash-disconnected")) return;
-    const msg = this.el.getAttribute("data-disconnected-message");
-    const div = document.createElement("div");
-    div.id = "flash-disconnected";
-    div.className = "toast-item";
-    div.dataset.key = "warning";
-    // role="alert" implies aria-live="assertive" but some AT/browser combos
-    // miss it on dynamically-added nodes — set both explicitly.
-    div.setAttribute("role", "alert");
-    div.setAttribute("aria-live", "assertive");
-    div.setAttribute("aria-atomic", "true");
-    div.innerHTML = `
-      <div class="toast-item__head">
-        <p class="toast-item__eyebrow">Notice</p>
-      </div>
-      <p class="toast-item__body"></p>`;
-    // Note: the disconnected banner has no dismiss button — it's auto-removed
-    // when the socket reconnects (see reconnected() below).
-    div.querySelector(".toast-item__body").textContent = msg;
-    this.el.appendChild(div);
+    if (this.disconnectedTimer || document.getElementById("flash-disconnected"))
+      return;
+    // Sub-1.5s socket flaps stay invisible — most reconnects happen
+    // before this fires, so we never flash the banner.
+    this.disconnectedTimer = setTimeout(() => {
+      this.disconnectedTimer = null;
+      if (document.getElementById("flash-disconnected")) return;
+      const msg = this.el.getAttribute("data-disconnected-message");
+      const div = document.createElement("div");
+      div.id = "flash-disconnected";
+      div.className = "toast-item";
+      div.dataset.key = "warning";
+      // role="alert" implies aria-live="assertive" but some AT/browser combos
+      // miss it on dynamically-added nodes — set both explicitly.
+      div.setAttribute("role", "alert");
+      div.setAttribute("aria-live", "assertive");
+      div.setAttribute("aria-atomic", "true");
+      div.innerHTML = `
+        <div class="toast-item__head">
+          <p class="toast-item__eyebrow">Notice</p>
+        </div>
+        <p class="toast-item__body"></p>`;
+      // Note: the disconnected banner has no dismiss button — it's auto-removed
+      // when the socket reconnects (see reconnected() below).
+      div.querySelector(".toast-item__body").textContent = msg;
+      this.el.appendChild(div);
+    }, 1500);
   },
 
   reconnected() {
+    if (this.disconnectedTimer) {
+      clearTimeout(this.disconnectedTimer);
+      this.disconnectedTimer = null;
+    }
     const banner = document.getElementById("flash-disconnected");
     if (!banner) return;
     this.dismiss(banner, null);

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -364,7 +364,8 @@ defmodule EdenflowersWeb.CheckoutLive do
       class="btn btn-primary btn-lg mt-2 flex flex-row gap-2 phx-submit-loading:btn-disabled"
     >
       <span>{render_slot(@inner_block)}</span>
-      <span class="phx-submit-loading:loading-spinner phx-submit-loading:loading"></span>
+      <%!-- 250ms gate so sub-threshold submits never flash a spinner. --%>
+      <span class="phx-submit-loading:loading-spinner phx-submit-loading:loading opacity-0 transition-opacity duration-0 phx-submit-loading:opacity-100 phx-submit-loading:delay-[250ms]"></span>
     </button>
     """
   end


### PR DESCRIPTION
## Summary

Defer loading indicators so sub-threshold delays don't flash UI. Same principle as the existing topbar gate (300ms).

**Submit spinner — 250ms gate** (`checkout_live.ex:367`)
- `opacity-0` by default with zero-duration transition (removal is instant)
- `phx-submit-loading:opacity-100` + `phx-submit-loading:delay-[250ms]` apply only while the form has `.phx-submit-loading`
- Appearing → 250ms delay → snap; disappearing → no delay → instant

**Disconnect banner — 1500ms gate** (`hooks.js` FlashHandler)
- `disconnected()` now sets a 1.5s timer instead of inserting the banner immediately
- `reconnected()` clears the pending timer; if the socket recovers in-window the banner never renders
- Most network blips clear well under 1.5s

**Dropped the loading dim + click gate** (`app.css`)
- The 0.7 opacity fade and `pointer-events: none` that fired on `.phx-loading` / `.phx-click-loading` are gone — with the disconnect banner now gated at 1.5s, the 400ms dim contradicted the same principle
- Kept `cursor: progress` on submit buttons

| Indicator | Gate | Where |
|---|---|---|
| Topbar (page nav) | 300ms | `app.js:43` (existing) |
| Submit spinner | 250ms | `checkout_live.ex:367` (this PR) |
| Disconnect banner | 1500ms | `hooks.js` FlashHandler (this PR) |
| ~~Body dim~~ | ~~400ms~~ | removed (this PR) |
| ~~Click gate~~ | ~~immediate~~ | removed (this PR) |

Per the article linked in the issue: https://fly.io/phoenix-files/make-your-liveview-feel-faster/

Closes #226

## Test plan

- [ ] Submit a quick local-only step in checkout — submit spinner does not flash
- [ ] Throttle network in DevTools and submit — spinner appears after ~250ms
- [ ] Stop the server briefly (<1.5s) and restart — disconnect banner does not flash
- [ ] Stop the server >1.5s — banner appears; on restart, banner dismisses and screen reader hears "Reconnected"
- [ ] Confirm page no longer dims during reconnect