### PR TITLE
refactor: extract Stripe orchestration from CheckoutLive

### DIFF
--- a/lib/edenflowers/checkout.ex
+++ b/lib/edenflowers/checkout.ex
@@ -1,0 +1,76 @@
+defmodule Edenflowers.Checkout do
+  @moduledoc """
+  Orchestrates the checkout payment lifecycle.
+
+  This module sits between the web layer (LiveViews, controllers) and the
+  Stripe API port. It owns creating, retrieving, updating and persisting
+  payment intents so that callers only need one function per step.
+  """
+
+  require Logger
+
+  alias Edenflowers.Store.Order
+
+  defp stripe_api, do: Application.get_env(:edenflowers, :stripe_api, Edenflowers.StripeAPI)
+
+  @doc """
+  Sets up the payment for an order that has reached the payment step.
+
+  * If the order has no `payment_intent_id`, a new PaymentIntent is created
+    on Stripe and the id is persisted on the order.
+  * If the order already has a `payment_intent_id`, the existing intent is
+    retrieved from Stripe.
+
+  Returns `{:ok, updated_order, client_secret}` or `{:error, reason}`.
+  """
+  def setup_payment(%{payment_intent_id: nil} = order, actor) do
+    case stripe_api().create_payment_intent(order) do
+      {:ok, payment_intent} ->
+        persist_payment_intent(order, payment_intent, actor)
+
+      {:error, reason} ->
+        Logger.error("Failed to create payment intent for order #{order.id}: #{inspect(reason)}")
+        {:error, :payment_intent_create_failed}
+    end
+  end
+
+  def setup_payment(order, _actor) do
+    case stripe_api().retrieve_payment_intent(order) do
+      {:ok, payment_intent} ->
+        {:ok, order, payment_intent.client_secret}
+
+      {:error, reason} ->
+        Logger.error("Failed to retrieve payment intent for order #{order.id}: #{inspect(reason)}")
+        {:error, :payment_intent_retrieve_failed}
+    end
+  end
+
+  @doc """
+  Updates the PaymentIntent amount to match the order's current total.
+
+  Returns `{:ok, payment_intent}` or `{:error, reason}`.
+  """
+  def update_payment(order) do
+    stripe_api().update_payment_intent(order)
+  end
+
+  # =======
+  # Private
+  # =======
+
+  defp persist_payment_intent(order, payment_intent, actor) do
+    case Order.add_payment_intent_id(order, payment_intent.id, actor: actor) do
+      {:ok, order} ->
+        {:ok, order, payment_intent.client_secret}
+
+      {:error, reason} ->
+        # Persisting the id failed — cancel the orphan intent on Stripe so it
+        # doesn't linger in the dashboard. Best-effort.
+        stripe_api().cancel_payment_intent(payment_intent)
+
+        Logger.error("Failed to persist payment_intent_id for order #{order.id}: #{inspect(reason)}")
+
+        {:error, :payment_intent_persist_failed}
+    end
+  end
+end

--- a/lib/edenflowers_web/live/checkout_live.ex
+++ b/lib/edenflowers_web/live/checkout_live.ex
@@ -13,7 +13,6 @@ defmodule EdenflowersWeb.CheckoutLive do
 
   @checkout_states Order.checkout_states()
 
-  defp stripe_api, do: Application.get_env(:edenflowers, :stripe_api, Edenflowers.StripeAPI)
   defp stripe_publishable_key, do: Application.get_env(:edenflowers, :stripe_publishable_key)
 
   defp submit_action_for(:contact_details), do: :submit_contact_details
@@ -40,8 +39,8 @@ defmodule EdenflowersWeb.CheckoutLive do
        |> assign(:card_variants, card_variants)
        |> assign(:order, order)
        |> assign(:form, build_submit_form(order))
-       |> assign(:client_secret, nil)
-       |> maybe_setup_stripe(order)}
+        |> assign(:client_secret, nil)
+        |> maybe_setup_payment(order, socket.assigns[:current_user])}
     else
       {:error, :empty_cart} ->
         # Mounting with an effectively-empty cart means the customer either
@@ -552,7 +551,7 @@ defmodule EdenflowersWeb.CheckoutLive do
   end
 
   def handle_event("pay", _, socket) do
-    case stripe_api().update_payment_intent(socket.assigns.order) do
+    case Edenflowers.Checkout.update_payment(socket.assigns.order) do
       {:ok, _payment_intent} ->
         {:noreply, push_event(socket, "stripe:process_payment", %{})}
 
