### PR TITLE
Fill Contact page with static shop details

### DIFF
--- a/lib/edenflowers_web/components/layouts.ex
+++ b/lib/edenflowers_web/components/layouts.ex
@@ -369,9 +369,9 @@ defmodule EdenflowersWeb.Layouts do
             </div>
 
             <div class="footer-grid__location space-y-2">
-              <h3 class="eyebrow text-base-content/60">Minimosen</h3>
-              <p class="footer-line whitespace-nowrap">Kauppapuistikko 21</p>
-              <p class="footer-line whitespace-nowrap">65100 Vaasa</p>
+              <h3 class="eyebrow text-base-content/60">Minimossen</h3>
+              <p class="footer-line whitespace-nowrap">{~t"Myrvägen 1"}</p>
+              <p class="footer-line whitespace-nowrap">{~t"65230 Vasa"}</p>
             </div>
 
             <div class="footer-grid__hours space-y-2">

--- a/lib/edenflowers_web/live/contact_live.ex
+++ b/lib/edenflowers_web/live/contact_live.ex
@@ -11,7 +11,55 @@ defmodule EdenflowersWeb.ContactLive do
     ~H"""
     <Layouts.app current_user={@current_user} order={@order} flash={@flash} current_path={@current_path}>
       <.container>
-        <h1 class="page-title">{~t"Contact"}</h1>
+        <h1 class="page-title mb-16 md:mb-20">{~t"Contact"}</h1>
+
+        <div class="max-w-3xl space-y-12">
+          <p class="text-base-content/80 text-lg">
+            {~t"Got a question, a special request, or want to talk through an arrangement? Reach us by email or phone, or stop by the shop during opening hours."}
+          </p>
+
+          <dl class="grid grid-cols-1 gap-10 sm:grid-cols-2">
+            <div class="space-y-2">
+              <dt class="eyebrow text-base-content/60">{~t"Email"}</dt>
+              <dd>
+                <a class="footer-line link-underline-hover-nav" href="mailto:info@edenflowers.fi">
+                  info@edenflowers.fi
+                </a>
+              </dd>
+            </div>
+
+            <div class="space-y-2">
+              <dt class="eyebrow text-base-content/60">{~t"Phone"}</dt>
+              <dd>
+                <a class="footer-line link-underline-hover-nav" href="tel:+358402209494">
+                  040 220 9494
+                </a>
+              </dd>
+            </div>
+
+            <div class="space-y-2">
+              <dt class="eyebrow text-base-content/60">{~t"Address"}</dt>
+              <dd class="not-italic">
+                <address class="space-y-1 not-italic">
+                  <p class="footer-line">Minimossen</p>
+                  <p class="footer-line">{~t"Myrvägen 1"}</p>
+                  <p class="footer-line">{~t"65230 Vasa"}</p>
+                </address>
+              </dd>
+            </div>
+
+            <div class="space-y-2">
+              <dt class="eyebrow text-base-content/60">{~t"Opening hours"}</dt>
+              <dd>
+                <ul class="space-y-1">
+                  <li class="footer-line">{~t"Mon–Fri: 09:00–17:00"}</li>
+                  <li class="footer-line">{~t"Sat: 10:00–15:00"}</li>
+                  <li class="footer-line">{~t"Sun: closed"}</li>
+                </ul>
+              </dd>
+            </div>
+          </dl>
+        </div>
       </.container>
     </Layouts.app>
     """

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,19 +11,19 @@
 msgid ""
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:526
+#: lib/edenflowers_web/components/core_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:153
-#: lib/edenflowers_web/components/layouts.ex:392
+#: lib/edenflowers_web/components/layouts.ex:164
+#: lib/edenflowers_web/components/layouts.ex:403
 #: lib/edenflowers_web/live/about_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:42
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr ""
@@ -35,72 +35,72 @@ msgstr ""
 
 #: lib/edenflowers_web/components/cart_drawer_component.ex:20
 #: lib/edenflowers_web/components/cart_drawer_component.ex:22
-#: lib/edenflowers_web/components/layouts.ex:330
-#: lib/edenflowers_web/components/layouts.ex:332
-#: lib/edenflowers_web/live/checkout_live.ex:358
+#: lib/edenflowers_web/components/layouts.ex:341
+#: lib/edenflowers_web/components/layouts.ex:343
+#: lib/edenflowers_web/live/checkout_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:152
+#: lib/edenflowers_web/components/layouts.ex:163
 #: lib/edenflowers_web/live/condolences_live.ex:14
 #: lib/edenflowers_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:154
-#: lib/edenflowers_web/components/layouts.ex:387
+#: lib/edenflowers_web/components/layouts.ex:165
+#: lib/edenflowers_web/components/layouts.ex:398
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:150
+#: lib/edenflowers_web/components/layouts.ex:161
 #: lib/edenflowers_web/live/courses_live.ex:25
 #: lib/edenflowers_web/live/home_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:374
-#: lib/edenflowers_web/live/checkout_live.ex:695
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:122
+#: lib/edenflowers_web/components/checkout_components.ex:135
+#: lib/edenflowers_web/live/checkout_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:390
+#: lib/edenflowers_web/live/checkout_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:379
+#: lib/edenflowers_web/live/checkout_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:96
+#: lib/edenflowers_web/components/calendar_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:76
+#: lib/edenflowers_web/components/calendar_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:149
+#: lib/edenflowers_web/components/layouts.ex:160
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:406
+#: lib/edenflowers_web/live/checkout_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:151
+#: lib/edenflowers_web/components/layouts.ex:162
 #: lib/edenflowers_web/live/home_live.ex:148
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Fresh flowers for everyday moments"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:236
+#: lib/edenflowers_web/components/layouts.ex:247
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr ""
@@ -129,23 +129,23 @@ msgstr ""
 msgid "Checkout"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:696
+#: lib/edenflowers_web/components/checkout_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:772
+#: lib/edenflowers_web/live/checkout_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:292
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:303
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:423
+#: lib/edenflowers_web/components/layouts.ex:434
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr ""
@@ -160,12 +160,12 @@ msgstr ""
 msgid "Decrement"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:276
+#: lib/edenflowers_web/live/checkout_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Delivery Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:236
+#: lib/edenflowers_web/live/checkout_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Delivery Method *"
 msgstr ""
@@ -180,12 +180,13 @@ msgstr ""
 msgid "Do you offer subscription services?"
 msgstr ""
 
+#: lib/edenflowers_web/live/contact_live.ex:23
 #: lib/edenflowers_web/otp_sign_in_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:96
+#: lib/edenflowers_web/live/checkout_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr ""
@@ -216,7 +217,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:247
+#: lib/edenflowers_web/components/layouts.ex:258
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr ""
@@ -226,27 +227,27 @@ msgstr ""
 msgid "Order #1234"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:43
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:344
+#: lib/edenflowers_web/live/checkout_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:278
+#: lib/edenflowers_web/live/checkout_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:123
+#: lib/edenflowers_web/live/checkout_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:134
+#: lib/edenflowers_web/live/checkout_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr ""
@@ -257,8 +258,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:293
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr ""
@@ -273,7 +274,7 @@ msgstr ""
 msgid "Sign in to your account"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:44
+#: lib/edenflowers/fulfillments.ex:45
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr ""
@@ -293,7 +294,7 @@ msgstr ""
 msgid "What is your delivery policy?"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:90
+#: lib/edenflowers_web/live/checkout_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr ""
@@ -324,12 +325,12 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:268
+#: lib/edenflowers_web/live/checkout_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:771
+#: lib/edenflowers_web/live/checkout_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Address *"
 msgstr ""
@@ -339,7 +340,7 @@ msgstr ""
 msgid "As a welcome gift, here is your 15% off promo code for your first order:"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:152
+#: lib/edenflowers_web/live/checkout_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
@@ -354,17 +355,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:170
+#: lib/edenflowers_web/live/checkout_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:260
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Delivery Instructions"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:678
+#: lib/edenflowers_web/components/checkout_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -379,7 +380,7 @@ msgstr ""
 msgid "Error loading checkout"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fulfillment date cannot be in the past"
 msgstr ""
