### PR TITLE
Force hackney HTTP/1.1 to work around Stripe :protocol_error

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,14 @@
 # General application configuration
 import Config
 
+# Workaround for stripity_stripe + hackney 4.x: hackney 4.0 negotiates HTTP/2
+# by default, but stripity_stripe still sends a `Connection: keep-alive` header,
+# which is illegal under HTTP/2 (RFC 7540 §8.1.2.2). hackney rejects the request
+# with :protocol_error, breaking Stripe payment intent creation at checkout.
+# Forcing HTTP/1.1 sidesteps it. Remove once stripity_stripe fixes the header.
+# Tracking: https://github.com/beam-community/stripity-stripe/issues/905
+config :hackney, default_protocols: [:http1]
+
 config :edenflowers, Oban,
   engine: Oban.Engines.Basic,
   notifier: Oban.Notifiers.Postgres,


### PR DESCRIPTION
## Problem

Checkout step 4 (Payment) fails to create a Stripe payment intent with:

```
%Stripe.Error{source: :network, code: :network_error,
  extra: %{hackney_reason: :protocol_error}, ...}
```

## Root cause

`stripity_stripe` **3.3.1** bumped hackney from `1.20` → **4.x**. hackney 4.0 negotiates **HTTP/2** by default (`default_protocols: [http2, http1]`), but `stripity_stripe` still injects a `Connection: keep-alive` header in `Stripe.API.add_common_headers/1`. Connection-specific headers are **forbidden under HTTP/2** (RFC 7540 §8.1.2.2), so hackney rejects the request with `:protocol_error` before it leaves the client. Every Stripe call fails.

Confirmed independent of network/VPN; reproduced on hackney 4.2.0 **and** 4.2.1.

## Fix

Pin hackney to HTTP/1.1 globally — the documented workaround in the upstream issue:

```elixir
config :hackney, default_protocols: [:http1]
```

This is the same protocol everything used before hackney 4.x, so it's low-risk. Verified: payment intent creation succeeds at checkout after restart.

## ⏳ Revert condition

This is a **workaround, not a real fix** — the bug must be fixed in `stripity_stripe` (drop connection-specific headers on HTTP/2). **Remove this config and re-test HTTP/2 once that ships.**

- [ ] Track upstream: beam-community/stripity-stripe#905
- [ ] When fixed/released, delete the `config :hackney, default_protocols` line and confirm checkout still works over HTTP/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)