@@ -754,7 +753,7 @@ defmodule EdenflowersWeb.CheckoutLive do
 
     socket
     |> assign_forms(order, opts)
-    |> ensure_stripe_for_state(order)
+    |> ensure_payment_for_state(order, actor(socket))
   end
 
   # Persisted (not just visual) so the dependent form-3b renders and the
@@ -786,67 +785,38 @@ defmodule EdenflowersWeb.CheckoutLive do
     push_event(socket, "focus-element", %{id: section_id(socket.assigns.id, state)})
   end
 
-  # ======
-  # Stripe
-  # ======
+  # =======
+  # Payment
+  # =======
 
   # We only touch Stripe once the customer is on the payment state. Earlier
   # mounts (or mounts where the LiveView reconnects on a non-payment state)
   # skip the round trip entirely.
-  defp maybe_setup_stripe(socket, %{state: :payment} = order), do: setup_stripe(socket, order)
-  defp maybe_setup_stripe(socket, _order), do: socket
+  defp maybe_setup_payment(socket, %{state: :payment} = order, actor) do
+    case Edenflowers.Checkout.setup_payment(order, actor) do
+      {:ok, updated_order, client_secret} ->
+        socket
+        |> assign(order: updated_order)
+        |> assign(client_secret: client_secret)
 
-  defp ensure_stripe_for_state(socket, %{state: :payment} = order) do
+      {:error, _reason} ->
+        payment_unavailable(socket)
+    end
+  end
+
+  defp maybe_setup_payment(socket, _order, _actor), do: socket
+
+  defp ensure_payment_for_state(socket, %{state: :payment} = order, actor) do
     if socket.assigns[:client_secret] do
       socket
     else
-      setup_stripe(socket, order)
+      maybe_setup_payment(socket, order, actor)
     end
   end
 
-  defp ensure_stripe_for_state(socket, _order), do: socket
+  defp ensure_payment_for_state(socket, _order, _actor), do: socket
 
-  defp setup_stripe(socket, %{payment_intent_id: nil} = order) do
-    case stripe_api().create_payment_intent(order) do
-      {:ok, payment_intent} ->
-        persist_payment_intent(socket, order, payment_intent)
-
-      {:error, reason} ->
-        Logger.error("Failed to create payment intent for order #{order.id}: #{inspect(reason)}")
-        stripe_unavailable(socket)
-    end
-  end
-
-  defp setup_stripe(socket, order) do
-    case stripe_api().retrieve_payment_intent(order) do
-      {:ok, payment_intent} ->
-        assign(socket, client_secret: payment_intent.client_secret)
-
-      {:error, reason} ->
-        Logger.error("Failed to retrieve payment intent for order #{order.id}: #{inspect(reason)}")
-        stripe_unavailable(socket)
-    end
-  end
-
-  defp persist_payment_intent(socket, order, payment_intent) do
-    case Order.add_payment_intent_id(order, payment_intent.id, actor: actor(socket)) do
-      {:ok, order} ->
-        socket
-        |> assign(order: order)
-        |> assign(client_secret: payment_intent.client_secret)
-
-      {:error, reason} ->
-        # Persisting the id failed — cancel the orphan intent on Stripe so it
-        # doesn't linger in the dashboard. Best-effort; surface a flash either way.
-        stripe_api().cancel_payment_intent(payment_intent)
-
-        Logger.error("Failed to persist payment_intent_id for order #{order.id}: #{inspect(reason)}")
-
-        stripe_unavailable(socket)
-    end
-  end
-
-  defp stripe_unavailable(socket) do
+  defp payment_unavailable(socket) do
     socket
     |> assign(client_secret: nil)
     |> put_flash(:error, ~t"Payment is temporarily unavailable. Please try again in a moment.")