@@ -399,40 +400,40 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:906
+#: lib/edenflowers_web/live/checkout_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:905
+#: lib/edenflowers_web/live/checkout_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:102
-#: lib/edenflowers_web/live/checkout_live.ex:221
-#: lib/edenflowers_web/live/checkout_live.ex:318
+#: lib/edenflowers_web/live/checkout_live.ex:104
+#: lib/edenflowers_web/live/checkout_live.ex:144
+#: lib/edenflowers_web/live/checkout_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:496
+#: lib/edenflowers_web/live/checkout_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:186
-#: lib/edenflowers_web/live/checkout_live.ex:189
+#: lib/edenflowers_web/live/checkout_live.ex:422
+#: lib/edenflowers_web/live/checkout_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Remove card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:426
+#: lib/edenflowers_web/live/checkout_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:904
+#: lib/edenflowers_web/live/checkout_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -452,7 +453,7 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/email.ex:56
+#: lib/edenflowers/email.ex:54
 #, elixir-autogen, elixir-format
 msgid "Welcome back to the Eden Flowers newsletter"
 msgstr ""
@@ -462,7 +463,7 @@ msgstr ""
 msgid "Welcome back to the Eden Flowers newsletter!"
 msgstr ""
 
-#: lib/edenflowers/email.ex:40
+#: lib/edenflowers/email.ex:38
 #, elixir-autogen, elixir-format
 msgid "Welcome to Eden Flowers — your 15% off code inside"
 msgstr ""
@@ -487,7 +488,7 @@ msgstr ""
 msgid "Your 15% off welcome code is still valid — here it is again:"
 msgstr ""
 
-#: lib/edenflowers/email.ex:48
+#: lib/edenflowers/email.ex:46
 #, elixir-autogen, elixir-format
 msgid "Your Eden Flowers promo code"
 msgstr ""
@@ -502,22 +503,22 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:263
+#: lib/edenflowers_web/live/checkout_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:764
+#: lib/edenflowers_web/live/checkout_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:765
+#: lib/edenflowers_web/live/checkout_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:41
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr ""
@@ -537,12 +538,13 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:368
+#: lib/edenflowers_web/components/layouts.ex:379
+#: lib/edenflowers_web/live/contact_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:399
+#: lib/edenflowers_web/components/layouts.ex:410
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
@@ -562,12 +564,7 @@ msgstr ""
 msgid "Browse bouquets"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:965
-#, elixir-autogen, elixir-format
-msgid "Cart changed but payment couldn't be updated. Please retry."
-msgstr ""
-
-#: lib/edenflowers_web/components/core_components.ex:1044
+#: lib/edenflowers_web/components/core_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Cart, empty"
 msgstr ""
@@ -582,7 +579,7 @@ msgstr ""
 msgid "Close cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:176
+#: lib/edenflowers_web/components/layouts.ex:187
 #, elixir-autogen, elixir-format
 msgid "Close navigation menu"
 msgstr ""
@@ -632,14 +629,14 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:575
+#: lib/edenflowers_web/live/checkout_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please refresh the page and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:349
-#: lib/edenflowers_web/live/checkout_live.ex:486
-#: lib/edenflowers_web/live/checkout_live.ex:972
+#: lib/edenflowers_web/live/checkout_live.ex:255
+#: lib/edenflowers_web/live/checkout_live.ex:560
+#: lib/edenflowers_web/live/checkout_live.ex:856
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please try again in a moment."
 msgstr ""
@@ -689,7 +686,7 @@ msgstr ""
 msgid "Eden Flowers' arrangements last 5–7 days with proper care. Change the water every 2–3 days, trim the stems, and keep them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:382
+#: lib/edenflowers_web/components/layouts.ex:393
 #, elixir-autogen, elixir-format
 msgid "FAQ"
 msgstr ""
@@ -699,23 +696,23 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:707
+#: lib/edenflowers_web/components/checkout_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "For %{name}"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
-#: lib/edenflowers_web/live/checkout_live.ex:706
+#: lib/edenflowers_web/components/checkout_components.ex:129
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For me"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For somebody else"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:885
+#: lib/edenflowers_web/components/core_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
@@ -725,7 +722,7 @@ msgstr ""
 msgid "Get 15% off your first order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:694
+#: lib/edenflowers_web/components/checkout_components.ex:121
 #, elixir-autogen, elixir-format
 msgid "Gift options"
 msgstr ""
@@ -735,7 +732,7 @@ msgstr ""
 msgid "Have a question?"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:378
+#: lib/edenflowers_web/components/layouts.ex:389
 #, elixir-autogen, elixir-format
 msgid "Help"
 msgstr ""
@@ -745,7 +742,7 @@ msgstr ""
 msgid "If you're not in, the flowers will be left in a safe, shaded spot. If no suitable spot is available, a note with redelivery instructions will be left. You can also specify delivery instructions during checkout."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Incl. VAT"
 msgstr ""
@@ -775,7 +772,7 @@ msgstr ""
 msgid "Only occasional emails — unsubscribe at any time."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Pickup"
 msgstr ""
@@ -796,7 +793,7 @@ msgstr ""
 msgid "See the FAQ"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:217
+#: lib/edenflowers_web/live/checkout_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Select a card"
 msgstr ""
@@ -851,7 +848,7 @@ msgstr ""
 msgid "Your account"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:693
+#: lib/edenflowers_web/components/checkout_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Your details"
 msgstr ""
@@ -866,7 +863,7 @@ msgstr ""
 msgid "Browse the store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:698
+#: lib/edenflowers_web/components/checkout_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -876,7 +873,7 @@ msgstr ""
 msgid "Continue with Google"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:699
+#: lib/edenflowers_web/components/checkout_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Current step"
 msgstr ""
@@ -931,7 +928,7 @@ msgstr ""
 msgid "Too many requests. Please wait a few minutes and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:700
+#: lib/edenflowers_web/components/checkout_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
@@ -971,7 +968,7 @@ msgstr ""
 msgid "We've sent you a new code."
 msgstr ""
 
-#: lib/edenflowers/email.ex:64
+#: lib/edenflowers/email.ex:62
 #, elixir-autogen, elixir-format
 msgid "Your Eden Flowers sign-in code"
 msgstr ""
@@ -981,7 +978,7 @@ msgstr ""
 msgid "Your receipt is attached to this email. If you need to change anything, just reply and I'll take care of it."
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:87
+#: lib/edenflowers_web/components/calendar_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "go to current month"
 msgstr ""
@@ -991,7 +988,7 @@ msgstr ""
 msgid "info@edenflowers.fi"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:230
+#: lib/edenflowers_web/components/calendar_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "not available"
 msgstr ""
@@ -1001,13 +998,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:229
-#: lib/edenflowers_web/components/calendar_component.ex:247
+#: lib/edenflowers_web/components/calendar_component.ex:392
+#: lib/edenflowers_web/components/calendar_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "selected"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:228
+#: lib/edenflowers_web/components/calendar_component.ex:391
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
@@ -1015,4 +1012,76 @@ msgstr ""
 #: lib/edenflowers_web/otp_sign_in_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "🥳 A sign-in code was sent to %{email}."
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:374
+#: lib/edenflowers_web/live/contact_live.ex:46
+#, elixir-autogen, elixir-format
+msgid "65230 Vasa"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:41
+#, elixir-autogen, elixir-format
+msgid "Address"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:18
+#, elixir-autogen, elixir-format
+msgid "Got a question, a special request, or want to talk through an arrangement? Reach us by email or phone, or stop by the shop during opening hours."
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Mon–Fri: 09:00–17:00"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:373
+#: lib/edenflowers_web/live/contact_live.ex:45
+#, elixir-autogen, elixir-format
+msgid "Myrvägen 1"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:32
+#, elixir-autogen, elixir-format
+msgid "Phone"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:39
+#, elixir-autogen, elixir-format
+msgid "Same-day fulfillment is not available"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Sat: 10:00–15:00"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Sun: closed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:40
+#, elixir-autogen, elixir-format
+msgid "The order deadline for today has passed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:41
+#, elixir-autogen, elixir-format
+msgid "This date is no longer available, please choose another"
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:377
+#, elixir-autogen, elixir-format
+msgid "Toggle "
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:383
+#, elixir-autogen, elixir-format
+msgid "Toggle week"
+msgstr ""
+
+#: lib/edenflowers_web/live_user_auth.ex:57
+#, elixir-autogen, elixir-format
+msgid "You must sign in to access this page."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:526
+#: lib/edenflowers_web/components/core_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:153
-#: lib/edenflowers_web/components/layouts.ex:392
+#: lib/edenflowers_web/components/layouts.ex:164
+#: lib/edenflowers_web/components/layouts.ex:403
 #: lib/edenflowers_web/live/about_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:42
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr ""
@@ -35,72 +35,72 @@ msgstr ""
 
 #: lib/edenflowers_web/components/cart_drawer_component.ex:20
 #: lib/edenflowers_web/components/cart_drawer_component.ex:22