--- a/test/edenflowers/checkout_test.exs
+++ b/test/edenflowers/checkout_test.exs
@@ -1,0 +1,110 @@
+defmodule Edenflowers.CheckoutTest do
+  use Edenflowers.DataCase, async: true
+
+  import Generator
+  import Mox
+
+  alias Edenflowers.Checkout
+
+  setup :verify_on_exit!
+
+  describe "setup_payment/2" do
+    test "creates and persists a payment intent when order has none" do
+      order = generate(order(state: :payment, grand_total: Decimal.new("50.00")))
+      payment_intent = %{id: "pi_new_123", client_secret: "pi_new_secret"}
+
+      expect(Edenflowers.StripeAPI.Mock, :create_payment_intent, fn ^order ->
+        {:ok, payment_intent}
+      end)
+
+      assert {:ok, updated_order, "pi_new_secret"} = Checkout.setup_payment(order, nil)
+      assert updated_order.payment_intent_id == "pi_new_123"
+    end
+
+    test "retrieves an existing payment intent when order already has one" do
+      order =
+        generate(
+          order(
+            state: :payment,
+            grand_total: Decimal.new("50.00"),
+            payment_intent_id: "pi_existing_456"
+          )
+        )
+
+      payment_intent = %{id: "pi_existing_456", client_secret: "pi_existing_secret"}
+
+      expect(Edenflowers.StripeAPI.Mock, :retrieve_payment_intent, fn ^order ->
+        {:ok, payment_intent}
+      end)
+
+      assert {:ok, ^order, "pi_existing_secret"} = Checkout.setup_payment(order, nil)
+    end
+
+    test "returns error when Stripe create fails" do
+      order = generate(order(state: :payment, grand_total: Decimal.new("50.00")))
+
+      expect(Edenflowers.StripeAPI.Mock, :create_payment_intent, fn ^order ->
+        {:error, %{message: "network timeout"}}
+      end)
+
+      assert {:error, :payment_intent_create_failed} = Checkout.setup_payment(order, nil)
+    end
+
+    test "returns error and cancels orphan intent when persist fails" do
+      # A placed order rejects add_payment_intent_id, simulating a persist failure.
+      order = generate(order(state: :placed, grand_total: Decimal.new("50.00")))
+      payment_intent = %{id: "pi_orphan_789", client_secret: "pi_orphan_secret"}
+
+      expect(Edenflowers.StripeAPI.Mock, :create_payment_intent, fn ^order ->
+        {:ok, payment_intent}
+      end)
+
+      expect(Edenflowers.StripeAPI.Mock, :cancel_payment_intent, fn ^payment_intent ->
+        {:ok, %{id: "pi_orphan_789", status: "canceled"}}
+      end)
+
+      assert {:error, :payment_intent_persist_failed} =
+               Checkout.setup_payment(order, nil)
+    end
+
+    test "returns error when Stripe retrieve fails" do
+      order =
+        generate(
+          order(
+            state: :payment,
+            grand_total: Decimal.new("50.00"),
+            payment_intent_id: "pi_existing_456"
+          )
+        )
+
+      expect(Edenflowers.StripeAPI.Mock, :retrieve_payment_intent, fn ^order ->
+        {:error, %{message: "not found"}}
+      end)
+
+      assert {:error, :payment_intent_retrieve_failed} = Checkout.setup_payment(order, nil)
+    end
+  end
+
+  describe "update_payment/1" do
+    test "delegates to the Stripe API port" do
+      order = generate(order(payment_intent_id: "pi_update_001", grand_total: Decimal.new("75.00")))
+      updated_intent = %{id: "pi_update_001", amount: 7500}
+
+      expect(Edenflowers.StripeAPI.Mock, :update_payment_intent, fn ^order ->
+        {:ok, updated_intent}
+      end)
+
+      assert {:ok, ^updated_intent} = Checkout.update_payment(order)
+    end
+
+    test "returns error when Stripe update fails" do
+      order = generate(order(payment_intent_id: "pi_update_002", grand_total: Decimal.new("75.00")))
+
+      expect(Edenflowers.StripeAPI.Mock, :update_payment_intent, fn ^order ->
+        {:error, %{message: "invalid amount"}}
+      end)
+
+      assert {:error, %{message: "invalid amount"}} = Checkout.update_payment(order)
+    end
+  end
+end


### PR DESCRIPTION
Extract payment-intent lifecycle (create, retrieve, update, persist, cancel) into `Edenflowers.Checkout` module.

**Before:** CheckoutLive contained 6 shallow private functions that mixed Stripe API calls with form rendering and event handling.

**After:** CheckoutLive delegates to `Checkout.setup_payment/2` and `Checkout.update_payment/1`. All Stripe orchestration lives in one place with direct unit tests through the StripeAPI.Mock seam.

- Adds `Edenflowers.Checkout` with `setup_payment/2` and `update_payment/1`
- Adds 7 unit tests exercising the seam without mounting LiveView
- Removes `stripe_api/0`, `maybe_setup_stripe/2`, `ensure_stripe_for_state/2`, `setup_stripe/2`, `persist_payment_intent/3`, `stripe_unavailable/1` from CheckoutLive
- 469 tests pass (0 failures)