-#: lib/edenflowers_web/components/layouts.ex:330
-#: lib/edenflowers_web/components/layouts.ex:332
-#: lib/edenflowers_web/live/checkout_live.ex:358
+#: lib/edenflowers_web/components/layouts.ex:341
+#: lib/edenflowers_web/components/layouts.ex:343
+#: lib/edenflowers_web/live/checkout_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:152
+#: lib/edenflowers_web/components/layouts.ex:163
 #: lib/edenflowers_web/live/condolences_live.ex:14
 #: lib/edenflowers_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:154
-#: lib/edenflowers_web/components/layouts.ex:387
+#: lib/edenflowers_web/components/layouts.ex:165
+#: lib/edenflowers_web/components/layouts.ex:398
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:150
+#: lib/edenflowers_web/components/layouts.ex:161
 #: lib/edenflowers_web/live/courses_live.ex:25
 #: lib/edenflowers_web/live/home_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:374
-#: lib/edenflowers_web/live/checkout_live.ex:695
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:122
+#: lib/edenflowers_web/components/checkout_components.ex:135
+#: lib/edenflowers_web/live/checkout_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:390
+#: lib/edenflowers_web/live/checkout_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:379
+#: lib/edenflowers_web/live/checkout_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:96
+#: lib/edenflowers_web/components/calendar_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:76
+#: lib/edenflowers_web/components/calendar_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:149
+#: lib/edenflowers_web/components/layouts.ex:160
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:406
+#: lib/edenflowers_web/live/checkout_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:151
+#: lib/edenflowers_web/components/layouts.ex:162
 #: lib/edenflowers_web/live/home_live.ex:148
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Fresh flowers for everyday moments"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:236
+#: lib/edenflowers_web/components/layouts.ex:247
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr ""
@@ -129,23 +129,23 @@ msgstr ""
 msgid "Checkout"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:696
+#: lib/edenflowers_web/components/checkout_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:772
+#: lib/edenflowers_web/live/checkout_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:292
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:303
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:423
+#: lib/edenflowers_web/components/layouts.ex:434
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr ""
@@ -160,12 +160,12 @@ msgstr ""
 msgid "Decrement"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:276
+#: lib/edenflowers_web/live/checkout_live.ex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:236
+#: lib/edenflowers_web/live/checkout_live.ex:159
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr ""
@@ -180,12 +180,13 @@ msgstr ""
 msgid "Do you offer subscription services?"
 msgstr ""
 
+#: lib/edenflowers_web/live/contact_live.ex:23
 #: lib/edenflowers_web/otp_sign_in_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:96
+#: lib/edenflowers_web/live/checkout_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr ""
@@ -216,7 +217,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:247
+#: lib/edenflowers_web/components/layouts.ex:258
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr ""
@@ -226,27 +227,27 @@ msgstr ""
 msgid "Order #1234"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:43
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:344
+#: lib/edenflowers_web/live/checkout_live.ex:250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:278
+#: lib/edenflowers_web/live/checkout_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:123
+#: lib/edenflowers_web/live/checkout_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:134
+#: lib/edenflowers_web/live/checkout_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr ""
@@ -257,8 +258,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:293
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr ""
@@ -273,7 +274,7 @@ msgstr ""
 msgid "Sign in to your account"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:44
+#: lib/edenflowers/fulfillments.ex:45
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr ""
@@ -293,7 +294,7 @@ msgstr ""
 msgid "What is your delivery policy?"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:90
+#: lib/edenflowers_web/live/checkout_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr ""
@@ -324,12 +325,12 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:268
+#: lib/edenflowers_web/live/checkout_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:771
+#: lib/edenflowers_web/live/checkout_live.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr ""
@@ -339,7 +340,7 @@ msgstr ""
 msgid "As a welcome gift, here is your 15% off promo code for your first order:"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:152
+#: lib/edenflowers_web/live/checkout_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
@@ -354,17 +355,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:170
+#: lib/edenflowers_web/live/checkout_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:260
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:678
+#: lib/edenflowers_web/components/checkout_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -379,7 +380,7 @@ msgstr ""
 msgid "Error loading checkout"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fulfillment date cannot be in the past"
 msgstr ""
@@ -399,40 +400,40 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:906
+#: lib/edenflowers_web/live/checkout_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:905
+#: lib/edenflowers_web/live/checkout_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:102
-#: lib/edenflowers_web/live/checkout_live.ex:221
-#: lib/edenflowers_web/live/checkout_live.ex:318
+#: lib/edenflowers_web/live/checkout_live.ex:104
+#: lib/edenflowers_web/live/checkout_live.ex:144
+#: lib/edenflowers_web/live/checkout_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:496
+#: lib/edenflowers_web/live/checkout_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:186
-#: lib/edenflowers_web/live/checkout_live.ex:189
+#: lib/edenflowers_web/live/checkout_live.ex:422
+#: lib/edenflowers_web/live/checkout_live.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:426
+#: lib/edenflowers_web/live/checkout_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:904
+#: lib/edenflowers_web/live/checkout_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -452,7 +453,7 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/email.ex:56
+#: lib/edenflowers/email.ex:54
 #, elixir-autogen, elixir-format
 msgid "Welcome back to the Eden Flowers newsletter"
 msgstr ""
@@ -462,7 +463,7 @@ msgstr ""
 msgid "Welcome back to the Eden Flowers newsletter!"
 msgstr ""
 
-#: lib/edenflowers/email.ex:40
+#: lib/edenflowers/email.ex:38
 #, elixir-autogen, elixir-format
 msgid "Welcome to Eden Flowers — your 15% off code inside"
 msgstr ""
@@ -487,7 +488,7 @@ msgstr ""
 msgid "Your 15% off welcome code is still valid — here it is again:"
 msgstr ""
 
-#: lib/edenflowers/email.ex:48
+#: lib/edenflowers/email.ex:46
 #, elixir-autogen, elixir-format
 msgid "Your Eden Flowers promo code"
 msgstr ""
@@ -502,22 +503,22 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:263
+#: lib/edenflowers_web/live/checkout_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:764
+#: lib/edenflowers_web/live/checkout_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:765
+#: lib/edenflowers_web/live/checkout_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:41
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Delivery address required"
@@ -537,12 +538,13 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:368
+#: lib/edenflowers_web/components/layouts.ex:379
+#: lib/edenflowers_web/live/contact_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:399
+#: lib/edenflowers_web/components/layouts.ex:410
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
@@ -562,12 +564,7 @@ msgstr ""
 msgid "Browse bouquets"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:965
-#, elixir-autogen, elixir-format
-msgid "Cart changed but payment couldn't be updated. Please retry."
-msgstr ""
-
-#: lib/edenflowers_web/components/core_components.ex:1044
+#: lib/edenflowers_web/components/core_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Cart, empty"
 msgstr ""
@@ -582,7 +579,7 @@ msgstr ""
 msgid "Close cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:176
+#: lib/edenflowers_web/components/layouts.ex:187
 #, elixir-autogen, elixir-format
 msgid "Close navigation menu"
 msgstr ""
@@ -632,14 +629,14 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:575
+#: lib/edenflowers_web/live/checkout_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please refresh the page and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:349
-#: lib/edenflowers_web/live/checkout_live.ex:486
-#: lib/edenflowers_web/live/checkout_live.ex:972
+#: lib/edenflowers_web/live/checkout_live.ex:255
+#: lib/edenflowers_web/live/checkout_live.ex:560
+#: lib/edenflowers_web/live/checkout_live.ex:856
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please try again in a moment."
 msgstr ""
@@ -689,7 +686,7 @@ msgstr ""
 msgid "Eden Flowers' arrangements last 5–7 days with proper care. Change the water every 2–3 days, trim the stems, and keep them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:382
+#: lib/edenflowers_web/components/layouts.ex:393
 #, elixir-autogen, elixir-format
 msgid "FAQ"
 msgstr ""
@@ -699,23 +696,23 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:707
+#: lib/edenflowers_web/components/checkout_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "For %{name}"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
-#: lib/edenflowers_web/live/checkout_live.ex:706
+#: lib/edenflowers_web/components/checkout_components.ex:129
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For me"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For somebody else"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:885
+#: lib/edenflowers_web/components/core_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
@@ -725,7 +722,7 @@ msgstr ""
 msgid "Get 15% off your first order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:694
+#: lib/edenflowers_web/components/checkout_components.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Gift options"
 msgstr ""
@@ -735,7 +732,7 @@ msgstr ""
 msgid "Have a question?"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:378
+#: lib/edenflowers_web/components/layouts.ex:389
 #, elixir-autogen, elixir-format
 msgid "Help"
 msgstr ""
@@ -745,7 +742,7 @@ msgstr ""
 msgid "If you're not in, the flowers will be left in a safe, shaded spot. If no suitable spot is available, a note with redelivery instructions will be left. You can also specify delivery instructions during checkout."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Incl. VAT"
 msgstr ""
@@ -775,7 +772,7 @@ msgstr ""
 msgid "Only occasional emails — unsubscribe at any time."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pickup"
 msgstr ""
@@ -796,7 +793,7 @@ msgstr ""
 msgid "See the FAQ"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:217
+#: lib/edenflowers_web/live/checkout_live.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a card"
 msgstr ""
@@ -851,7 +848,7 @@ msgstr ""
 msgid "Your account"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:693
+#: lib/edenflowers_web/components/checkout_components.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your details"
 msgstr ""
@@ -866,7 +863,7 @@ msgstr ""
 msgid "Browse the store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:698
+#: lib/edenflowers_web/components/checkout_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -876,7 +873,7 @@ msgstr ""
 msgid "Continue with Google"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:699
+#: lib/edenflowers_web/components/checkout_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Current step"
 msgstr ""
@@ -931,7 +928,7 @@ msgstr ""
 msgid "Too many requests. Please wait a few minutes and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:700
+#: lib/edenflowers_web/components/checkout_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
@@ -971,7 +968,7 @@ msgstr ""
 msgid "We've sent you a new code."
 msgstr ""
 
-#: lib/edenflowers/email.ex:64
+#: lib/edenflowers/email.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Eden Flowers sign-in code"
 msgstr ""
@@ -981,7 +978,7 @@ msgstr ""
 msgid "Your receipt is attached to this email. If you need to change anything, just reply and I'll take care of it."
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:87
+#: lib/edenflowers_web/components/calendar_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "go to current month"
 msgstr ""
@@ -991,7 +988,7 @@ msgstr ""
 msgid "info@edenflowers.fi"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:230
+#: lib/edenflowers_web/components/calendar_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "not available"
 msgstr ""
@@ -1001,13 +998,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:229
-#: lib/edenflowers_web/components/calendar_component.ex:247
+#: lib/edenflowers_web/components/calendar_component.ex:392
+#: lib/edenflowers_web/components/calendar_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "selected"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:228
+#: lib/edenflowers_web/components/calendar_component.ex:391
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
@@ -1015,4 +1012,76 @@ msgstr ""
 #: lib/edenflowers_web/otp_sign_in_live.ex:58
 #, elixir-autogen, elixir-format, fuzzy
 msgid "🥳 A sign-in code was sent to %{email}."
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:374
+#: lib/edenflowers_web/live/contact_live.ex:46
+#, elixir-autogen, elixir-format
+msgid "65230 Vasa"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Address"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:18
+#, elixir-autogen, elixir-format
+msgid "Got a question, a special request, or want to talk through an arrangement? Reach us by email or phone, or stop by the shop during opening hours."
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Mon–Fri: 09:00–17:00"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:373
+#: lib/edenflowers_web/live/contact_live.ex:45
+#, elixir-autogen, elixir-format
+msgid "Myrvägen 1"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Phone"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:39
+#, elixir-autogen, elixir-format
+msgid "Same-day fulfillment is not available"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Sat: 10:00–15:00"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Sun: closed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:40
+#, elixir-autogen, elixir-format
+msgid "The order deadline for today has passed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:41
+#, elixir-autogen, elixir-format
+msgid "This date is no longer available, please choose another"
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:377
+#, elixir-autogen, elixir-format
+msgid "Toggle "
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:383
+#, elixir-autogen, elixir-format
+msgid "Toggle week"
+msgstr ""
+
+#: lib/edenflowers_web/live_user_auth.ex:57
+#, elixir-autogen, elixir-format
+msgid "You must sign in to access this page."
 msgstr ""

--- a/priv/gettext/fi/LC_MESSAGES/default.po
+++ b/priv/gettext/fi/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:526
+#: lib/edenflowers_web/components/core_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Toiminnot"
 
-#: lib/edenflowers_web/components/layouts.ex:153
-#: lib/edenflowers_web/components/layouts.ex:392
+#: lib/edenflowers_web/components/layouts.ex:164
+#: lib/edenflowers_web/components/layouts.ex:403
 #: lib/edenflowers_web/live/about_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Tietoa meistä"
 
-#: lib/edenflowers/fulfillments.ex:42
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr "Osoitetta ei löytynyt"
@@ -35,72 +35,72 @@ msgstr "Käytä"
 
 #: lib/edenflowers_web/components/cart_drawer_component.ex:20
 #: lib/edenflowers_web/components/cart_drawer_component.ex:22
-#: lib/edenflowers_web/components/layouts.ex:330
-#: lib/edenflowers_web/components/layouts.ex:332
-#: lib/edenflowers_web/live/checkout_live.ex:358
+#: lib/edenflowers_web/components/layouts.ex:341
+#: lib/edenflowers_web/components/layouts.ex:343
+#: lib/edenflowers_web/live/checkout_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr "Ostoskori"
 
-#: lib/edenflowers_web/components/layouts.ex:152
+#: lib/edenflowers_web/components/layouts.ex:163
 #: lib/edenflowers_web/live/condolences_live.ex:14
 #: lib/edenflowers_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr "Suruvalittelut"
 
-#: lib/edenflowers_web/components/layouts.ex:154
-#: lib/edenflowers_web/components/layouts.ex:387
+#: lib/edenflowers_web/components/layouts.ex:165
+#: lib/edenflowers_web/components/layouts.ex:398
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Yhteystiedot"
 
-#: lib/edenflowers_web/components/layouts.ex:150
+#: lib/edenflowers_web/components/layouts.ex:161
 #: lib/edenflowers_web/live/courses_live.ex:25
 #: lib/edenflowers_web/live/home_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr "Kurssit"
 
-#: lib/edenflowers_web/live/checkout_live.ex:374
-#: lib/edenflowers_web/live/checkout_live.ex:695
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:122
+#: lib/edenflowers_web/components/checkout_components.ex:135
+#: lib/edenflowers_web/live/checkout_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr "Toimitus"
 
-#: lib/edenflowers_web/live/checkout_live.ex:390
+#: lib/edenflowers_web/live/checkout_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr "Alennus"
 
-#: lib/edenflowers_web/live/checkout_live.ex:379
+#: lib/edenflowers_web/live/checkout_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Ilmainen"
 
-#: lib/edenflowers_web/components/calendar_component.ex:96
+#: lib/edenflowers_web/components/calendar_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Seuraava kuukausi"
 
-#: lib/edenflowers_web/components/calendar_component.ex:76
+#: lib/edenflowers_web/components/calendar_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Edellinen kuukausi"
 
-#: lib/edenflowers_web/components/layouts.ex:149
+#: lib/edenflowers_web/components/layouts.ex:160
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr "Kauppa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:406
+#: lib/edenflowers_web/live/checkout_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr "Yhteensä"
 
-#: lib/edenflowers_web/components/layouts.ex:151
+#: lib/edenflowers_web/components/layouts.ex:162
 #: lib/edenflowers_web/live/home_live.ex:148
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
@@ -112,7 +112,7 @@ msgstr "Häät"
 msgid "Fresh flowers for everyday moments"
 msgstr "Tuoreita kukkia arkipäivän hetkiin"
 
-#: lib/edenflowers_web/components/layouts.ex:236
+#: lib/edenflowers_web/components/layouts.ex:247
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr "Kerro meille mitä mieltä olet uudesta verkkosivustosta! 🚀"
@@ -129,23 +129,23 @@ msgstr "Osta nyt"
 msgid "Checkout"
 msgstr "Kassa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:696
+#: lib/edenflowers_web/components/checkout_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr "Maksu"
 
-#: lib/edenflowers_web/live/checkout_live.ex:772
+#: lib/edenflowers_web/live/checkout_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr "Puhelinnumero"
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:292
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:303
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Tili"
 
-#: lib/edenflowers_web/components/layouts.ex:423
+#: lib/edenflowers_web/components/layouts.ex:434
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr "Rakennettu "
@@ -160,12 +160,12 @@ msgstr "Voinko sisällyttää henkilökohtaisen viestin tilaukseeni?"
 msgid "Decrement"
 msgstr "Vähennä"
 
-#: lib/edenflowers_web/live/checkout_live.ex:276
+#: lib/edenflowers_web/live/checkout_live.ex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr "Toimituspäivä *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:236
+#: lib/edenflowers_web/live/checkout_live.ex:159
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr "Toimitustapa *"
@@ -180,12 +180,13 @@ msgstr "Yhteys palvelimeen katkennut. Yhdistetään uudelleen..."
 msgid "Do you offer subscription services?"
 msgstr "Tarjoatteko tilauspalveluita?"
 
+#: lib/edenflowers_web/live/contact_live.ex:23
 #: lib/edenflowers_web/otp_sign_in_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Sähköposti"
 
-#: lib/edenflowers_web/live/checkout_live.ex:96
+#: lib/edenflowers_web/live/checkout_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr "Sähköposti *"
@@ -216,7 +217,7 @@ msgstr "Lisää"
 msgid "Learn more"
 msgstr "Lue lisää"
 
-#: lib/edenflowers_web/components/layouts.ex:247
+#: lib/edenflowers_web/components/layouts.ex:258
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr "Avaa navigointivalikko"
@@ -226,27 +227,27 @@ msgstr "Avaa navigointivalikko"
 msgid "Order #1234"
 msgstr "Tilaus #1234"
 
-#: lib/edenflowers/fulfillments.ex:43
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr "Toimitusalueen ulkopuolella"
 
-#: lib/edenflowers_web/live/checkout_live.ex:344
+#: lib/edenflowers_web/live/checkout_live.ex:250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr "Maksa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:278
+#: lib/edenflowers_web/live/checkout_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr "Noutopäivä *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:123
+#: lib/edenflowers_web/live/checkout_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr "Vastaanottaja *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:134
+#: lib/edenflowers_web/live/checkout_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr "Vastaanottajan nimi *"
@@ -257,8 +258,8 @@ msgstr "Vastaanottajan nimi *"
 msgid "Remove"
 msgstr "Poista"
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:293
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr "Kirjaudu sisään"
@@ -273,7 +274,7 @@ msgstr "Kirjaudu sisään"
 msgid "Sign in to your account"
 msgstr "Kirjaudu tilillesi"
 
-#: lib/edenflowers/fulfillments.ex:44
+#: lib/edenflowers/fulfillments.ex:45
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr "Toimituskulujen laskemisessa tapahtui virhe, yritä myöhemmin uudelleen"
@@ -293,7 +294,7 @@ msgstr "Mitä tapahtuu, jos en ole kotona toimituksen aikana?"
 msgid "What is your delivery policy?"
 msgstr "Mikä on toimituspolitiikkanne?"
 
-#: lib/edenflowers_web/live/checkout_live.ex:90
+#: lib/edenflowers_web/live/checkout_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr "Nimesi *"
@@ -324,12 +325,12 @@ msgstr "Ystävällisin terveisin"
 msgid "Hi"
 msgstr "Hei"
 
-#: lib/edenflowers_web/live/checkout_live.ex:268
+#: lib/edenflowers_web/live/checkout_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:771
+#: lib/edenflowers_web/live/checkout_live.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr "Osoite"
@@ -339,7 +340,7 @@ msgstr "Osoite"
 msgid "As a welcome gift, here is your 15% off promo code for your first order:"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:152
+#: lib/edenflowers_web/live/checkout_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
@@ -354,17 +355,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:170
+#: lib/edenflowers_web/live/checkout_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:260
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr "Toimitus­tiedot"
 
-#: lib/edenflowers_web/live/checkout_live.ex:678
+#: lib/edenflowers_web/components/checkout_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -379,7 +380,7 @@ msgstr ""
 msgid "Error loading checkout"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fulfillment date cannot be in the past"
 msgstr ""
@@ -399,40 +400,40 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:906
+#: lib/edenflowers_web/live/checkout_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:905
+#: lib/edenflowers_web/live/checkout_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:102
-#: lib/edenflowers_web/live/checkout_live.ex:221
-#: lib/edenflowers_web/live/checkout_live.ex:318
+#: lib/edenflowers_web/live/checkout_live.ex:104
+#: lib/edenflowers_web/live/checkout_live.ex:144
+#: lib/edenflowers_web/live/checkout_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:496
+#: lib/edenflowers_web/live/checkout_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:186
-#: lib/edenflowers_web/live/checkout_live.ex:189
+#: lib/edenflowers_web/live/checkout_live.ex:422
+#: lib/edenflowers_web/live/checkout_live.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr "Poista"
 
-#: lib/edenflowers_web/live/checkout_live.ex:426
+#: lib/edenflowers_web/live/checkout_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:904
+#: lib/edenflowers_web/live/checkout_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -452,7 +453,7 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/email.ex:56
+#: lib/edenflowers/email.ex:54
 #, elixir-autogen, elixir-format
 msgid "Welcome back to the Eden Flowers newsletter"
 msgstr ""
@@ -462,7 +463,7 @@ msgstr ""
 msgid "Welcome back to the Eden Flowers newsletter!"
 msgstr ""
 
-#: lib/edenflowers/email.ex:40
+#: lib/edenflowers/email.ex:38
 #, elixir-autogen, elixir-format
 msgid "Welcome to Eden Flowers — your 15% off code inside"
 msgstr ""
@@ -487,7 +488,7 @@ msgstr ""
 msgid "Your 15% off welcome code is still valid — here it is again:"
 msgstr ""
 
-#: lib/edenflowers/email.ex:48
+#: lib/edenflowers/email.ex:46
 #, elixir-autogen, elixir-format
 msgid "Your Eden Flowers promo code"
 msgstr ""
@@ -502,22 +503,22 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:263
+#: lib/edenflowers_web/live/checkout_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:764
+#: lib/edenflowers_web/live/checkout_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:765
+#: lib/edenflowers_web/live/checkout_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:41
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Toimitusosoite vaaditaan"
@@ -537,12 +538,13 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:368
+#: lib/edenflowers_web/components/layouts.ex:379
+#: lib/edenflowers_web/live/contact_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:399
+#: lib/edenflowers_web/components/layouts.ex:410
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
@@ -562,12 +564,7 @@ msgstr "Valitse kortti ennen viestin kirjoittamista"
 msgid "Browse bouquets"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:965
-#, elixir-autogen, elixir-format
-msgid "Cart changed but payment couldn't be updated. Please retry."
-msgstr ""
-
-#: lib/edenflowers_web/components/core_components.ex:1044
+#: lib/edenflowers_web/components/core_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Cart, empty"
 msgstr ""
@@ -582,7 +579,7 @@ msgstr ""
 msgid "Close cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:176
+#: lib/edenflowers_web/components/layouts.ex:187
 #, elixir-autogen, elixir-format
 msgid "Close navigation menu"
 msgstr ""
@@ -632,14 +629,14 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:575
+#: lib/edenflowers_web/live/checkout_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please refresh the page and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:349
-#: lib/edenflowers_web/live/checkout_live.ex:486
-#: lib/edenflowers_web/live/checkout_live.ex:972
+#: lib/edenflowers_web/live/checkout_live.ex:255
+#: lib/edenflowers_web/live/checkout_live.ex:560
+#: lib/edenflowers_web/live/checkout_live.ex:856
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please try again in a moment."
 msgstr ""
@@ -689,7 +686,7 @@ msgstr ""
 msgid "Eden Flowers' arrangements last 5–7 days with proper care. Change the water every 2–3 days, trim the stems, and keep them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:382
+#: lib/edenflowers_web/components/layouts.ex:393
 #, elixir-autogen, elixir-format
 msgid "FAQ"
 msgstr ""
@@ -699,23 +696,23 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:707
+#: lib/edenflowers_web/components/checkout_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "For %{name}"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
-#: lib/edenflowers_web/live/checkout_live.ex:706
+#: lib/edenflowers_web/components/checkout_components.ex:129
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For me"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For somebody else"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:885
+#: lib/edenflowers_web/components/core_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
@@ -725,7 +722,7 @@ msgstr ""
 msgid "Get 15% off your first order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:694
+#: lib/edenflowers_web/components/checkout_components.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Gift options"
 msgstr "Lahjavalinnat"
@@ -735,7 +732,7 @@ msgstr "Lahjavalinnat"
 msgid "Have a question?"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:378
+#: lib/edenflowers_web/components/layouts.ex:389
 #, elixir-autogen, elixir-format
 msgid "Help"
 msgstr ""
@@ -745,7 +742,7 @@ msgstr ""
 msgid "If you're not in, the flowers will be left in a safe, shaded spot. If no suitable spot is available, a note with redelivery instructions will be left. You can also specify delivery instructions during checkout."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Incl. VAT"
 msgstr ""
@@ -775,7 +772,7 @@ msgstr ""
 msgid "Only occasional emails — unsubscribe at any time."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pickup"
 msgstr "Noutopäivä *"
@@ -796,7 +793,7 @@ msgstr ""
 msgid "See the FAQ"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:217
+#: lib/edenflowers_web/live/checkout_live.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a card"
 msgstr ""
@@ -851,7 +848,7 @@ msgstr ""
 msgid "Your account"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:693
+#: lib/edenflowers_web/components/checkout_components.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your details"
 msgstr "Tietosi"
@@ -866,7 +863,7 @@ msgstr ""
 msgid "Browse the store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:698
+#: lib/edenflowers_web/components/checkout_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -876,7 +873,7 @@ msgstr ""
 msgid "Continue with Google"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:699
+#: lib/edenflowers_web/components/checkout_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Current step"
 msgstr ""
@@ -931,7 +928,7 @@ msgstr "Kiitos tilauksestasi. Viitenumerosi on %{reference}, ja kaikki on valmii
 msgid "Too many requests. Please wait a few minutes and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:700
+#: lib/edenflowers_web/components/checkout_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
@@ -971,7 +968,7 @@ msgstr ""
 msgid "We've sent you a new code."
 msgstr ""
 
-#: lib/edenflowers/email.ex:64
+#: lib/edenflowers/email.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Eden Flowers sign-in code"
 msgstr ""
@@ -981,7 +978,7 @@ msgstr ""
 msgid "Your receipt is attached to this email. If you need to change anything, just reply and I'll take care of it."
 msgstr "Kuittisi on liitteenä tässä viestissä. Jos jotain pitää muuttaa, vastaa vain tähän viestiin niin hoidan asian."
 
-#: lib/edenflowers_web/components/calendar_component.ex:87
+#: lib/edenflowers_web/components/calendar_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "go to current month"
 msgstr ""
@@ -991,7 +988,7 @@ msgstr ""
 msgid "info@edenflowers.fi"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:230
+#: lib/edenflowers_web/components/calendar_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "not available"
 msgstr ""
@@ -1001,13 +998,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:229
-#: lib/edenflowers_web/components/calendar_component.ex:247
+#: lib/edenflowers_web/components/calendar_component.ex:392
+#: lib/edenflowers_web/components/calendar_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "selected"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:228
+#: lib/edenflowers_web/components/calendar_component.ex:391
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
@@ -1016,3 +1013,75 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "🥳 A sign-in code was sent to %{email}."
 msgstr "🥳 Kirjautumislinkki lähetettiin osoitteeseen %{email}."
+
+#: lib/edenflowers_web/components/layouts.ex:374
+#: lib/edenflowers_web/live/contact_live.ex:46
+#, elixir-autogen, elixir-format
+msgid "65230 Vasa"
+msgstr "65230 Vaasa"
+
+#: lib/edenflowers_web/live/contact_live.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Address"
+msgstr "Osoite"
+
+#: lib/edenflowers_web/live/contact_live.ex:18
+#, elixir-autogen, elixir-format
+msgid "Got a question, a special request, or want to talk through an arrangement? Reach us by email or phone, or stop by the shop during opening hours."
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Mon–Fri: 09:00–17:00"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:373
+#: lib/edenflowers_web/live/contact_live.ex:45
+#, elixir-autogen, elixir-format
+msgid "Myrvägen 1"
+msgstr "Muurahaistie 1"
+
+#: lib/edenflowers_web/live/contact_live.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Phone"
+msgstr "Puhelinnumero"
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:39
+#, elixir-autogen, elixir-format
+msgid "Same-day fulfillment is not available"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Sat: 10:00–15:00"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Sun: closed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:40
+#, elixir-autogen, elixir-format
+msgid "The order deadline for today has passed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:41
+#, elixir-autogen, elixir-format
+msgid "This date is no longer available, please choose another"
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:377
+#, elixir-autogen, elixir-format
+msgid "Toggle "
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:383
+#, elixir-autogen, elixir-format
+msgid "Toggle week"
+msgstr ""
+
+#: lib/edenflowers_web/live_user_auth.ex:57
+#, elixir-autogen, elixir-format
+msgid "You must sign in to access this page."
+msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/edenflowers_web/components/core_components.ex:526
+#: lib/edenflowers_web/components/core_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: lib/edenflowers_web/components/layouts.ex:153
-#: lib/edenflowers_web/components/layouts.ex:392
+#: lib/edenflowers_web/components/layouts.ex:164
+#: lib/edenflowers_web/components/layouts.ex:403
 #: lib/edenflowers_web/live/about_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Om oss"
 
-#: lib/edenflowers/fulfillments.ex:42
+#: lib/edenflowers/fulfillments.ex:43
 #, elixir-autogen, elixir-format
 msgid "Address not found"
 msgstr "Adressen hittades inte"
@@ -35,72 +35,72 @@ msgstr "Tillämpa"
 
 #: lib/edenflowers_web/components/cart_drawer_component.ex:20
 #: lib/edenflowers_web/components/cart_drawer_component.ex:22
-#: lib/edenflowers_web/components/layouts.ex:330
-#: lib/edenflowers_web/components/layouts.ex:332
-#: lib/edenflowers_web/live/checkout_live.ex:358
+#: lib/edenflowers_web/components/layouts.ex:341
+#: lib/edenflowers_web/components/layouts.ex:343
+#: lib/edenflowers_web/live/checkout_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Cart"
 msgstr "Varukorg"
 
-#: lib/edenflowers_web/components/layouts.ex:152
+#: lib/edenflowers_web/components/layouts.ex:163
 #: lib/edenflowers_web/live/condolences_live.ex:14
 #: lib/edenflowers_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Condolences"
 msgstr "Kondoleanser"
 
-#: lib/edenflowers_web/components/layouts.ex:154
-#: lib/edenflowers_web/components/layouts.ex:387
+#: lib/edenflowers_web/components/layouts.ex:165
+#: lib/edenflowers_web/components/layouts.ex:398
 #: lib/edenflowers_web/live/contact_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
 
-#: lib/edenflowers_web/components/layouts.ex:150
+#: lib/edenflowers_web/components/layouts.ex:161
 #: lib/edenflowers_web/live/courses_live.ex:25
 #: lib/edenflowers_web/live/home_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Courses"
 msgstr "Kurser"
 
-#: lib/edenflowers_web/live/checkout_live.ex:374
-#: lib/edenflowers_web/live/checkout_live.ex:695
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:122
+#: lib/edenflowers_web/components/checkout_components.ex:135
+#: lib/edenflowers_web/live/checkout_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Delivery"
 msgstr "Leverans"
 
-#: lib/edenflowers_web/live/checkout_live.ex:390
+#: lib/edenflowers_web/live/checkout_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Discount"
 msgstr "Rabatt"
 
-#: lib/edenflowers_web/live/checkout_live.ex:379
+#: lib/edenflowers_web/live/checkout_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratis"
 
-#: lib/edenflowers_web/components/calendar_component.ex:96
+#: lib/edenflowers_web/components/calendar_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Nästa månad"
 
-#: lib/edenflowers_web/components/calendar_component.ex:76
+#: lib/edenflowers_web/components/calendar_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Föregående månad"
 
-#: lib/edenflowers_web/components/layouts.ex:149
+#: lib/edenflowers_web/components/layouts.ex:160
 #, elixir-autogen, elixir-format
 msgid "Store"
 msgstr "Butik"
 
-#: lib/edenflowers_web/live/checkout_live.ex:406
+#: lib/edenflowers_web/live/checkout_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr "Totalt"
 
-#: lib/edenflowers_web/components/layouts.ex:151
+#: lib/edenflowers_web/components/layouts.ex:162
 #: lib/edenflowers_web/live/home_live.ex:148
 #: lib/edenflowers_web/live/weddings_live.ex:14
 #, elixir-autogen, elixir-format
@@ -112,7 +112,7 @@ msgstr "Bröllop"
 msgid "Fresh flowers for everyday moments"
 msgstr "Färska blommor för vardagliga stunder"
 
-#: lib/edenflowers_web/components/layouts.ex:236
+#: lib/edenflowers_web/components/layouts.ex:247
 #, elixir-autogen, elixir-format
 msgid "Let us know what you think of the new website! 🚀"
 msgstr "Låt oss veta vad du tycker om den nya webbplatsen! 🚀"
@@ -129,23 +129,23 @@ msgstr "Handla nu"
 msgid "Checkout"
 msgstr "Kassa"
 
-#: lib/edenflowers_web/live/checkout_live.ex:696
+#: lib/edenflowers_web/components/checkout_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr "Betalning"
 
-#: lib/edenflowers_web/live/checkout_live.ex:772
+#: lib/edenflowers_web/live/checkout_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:292
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:303
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/edenflowers_web/components/layouts.ex:423
+#: lib/edenflowers_web/components/layouts.ex:434
 #, elixir-autogen, elixir-format
 msgid "Built with "
 msgstr "Byggd med "
@@ -160,12 +160,12 @@ msgstr "Kan jag inkludera ett personligt meddelande med min beställning?"
 msgid "Decrement"
 msgstr "Minska"
 
-#: lib/edenflowers_web/live/checkout_live.ex:276
+#: lib/edenflowers_web/live/checkout_live.ex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Date *"
 msgstr "Leveransdatum *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:236
+#: lib/edenflowers_web/live/checkout_live.ex:159
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Method *"
 msgstr "Leveransmetod *"
@@ -180,12 +180,13 @@ msgstr "Frånkopplad från servern. Återansluter..."
 msgid "Do you offer subscription services?"
 msgstr "Erbjuder ni prenumerationstjänster?"
 
+#: lib/edenflowers_web/live/contact_live.ex:23
 #: lib/edenflowers_web/otp_sign_in_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-post"
 
-#: lib/edenflowers_web/live/checkout_live.ex:96
+#: lib/edenflowers_web/live/checkout_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Email *"
 msgstr "E-post *"
@@ -216,7 +217,7 @@ msgstr "Öka"
 msgid "Learn more"
 msgstr "Läs mer"
 
-#: lib/edenflowers_web/components/layouts.ex:247
+#: lib/edenflowers_web/components/layouts.ex:258
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
 msgstr "Öppna navigeringsmeny"
@@ -226,27 +227,27 @@ msgstr "Öppna navigeringsmeny"
 msgid "Order #1234"
 msgstr "Beställning #1234"
 
-#: lib/edenflowers/fulfillments.ex:43
+#: lib/edenflowers/fulfillments.ex:44
 #, elixir-autogen, elixir-format
 msgid "Outside delivery range"
 msgstr "Utanför leveransområdet"
 
-#: lib/edenflowers_web/live/checkout_live.ex:344
+#: lib/edenflowers_web/live/checkout_live.ex:250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pay"
 msgstr "Betala"
 
-#: lib/edenflowers_web/live/checkout_live.ex:278
+#: lib/edenflowers_web/live/checkout_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pickup Date *"
 msgstr "Upphämtningsdatum *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:123
+#: lib/edenflowers_web/live/checkout_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Recipient *"
 msgstr "Mottagare *"
 
-#: lib/edenflowers_web/live/checkout_live.ex:134
+#: lib/edenflowers_web/live/checkout_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Recipient Name *"
 msgstr "Mottagarens namn *"
@@ -257,8 +258,8 @@ msgstr "Mottagarens namn *"
 msgid "Remove"
 msgstr "Ta bort"
 
-#: lib/edenflowers_web/components/layouts.ex:201
-#: lib/edenflowers_web/components/layouts.ex:293
+#: lib/edenflowers_web/components/layouts.ex:212
+#: lib/edenflowers_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Sign In"
 msgstr "Logga in"
@@ -273,7 +274,7 @@ msgstr "Logga in"
 msgid "Sign in to your account"
 msgstr "Logga in på ditt konto"
 
-#: lib/edenflowers/fulfillments.ex:44
+#: lib/edenflowers/fulfillments.ex:45
 #, elixir-autogen, elixir-format
 msgid "There was a problem calculating delivery cost, please try again later"
 msgstr "Det uppstod ett problem med att beräkna leveranskostnaden, försök igen senare"
@@ -293,7 +294,7 @@ msgstr "Vad händer om jag inte är hemma vid leverans?"
 msgid "What is your delivery policy?"
 msgstr "Vad är er leveranspolicy?"
 
-#: lib/edenflowers_web/live/checkout_live.ex:90
+#: lib/edenflowers_web/live/checkout_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Your Name *"
 msgstr "Ditt namn *"
@@ -324,12 +325,12 @@ msgstr "Med vänliga hälsningar"
 msgid "Hi"
 msgstr "Hej"
 
-#: lib/edenflowers_web/live/checkout_live.ex:268
+#: lib/edenflowers_web/live/checkout_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "045 1505141"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:771
+#: lib/edenflowers_web/live/checkout_live.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address *"
 msgstr "Adress"
@@ -339,7 +340,7 @@ msgstr "Adress"
 msgid "As a welcome gift, here is your 15% off promo code for your first order:"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:152
+#: lib/edenflowers_web/live/checkout_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Card Message"
 msgstr ""
@@ -354,17 +355,17 @@ msgstr ""
 msgid "Cart total must be at least %{utils_format_money} to use this promotion"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:170
+#: lib/edenflowers_web/live/checkout_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Change card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:260
+#: lib/edenflowers_web/live/checkout_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delivery Instructions"
 msgstr "Leverans­information"
 
-#: lib/edenflowers_web/live/checkout_live.ex:678
+#: lib/edenflowers_web/components/checkout_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -379,7 +380,7 @@ msgstr ""
 msgid "Error loading checkout"
 msgstr ""
 
-#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:14
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:38
 #, elixir-autogen, elixir-format
 msgid "Fulfillment date cannot be in the past"
 msgstr ""
@@ -399,40 +400,40 @@ msgstr ""
 msgid "It looks like you're already subscribed to the Eden Flowers newsletter."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:906
+#: lib/edenflowers_web/live/checkout_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Large"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:905
+#: lib/edenflowers_web/live/checkout_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:102
-#: lib/edenflowers_web/live/checkout_live.ex:221
-#: lib/edenflowers_web/live/checkout_live.ex:318
+#: lib/edenflowers_web/live/checkout_live.ex:104
+#: lib/edenflowers_web/live/checkout_live.ex:144
+#: lib/edenflowers_web/live/checkout_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:496
+#: lib/edenflowers_web/live/checkout_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Payment processing error. Please try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:186
-#: lib/edenflowers_web/live/checkout_live.ex:189
+#: lib/edenflowers_web/live/checkout_live.ex:422
+#: lib/edenflowers_web/live/checkout_live.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove card"
 msgstr "Ta bort"
 
-#: lib/edenflowers_web/live/checkout_live.ex:426
+#: lib/edenflowers_web/live/checkout_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Select a Card"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:904
+#: lib/edenflowers_web/live/checkout_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "Small"
 msgstr ""
@@ -452,7 +453,7 @@ msgstr ""
 msgid "The code is valid for 30 days and can be used once at checkout."
 msgstr ""
 
-#: lib/edenflowers/email.ex:56
+#: lib/edenflowers/email.ex:54
 #, elixir-autogen, elixir-format
 msgid "Welcome back to the Eden Flowers newsletter"
 msgstr ""
@@ -462,7 +463,7 @@ msgstr ""
 msgid "Welcome back to the Eden Flowers newsletter!"
 msgstr ""
 
-#: lib/edenflowers/email.ex:40
+#: lib/edenflowers/email.ex:38
 #, elixir-autogen, elixir-format
 msgid "Welcome to Eden Flowers — your 15% off code inside"
 msgstr ""
@@ -487,7 +488,7 @@ msgstr ""
 msgid "Your 15% off welcome code is still valid — here it is again:"
 msgstr ""
 
-#: lib/edenflowers/email.ex:48
+#: lib/edenflowers/email.ex:46
 #, elixir-autogen, elixir-format
 msgid "Your Eden Flowers promo code"
 msgstr ""
@@ -502,22 +503,22 @@ msgstr ""
 msgid "Your password has successfully been reset"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:263
+#: lib/edenflowers_web/live/checkout_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "e.g. Door code 1234, leave at the front door"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:764
+#: lib/edenflowers_web/live/checkout_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Address *"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:765
+#: lib/edenflowers_web/live/checkout_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{name}'s Phone Number"
 msgstr ""
 
-#: lib/edenflowers/fulfillments.ex:41
+#: lib/edenflowers/fulfillments.ex:42
 #, elixir-autogen, elixir-format
 msgid "Delivery address required"
 msgstr "Leveransadress krävs"
@@ -537,12 +538,13 @@ msgstr ""
 msgid "Hello, I'm Jennie"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:368
+#: lib/edenflowers_web/components/layouts.ex:379
+#: lib/edenflowers_web/live/contact_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Opening hours"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:399
+#: lib/edenflowers_web/components/layouts.ex:410
 #, elixir-autogen, elixir-format
 msgid "Socials"
 msgstr ""
@@ -562,12 +564,7 @@ msgstr "Välj ett kort innan du skriver ett meddelande"
 msgid "Browse bouquets"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:965
-#, elixir-autogen, elixir-format
-msgid "Cart changed but payment couldn't be updated. Please retry."
-msgstr ""
-
-#: lib/edenflowers_web/components/core_components.ex:1044
+#: lib/edenflowers_web/components/core_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Cart, empty"
 msgstr ""
@@ -582,7 +579,7 @@ msgstr ""
 msgid "Close cart"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:176
+#: lib/edenflowers_web/components/layouts.ex:187
 #, elixir-autogen, elixir-format
 msgid "Close navigation menu"
 msgstr ""
@@ -632,14 +629,14 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:575
+#: lib/edenflowers_web/live/checkout_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please refresh the page and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:349
-#: lib/edenflowers_web/live/checkout_live.ex:486
-#: lib/edenflowers_web/live/checkout_live.ex:972
+#: lib/edenflowers_web/live/checkout_live.ex:255
+#: lib/edenflowers_web/live/checkout_live.ex:560
+#: lib/edenflowers_web/live/checkout_live.ex:856
 #, elixir-autogen, elixir-format
 msgid "Payment is temporarily unavailable. Please try again in a moment."
 msgstr ""
@@ -689,7 +686,7 @@ msgstr ""
 msgid "Eden Flowers' arrangements last 5–7 days with proper care. Change the water every 2–3 days, trim the stems, and keep them away from direct sunlight and drafts."
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:382
+#: lib/edenflowers_web/components/layouts.ex:393
 #, elixir-autogen, elixir-format
 msgid "FAQ"
 msgstr ""
@@ -699,23 +696,23 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:707
+#: lib/edenflowers_web/components/checkout_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "For %{name}"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
-#: lib/edenflowers_web/live/checkout_live.ex:706
+#: lib/edenflowers_web/components/checkout_components.ex:129
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For me"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:125
+#: lib/edenflowers_web/live/checkout_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "For somebody else"
 msgstr ""
 
-#: lib/edenflowers_web/components/core_components.ex:885
+#: lib/edenflowers_web/components/core_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
@@ -725,7 +722,7 @@ msgstr ""
 msgid "Get 15% off your first order."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:694
+#: lib/edenflowers_web/components/checkout_components.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Gift options"
 msgstr "Presentalternativ"
@@ -735,7 +732,7 @@ msgstr "Presentalternativ"
 msgid "Have a question?"
 msgstr ""
 
-#: lib/edenflowers_web/components/layouts.ex:378
+#: lib/edenflowers_web/components/layouts.ex:389
 #, elixir-autogen, elixir-format
 msgid "Help"
 msgstr ""
@@ -745,7 +742,7 @@ msgstr ""
 msgid "If you're not in, the flowers will be left in a safe, shaded spot. If no suitable spot is available, a note with redelivery instructions will be left. You can also specify delivery instructions during checkout."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:401
+#: lib/edenflowers_web/live/checkout_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Incl. VAT"
 msgstr ""
@@ -775,7 +772,7 @@ msgstr ""
 msgid "Only occasional emails — unsubscribe at any time."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:712
+#: lib/edenflowers_web/components/checkout_components.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pickup"
 msgstr "Upphämtningsdatum *"
@@ -796,7 +793,7 @@ msgstr ""
 msgid "See the FAQ"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:217
+#: lib/edenflowers_web/live/checkout_live.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a card"
 msgstr ""
@@ -851,7 +848,7 @@ msgstr ""
 msgid "Your account"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:693
+#: lib/edenflowers_web/components/checkout_components.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your details"
 msgstr "Dina uppgifter"
@@ -866,7 +863,7 @@ msgstr ""
 msgid "Browse the store"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:698
+#: lib/edenflowers_web/components/checkout_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -876,7 +873,7 @@ msgstr ""
 msgid "Continue with Google"
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:699
+#: lib/edenflowers_web/components/checkout_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Current step"
 msgstr ""
@@ -931,7 +928,7 @@ msgstr "Tack för din beställning. Ditt referensnummer är %{reference} och jag
 msgid "Too many requests. Please wait a few minutes and try again."
 msgstr ""
 
-#: lib/edenflowers_web/live/checkout_live.ex:700
+#: lib/edenflowers_web/components/checkout_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
@@ -971,7 +968,7 @@ msgstr ""
 msgid "We've sent you a new code."
 msgstr ""
 
-#: lib/edenflowers/email.ex:64
+#: lib/edenflowers/email.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Eden Flowers sign-in code"
 msgstr ""
@@ -981,7 +978,7 @@ msgstr ""
 msgid "Your receipt is attached to this email. If you need to change anything, just reply and I'll take care of it."
 msgstr "Ditt kvitto bifogas i detta e-postmeddelande. Om något behöver ändras, svara bara på det här mejlet så ordnar jag det."
 
-#: lib/edenflowers_web/components/calendar_component.ex:87
+#: lib/edenflowers_web/components/calendar_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "go to current month"
 msgstr ""
@@ -991,7 +988,7 @@ msgstr ""
 msgid "info@edenflowers.fi"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:230
+#: lib/edenflowers_web/components/calendar_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "not available"
 msgstr ""
@@ -1001,13 +998,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:229
-#: lib/edenflowers_web/components/calendar_component.ex:247
+#: lib/edenflowers_web/components/calendar_component.ex:392
+#: lib/edenflowers_web/components/calendar_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "selected"
 msgstr ""
 
-#: lib/edenflowers_web/components/calendar_component.ex:228
+#: lib/edenflowers_web/components/calendar_component.ex:391
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
@@ -1016,3 +1013,75 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "🥳 A sign-in code was sent to %{email}."
 msgstr "🥳 En inloggningslänk skickades till %{email}."
+
+#: lib/edenflowers_web/components/layouts.ex:374
+#: lib/edenflowers_web/live/contact_live.ex:46
+#, elixir-autogen, elixir-format
+msgid "65230 Vasa"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Address"
+msgstr "Adress"
+
+#: lib/edenflowers_web/live/contact_live.ex:18
+#, elixir-autogen, elixir-format
+msgid "Got a question, a special request, or want to talk through an arrangement? Reach us by email or phone, or stop by the shop during opening hours."
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Mon–Fri: 09:00–17:00"
+msgstr ""
+
+#: lib/edenflowers_web/components/layouts.ex:373
+#: lib/edenflowers_web/live/contact_live.ex:45
+#, elixir-autogen, elixir-format
+msgid "Myrvägen 1"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Phone"
+msgstr "Telefonnummer"
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:39
+#, elixir-autogen, elixir-format
+msgid "Same-day fulfillment is not available"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Sat: 10:00–15:00"
+msgstr ""
+
+#: lib/edenflowers_web/live/contact_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "Sun: closed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:40
+#, elixir-autogen, elixir-format
+msgid "The order deadline for today has passed"
+msgstr ""
+
+#: lib/edenflowers/store/order/validations/validate_fulfillment_date.ex:41
+#, elixir-autogen, elixir-format
+msgid "This date is no longer available, please choose another"
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:377
+#, elixir-autogen, elixir-format
+msgid "Toggle "
+msgstr ""
+
+#: lib/edenflowers_web/components/calendar_component.ex:383
+#, elixir-autogen, elixir-format
+msgid "Toggle week"
+msgstr ""
+
+#: lib/edenflowers_web/live_user_auth.ex:57
+#, elixir-autogen, elixir-format
+msgid "You must sign in to access this page."
+msgstr ""


### PR DESCRIPTION
## Summary
- Adds email, phone, address, and opening hours to `/contact`, styled like the existing FAQ/About pages.
- Corrects the footer address to the registered shop address (`Minimossen, Myrvägen 1, 65230 Vasa`) — verified against [Stormossen's listing for Minimossen](https://www.stormossen.fi/sv/minimossen/) and `priv/receipts/shop.toml`.
- Wraps the street and postal-city lines in `~t` sigils so the Finnish locale renders the parallel Finnish form (`Muurahaistie 1, 65230 Vaasa`). Swedish and English fall back to the source (registered Swedish form).

Closes #235

## Notes / out-of-scope
- `home_live.ex` still mentions "Kauppapuistikko" in the marketing copy and the map alt text — that looks like stale text from a previous location. Worth a follow-up to scrub the homepage, but I'm scoping this PR to the Contact page + footer.
- The Stormossen listing shows mall hours as Mon–Fri 10–18 / Sat 10–15. The footer (and now the contact page) shows Eden Flowers' own hours as Mon–Fri 09–17 / Sat 10–15 — I left these as-is since they're the shop's hours, possibly different from the mall's overall hours.

## Test plan
- [ ] Visit `/contact` in each locale (en, fi, sv); confirm address renders correctly per locale
- [ ] Click email/phone links — open mail client/dialer respectively
- [ ] Visit footer — confirm address matches the contact page